### PR TITLE
Add support for building snaps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: gitleaks
+version: '1.0'
+summary: Audit git repos for secrets
+description: |
+  Audit git repos for secrets. 
+grade: stable
+confinement: strict
+base: core18
+parts:
+  gitleaks:
+    plugin: go
+    source: https://github.com/zricethezav/gitleaks.git
+    go-importpath: github.com/zricethezav/gitleaks
+    build-packages:
+      - build-essential
+apps:
+  gitleaks:
+    command: bin/gitleaks
+    plugs:
+      - home
+      - network


### PR DESCRIPTION
Hey Zach,

Following up on what we discussed, here's the PR for building a snap package of gitleaks.

I used a stock Ubuntu 18.04 system to build gitleaks locally. You can also use CI systems or our free build system (build.snapcraft.io), if you like.

snap install snapcraft --classic --beta
git clone https://github.com/igorljubuncic/gitleaks.git
cd gitleaks
git checkout add-snapcraft
snapcraft

The last command will generate a <gitleaks-version>.snap file, something like gitleaks_1.0_amd64.snap.

This snap can be installed and tested locally with (you temporarily need the --dangerous flag because at the moment the snap does not originate from the snap store; you don't need this flag when installing snaps from the snap store):

snap install gitleaks_1.0_amd64.snap --dangerous

Once installed, the gitleaks command can be executed, e.g.: snap run gitleaks <options>.

Next, you will need to complete a couple more steps:

- Register a developer account in the snap store https://snapcraft.io/account.
- Register the gitleaks name in the store. You can also do this on the command line: 

snapcraft login
snapcraft register

- Upload the previously built snap of gitleaks to the store. The store supports multiple risk levels as “channels”. Stable is where stable releases are pushed. Optionally, beta and candidate channels can also be used, for different levels of stability and testing. Edge is where you typically land the first build.

snapcraft push gitleaks_1.0_amd64.snap --release edge

- Test installing on a clean machine (this is an optional step):

snap install gitleaks --edge

After you have completed your tests, you can push a stable release to the stable channel, update the store page, and promote the application online. We can definitely help there, and we'd be happy to feature your application in our store.

Let me know if anything is missing - and I will update the changelog if needed.

Thank you.