### PR TITLE
Fix allowlist regex

### DIFF
--- a/config/allowlist_test.go
+++ b/config/allowlist_test.go
@@ -43,26 +43,33 @@ func TestCommitAllowed(t *testing.T) {
 func TestRegexAllowed(t *testing.T) {
 	tests := []struct {
 		allowlist    Allowlist
-		secret       string
+		line         string
 		regexAllowed bool
 	}{
 		{
 			allowlist: Allowlist{
 				Regexes: []*regexp.Regexp{regexp.MustCompile("matchthis")},
 			},
-			secret:       "a secret: matchthis, done",
+			line:         "a secret: matchthis, done",
+			regexAllowed: true,
+		},
+		{
+			allowlist: Allowlist{
+				Regexes: []*regexp.Regexp{regexp.MustCompile("identifier")},
+			},
+			line:         "identifier='secret!@#'",
 			regexAllowed: true,
 		},
 		{
 			allowlist: Allowlist{
 				Regexes: []*regexp.Regexp{regexp.MustCompile("matchthis")},
 			},
-			secret:       "a secret",
+			line:         "a secret",
 			regexAllowed: false,
 		},
 	}
 	for _, tt := range tests {
-		assert.Equal(t, tt.regexAllowed, tt.allowlist.RegexAllowed(tt.secret))
+		assert.Equal(t, tt.regexAllowed, tt.allowlist.RegexAllowed(tt.line))
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -36,6 +36,24 @@ func TestTranslate(t *testing.T) {
 			},
 		},
 		{
+			cfgName: "allow_identifier_re",
+			cfg: Config{
+				Rules: map[string]Rule{"aws-access-key": {
+					Description: "AWS Access Key",
+					Regex:       regexp.MustCompile("(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}"),
+					Tags:        []string{"key", "AWS"},
+					Keywords:    []string{},
+					RuleID:      "aws-access-key",
+					Allowlist: Allowlist{
+						Regexes: []*regexp.Regexp{
+							regexp.MustCompile("awsAccessKey"),
+						},
+					},
+				},
+				},
+			},
+		},
+		{
 			cfgName: "allow_commit",
 			cfg: Config{
 				Rules: map[string]Rule{"aws-access-key": {

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -266,8 +266,8 @@ func (d *Detector) detectRule(fragment Fragment, rule config.Rule) []report.Find
 		}
 
 		// check if the secret is in the allowlist
-		if rule.Allowlist.RegexAllowed(finding.Secret) ||
-			d.Config.Allowlist.RegexAllowed(finding.Secret) {
+		if rule.Allowlist.RegexAllowed(finding.Line) ||
+			d.Config.Allowlist.RegexAllowed(finding.Line) {
 			continue
 		}
 

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -199,6 +199,14 @@ func TestDetect(t *testing.T) {
 			expectedFindings: []report.Finding{},
 		},
 		{
+			cfgName: "allow_identifier_re",
+			fragment: Fragment{
+				Raw:      `awsAccessKey := \"AKIALALEMEL33243OLIA\"`,
+				FilePath: "tmp.go",
+			},
+			expectedFindings: []report.Finding{},
+		},
+		{
 			cfgName: "allow_path",
 			fragment: Fragment{
 				Raw:      `awsToken := \"AKIALALEMEL33243OLIA\"`,

--- a/testdata/config/allow_identifier_re.toml
+++ b/testdata/config/allow_identifier_re.toml
@@ -1,0 +1,9 @@
+title = "simple config with allowlist for regex identifier"
+
+[[rules]]
+    description = "AWS Access Key"
+    id = "aws-access-key"
+    regex = '''(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
+    tags = ["key", "AWS"]
+    [rules.allowlist]
+        regexes = ['''awsAccessKey''']


### PR DESCRIPTION


### Description:
* Fixes https://github.com/zricethezav/gitleaks/issues/1025
* The allowlist regex is only applied to the finding's secret, not the full line.
* According to the [README](https://github.com/zricethezav/gitleaks#configuration), the stopwords target the secret whereas the regexes target the "entire regex match", which I interpreted to mean the `Line` in the `Finding` struct.
* So I changed the logic in detect.go to check the regexes against the Line.
* Also added some tests

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
