### PR TITLE
feat: change aws-access-token description

### DIFF
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -116,7 +116,7 @@ keywords = [
 ]
 
 [[rules]]
-description = "AWS"
+description = "AWS Access Token"
 id = "aws-access-token"
 regex = '''(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
 keywords = [


### PR DESCRIPTION
Signed-off-by: Mints <odysseas@mavrocordatos.com>

### Description:
Change the aws-access-token description so that it matches with the other rules.

Here is the matching issue: https://github.com/zricethezav/gitleaks/issues/1080#issue-1551158171

### Checklist:

* [X] Does your PR pass tests?
* [X] Have you lint your code locally prior to submission?
