### PR TITLE
Add Defined Networking API Tokens Detector

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -41,6 +41,7 @@ func main() {
 	configRules = append(configRules, rules.Contentful())
 	configRules = append(configRules, rules.Databricks())
 	configRules = append(configRules, rules.DatadogtokenAccessToken())
+	configRules = append(configRules, rules.DefinedNetworkingAPIToken())
 	configRules = append(configRules, rules.DigitalOceanPAT())
 	configRules = append(configRules, rules.DigitalOceanOAuthToken())
 	configRules = append(configRules, rules.DigitalOceanRefreshToken())

--- a/cmd/generate/config/rules/definednetworking.go
+++ b/cmd/generate/config/rules/definednetworking.go
@@ -1,0 +1,32 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+func DefinedNetworkingAPIToken() *config.Rule {
+	// Define Rule
+	r := config.Rule{
+		// Human redable description of the rule
+		Description: "Defined Networking API token",
+
+		// Unique ID for the rule
+		RuleID: "defined-networking-api-token",
+
+		// Regex capture group for the actual secret
+		SecretGroup: 1,
+
+		// Regex used for detecting secrets. See regex section below for more details
+		Regex: generateSemiGenericRegex([]string{"dnkey"}, `dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52}`),
+
+		// Keywords used for string matching on fragments (think of this as a prefilter)
+		Keywords: []string{"dnkey"},
+	}
+
+	// validate
+	tps := []string{
+		generateSampleSecret("dnkey", "dnkey-"+secrets.NewSecret(alphaNumericExtended("26"))+"-"+secrets.NewSecret(alphaNumericExtended("52"))),
+	}
+	return validate(r, tps, nil)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -243,6 +243,15 @@ keywords = [
 ]
 
 [[rules]]
+description = "Defined Networking API token"
+id = "defined-networking-api-token"
+regex = '''(?i)(?:dnkey)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:=|\|\|:|<=|=>|:)(?:'|\"|\s|=|\x60){0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+secretGroup = 1
+keywords = [
+    "dnkey",
+]
+
+[[rules]]
 description = "DigitalOcean OAuth Access Token"
 id = "digitalocean-access-token"
 regex = '''(?i)\b(doo_v1_[a-f0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''


### PR DESCRIPTION

### Description:
Adds detection support for Defined Networking tokens (https://docs.defined.net/guides/automating-host-creation/)

I added a fixture in addition to the generator, I think I may be able to use the `generateUniqueToken` instead of the semi-generic option? Let me know if I should update accordingly.


### Checklist:

* [X] Does your PR pass tests?
* [X] Have you written new tests for your changes?
* [X] Have you lint your code locally prior to submission?
