### PR TITLE
Fix False Positives: Use Word Boundaries for EasyPost Tokens

### DIFF
--- a/cmd/generate/config/rules/easypost.go
+++ b/cmd/generate/config/rules/easypost.go
@@ -12,7 +12,7 @@ func EasyPost() *config.Rule {
 	r := config.Rule{
 		Description: "EasyPost API token",
 		RuleID:      "easypost-api-token",
-		Regex:       regexp.MustCompile(`EZAK(?i)[a-z0-9]{54}`),
+		Regex:       regexp.MustCompile(`\bEZAK(?i)[a-z0-9]{54}`),
 		Keywords:    []string{"EZAK"},
 	}
 
@@ -28,7 +28,7 @@ func EasyPostTestAPI() *config.Rule {
 	r := config.Rule{
 		Description: "EasyPost test API token",
 		RuleID:      "easypost-test-api-token",
-		Regex:       regexp.MustCompile(`EZTK(?i)[a-z0-9]{54}`),
+		Regex:       regexp.MustCompile(`\bEZTK(?i)[a-z0-9]{54}`),
 		Keywords:    []string{"EZTK"},
 	}
 

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -357,7 +357,7 @@ keywords = [
 [[rules]]
 description = "EasyPost API token"
 id = "easypost-api-token"
-regex = '''EZAK(?i)[a-z0-9]{54}'''
+regex = '''\bEZAK(?i)[a-z0-9]{54}'''
 keywords = [
     "ezak",
 ]
@@ -365,7 +365,7 @@ keywords = [
 [[rules]]
 description = "EasyPost test API token"
 id = "easypost-test-api-token"
-regex = '''EZTK(?i)[a-z0-9]{54}'''
+regex = '''\bEZTK(?i)[a-z0-9]{54}'''
 keywords = [
     "eztk",
 ]


### PR DESCRIPTION
Use Word Boundaries for EasyPost Tokens

### Description:
I am storing Elastic Kibana Exports in a GIT repo which look like:
```json
{
     "asset-a30a06eb-2276-44b1-a62d-856e2116138c": {
          "@created": "2019-03-29T14:02:51.349Z",
          "id": "asset-a30a06eb-2276-44b1-a62d-856e2116138c",
          "type": "dataurl",
          "value": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/4gxYSU..aEZAKjP3cFfmXvke1VN43DcuR1BJyTjPNZx0AfLLuRmCAKrAAkcEf0qgqbJ..."
     }
}
```
The Base64 encoded images cause a false positive as GitLeaks detects an EasyPost API Token starting with `EZAK`.  I added a word boundary to prevent detecting EasyPost tokens in a Base64 string.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
