### PR TITLE
fix(detect): avoid panic with verbose flag

### DIFF
--- a/detect/utils.go
+++ b/detect/utils.go
@@ -98,9 +98,9 @@ func printFinding(f report.Finding, noColor bool) {
 	f.Match = strings.TrimSpace(f.Match)
 
 	isFileMatch := strings.HasPrefix(f.Match, "file detected:")
-	skipColor := !noColor
+	skipColor := noColor
 	finding := ""
-	secret := ""
+	var secret lipgloss.Style
 	
 	// Matches from filenames do not have a |line| or |secret|
 	if !isFileMatch {
@@ -122,7 +122,7 @@ func printFinding(f report.Finding, noColor bool) {
 		}
 
 		matchBeginning := lipgloss.NewStyle().SetString(f.Match[0:secretInMatchIdx]).Foreground(lipgloss.Color("#f5d445"))
-		secret := lipgloss.NewStyle().SetString(f.Secret).
+		secret = lipgloss.NewStyle().SetString(f.Secret).
 			Bold(true).
 			Italic(true).
 			Foreground(lipgloss.Color("#f05c07"))

--- a/detect/utils.go
+++ b/detect/utils.go
@@ -133,7 +133,7 @@ func printFinding(f report.Finding, noColor bool) {
 			lineEndIdx = len(f.Line) - 1
 		}
 
-		lineEnd := f.Line[matchInLineIDX+len(f.Match):]
+		lineEnd := f.Line[lineEndIdx:]
 
 		if len(f.Secret) > 100 {
 			secret = lipgloss.NewStyle().SetString(f.Secret[0:100] + "...").

--- a/detect/utils.go
+++ b/detect/utils.go
@@ -107,7 +107,7 @@ func printFinding(f report.Finding, noColor bool) {
 		matchInLineIDX := strings.Index(f.Line, f.Match)
 		secretInMatchIdx := strings.Index(f.Match, f.Secret)
 
-		skipColor := false
+		skipColor = false
 
 		if matchInLineIDX == -1 || noColor {
 			skipColor = true
@@ -145,7 +145,7 @@ func printFinding(f report.Finding, noColor bool) {
 			lineEnd = lineEnd[0:20] + "..."
 		}
 
-		finding := fmt.Sprintf("%s%s%s%s%s\n", strings.TrimPrefix(strings.TrimLeft(start, " "), "\n"), matchBeginning, secret, matchEnd, lineEnd)
+		finding = fmt.Sprintf("%s%s%s%s%s\n", strings.TrimPrefix(strings.TrimLeft(start, " "), "\n"), matchBeginning, secret, matchEnd, lineEnd)
 	}
 
 	if skipColor || isFileMatch {

--- a/detect/utils.go
+++ b/detect/utils.go
@@ -92,57 +92,63 @@ func filter(findings []report.Finding, redact bool) []report.Finding {
 }
 
 func printFinding(f report.Finding, noColor bool) {
-	// trim all whitespace and tabs from the line
+	// trim all whitespace and tabs
 	f.Line = strings.TrimSpace(f.Line)
-	// trim all whitespace and tabs from the secret
 	f.Secret = strings.TrimSpace(f.Secret)
-	// trim all whitespace and tabs from the match
 	f.Match = strings.TrimSpace(f.Match)
 
-	matchInLineIDX := strings.Index(f.Line, f.Match)
-	secretInMatchIdx := strings.Index(f.Match, f.Secret)
+	isFileMatch := strings.HasPrefix(f.Match, "file detected:")
+	skipColor := !noColor
+	finding := ""
+	secret := ""
+	
+	// Matches from filenames do not have a |line| or |secret|
+	if !isFileMatch {
+		matchInLineIDX := strings.Index(f.Line, f.Match)
+		secretInMatchIdx := strings.Index(f.Match, f.Secret)
 
-	skipColor := false
+		skipColor := false
 
-	if matchInLineIDX == -1 || noColor {
-		skipColor = true
-		matchInLineIDX = 0
-	}
+		if matchInLineIDX == -1 || noColor {
+			skipColor = true
+			matchInLineIDX = 0
+		}
 
-	start := f.Line[0:matchInLineIDX]
-	startMatchIdx := 0
-	if matchInLineIDX > 20 {
-		startMatchIdx = matchInLineIDX - 20
-		start = "..." + f.Line[startMatchIdx:matchInLineIDX]
-	}
+		start := f.Line[0:matchInLineIDX]
+		startMatchIdx := 0
+		if matchInLineIDX > 20 {
+			startMatchIdx = matchInLineIDX - 20
+			start = "..." + f.Line[startMatchIdx:matchInLineIDX]
+		}
 
-	matchBeginning := lipgloss.NewStyle().SetString(f.Match[0:secretInMatchIdx]).Foreground(lipgloss.Color("#f5d445"))
-	secret := lipgloss.NewStyle().SetString(f.Secret).
-		Bold(true).
-		Italic(true).
-		Foreground(lipgloss.Color("#f05c07"))
-	matchEnd := lipgloss.NewStyle().SetString(f.Match[secretInMatchIdx+len(f.Secret):]).Foreground(lipgloss.Color("#f5d445"))
-
-	lineEndIdx := matchInLineIDX + len(f.Match)
-	if len(f.Line)-1 <= lineEndIdx {
-		lineEndIdx = len(f.Line) - 1
-	}
-
-	lineEnd := f.Line[matchInLineIDX+len(f.Match):]
-
-	if len(f.Secret) > 100 {
-		secret = lipgloss.NewStyle().SetString(f.Secret[0:100] + "...").
+		matchBeginning := lipgloss.NewStyle().SetString(f.Match[0:secretInMatchIdx]).Foreground(lipgloss.Color("#f5d445"))
+		secret := lipgloss.NewStyle().SetString(f.Secret).
 			Bold(true).
 			Italic(true).
 			Foreground(lipgloss.Color("#f05c07"))
-	}
-	if len(lineEnd) > 20 {
-		lineEnd = lineEnd[0:20] + "..."
+		matchEnd := lipgloss.NewStyle().SetString(f.Match[secretInMatchIdx+len(f.Secret):]).Foreground(lipgloss.Color("#f5d445"))
+
+		lineEndIdx := matchInLineIDX + len(f.Match)
+		if len(f.Line)-1 <= lineEndIdx {
+			lineEndIdx = len(f.Line) - 1
+		}
+
+		lineEnd := f.Line[matchInLineIDX+len(f.Match):]
+
+		if len(f.Secret) > 100 {
+			secret = lipgloss.NewStyle().SetString(f.Secret[0:100] + "...").
+				Bold(true).
+				Italic(true).
+				Foreground(lipgloss.Color("#f05c07"))
+		}
+		if len(lineEnd) > 20 {
+			lineEnd = lineEnd[0:20] + "..."
+		}
+
+		finding := fmt.Sprintf("%s%s%s%s%s\n", strings.TrimPrefix(strings.TrimLeft(start, " "), "\n"), matchBeginning, secret, matchEnd, lineEnd)
 	}
 
-	finding := fmt.Sprintf("%s%s%s%s%s\n", strings.TrimPrefix(strings.TrimLeft(start, " "), "\n"), matchBeginning, secret, matchEnd, lineEnd)
-
-	if skipColor {
+	if skipColor || isFileMatch {
 		fmt.Printf("%-12s %s\n", "Finding:", f.Match)
 		fmt.Printf("%-12s %s\n", "Secret:", f.Secret)
 	} else {


### PR DESCRIPTION
### Description:

This should fix the panic from #1141 by skipping formatting of `f.Line` and `f.Secret` for file matches, which have an empty value anyways.

It does not fix the underlying behaviour of panics being intermittently swallowed by semgroup.
https://github.com/gitleaks/gitleaks/blob/839f114f2b2ca9429300e545aa5c93a2caf2e3d8/detect/detect.go#L506 

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
