### PR TITLE
Add detection for OpenAI API keys

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -116,6 +116,7 @@ func main() {
 	configRules = append(configRules, rules.NPM())
 	configRules = append(configRules, rules.NytimesAccessToken())
 	configRules = append(configRules, rules.OktaAccessToken())
+	configRules = append(configRules, rules.OpenAI())
 	configRules = append(configRules, rules.PlaidAccessID())
 	configRules = append(configRules, rules.PlaidSecretKey())
 	configRules = append(configRules, rules.PlaidAccessToken())

--- a/cmd/generate/config/rules/openai.go
+++ b/cmd/generate/config/rules/openai.go
@@ -13,7 +13,6 @@ func OpenAI() *config.Rule {
 		Regex:       generateUniqueTokenRegex(`sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20}`),
 		SecretGroup: 1,
 		Keywords: []string{
-			"sk-",
 			"T3BlbkFJ",
 		},
 	}

--- a/cmd/generate/config/rules/openai.go
+++ b/cmd/generate/config/rules/openai.go
@@ -1,0 +1,26 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+func OpenAI() *config.Rule {
+	// define rule
+	r := config.Rule{
+		RuleID:      "openai-api-key",
+		Description: "OpenAI API Key",
+		Regex:       generateUniqueTokenRegex(`sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20}`),
+		SecretGroup: 1,
+		Keywords: []string{
+			"sk-",
+			"T3BlbkFJ",
+		},
+	}
+
+	// validate
+	tps := []string{
+		generateSampleSecret("openaiApiKey", "sk-"+secrets.NewSecret(alphaNumeric("20"))+"T3BlbkFJ"+secrets.NewSecret(alphaNumeric("20"))),
+	}
+	return validate(r, tps, nil)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2372,6 +2372,15 @@ keywords = [
 ]
 
 [[rules]]
+description = "OpenAI API Key"
+id = "openai-api-key"
+regex = '''(?i)\b(sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+secretGroup = 1
+keywords = [
+    "sk-","t3blbkfj",
+]
+
+[[rules]]
 description = "Plaid API Token"
 id = "plaid-api-token"
 regex = '''(?i)(?:plaid)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:=|\|\|:|<=|=>|:)(?:'|\"|\s|=|\x60){0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''


### PR DESCRIPTION
### Description:

Add detection for OpenAI API keys. Interestingly, their API keys look made up of base64 and contains the encoded string "OpenAI" (`T3BlbkFJ`) between 2 blocks of random bytes so this rule should be pretty precise.

### Checklist:

* [X] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [X] Have you lint your code locally prior to submission?
