### PR TITLE
Fix G307 warning:  Deferring unsafe method "Close" on type "*os.File"

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -157,7 +157,7 @@ func (d *Detector) AddGitleaksIgnore(gitleaksIgnorePath string) error {
 	// https://github.com/securego/gosec/issues/512
 	defer func() {
 		if err := file.Close(); err != nil { 
-			logger.Printf("Error closing .gitleaksignore file: %s\n", err)
+			log.Warn().Msgf("Error closing .gitleaksignore file: %s\n", err)
 		}
     }()
 	scanner := bufio.NewScanner(file)

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -154,7 +154,12 @@ func (d *Detector) AddGitleaksIgnore(gitleaksIgnorePath string) error {
 		return err
 	}
 
-	defer file.Close()
+	// https://github.com/securego/gosec/issues/512
+	defer func() {
+		if err := file.Close(); err != nil { 
+			logger.Printf("Error closing .gitleaksignore file: %s\n", err)
+		}
+    }()
 	scanner := bufio.NewScanner(file)
 
 	for scanner.Scan() {


### PR DESCRIPTION
### Description:

Minor change to fix GoSec flagging this line:

https://github.com/gitleaks/gitleaks/blob/66361e548f50ed44659b6cd26c3e76323922af2a/detect/detect.go#L157

Explanation: https://github.com/securego/gosec/issues/512

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
