### PR TITLE
feat(generic api key rule): handle more use cases

### DIFF
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -504,11 +504,11 @@ keywords = [
 [[rules]]
 description = "Generic API Key"
 id = "generic-api-key"
-regex = '''(?i)(?:key|api|token|secret|client|passwd|password|auth|access)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:=|\|\|:|<=|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9a-z\-_.=]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)(?:key|api|token|secret|client|passwd|password|auth|access|passphrase)(?:[0-9a-z\-_\t .()]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:=|\|\|:|<=|=>|:)(?:'|\"|\s|=|\x60){0,5}([[:graph:]]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 secretGroup = 1
 entropy = 3.5
 keywords = [
-    "key","api","token","secret","client","passwd","password","auth","access",
+    "key","api","token","secret","client","passwd","password","auth","access", "passphrase",
 ]
 [rules.allowlist]
 stopwords= [

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -240,6 +240,14 @@ func TestDetect(t *testing.T) {
 			},
 		},
 		{
+			cfgName: "generic",
+			fragment: Fragment{
+				Raw:      `env(JWT_PASSPHRASE): 'MyAw$s0m3P4ssphr4s3'`,
+				FilePath: "tmp.go",
+			},
+			expectedFindings: []report.Finding{},
+		},
+		{
 			cfgName: "generic_with_py_path",
 			fragment: Fragment{
 				Raw:      `const Discord_Public_Key = "e7322523fb86ed64c836a979cf8465fbd436378c653c1db38f9ae87bc62a6fd5"`,

--- a/testdata/config/generic.toml
+++ b/testdata/config/generic.toml
@@ -3,6 +3,6 @@ title = "gitleaks config"
 [[rules]]
 description = "Generic API Key"
 id = "generic-api-key"
-regex = '''(?i)((key|api|token|secret|password)[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([0-9a-zA-Z\-_=]{8,64})['\"]'''
+regex = '''(?i)(?:key|api|token|secret|client|passwd|password|auth|access|passphrase)(?:[0-9a-z\-_\t .()]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:=|\|\|:|<=|=>|:)(?:'|\"|\s|=|\x60){0,5}([[:graph:]]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3.7
 secretGroup = 4

--- a/testdata/config/generic_with_py_path.toml
+++ b/testdata/config/generic_with_py_path.toml
@@ -3,7 +3,7 @@ title = "gitleaks config"
 [[rules]]
 description = "Generic API Key"
 id = "generic-api-key"
-regex = '''(?i)((key|api|token|secret|password)[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([0-9a-zA-Z\-_=]{8,64})['\"]'''
+regex = '''(?i)(?:key|api|token|secret|client|passwd|password|auth|access|passphrase)(?:[0-9a-z\-_\t .()]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:=|\|\|:|<=|=>|:)(?:'|\"|\s|=|\x60){0,5}([[:graph:]]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 path = '''.py'''
 entropy = 3.7
 secretGroup = 4


### PR DESCRIPTION
The "generic-api-key" does not handle the "passphrase" term in case we set one. In addition, we added more chars to capture (graphical (== [!-~] == [A-Za-z0-9!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])) see https://pkg.go.dev/regexp/syntax for more details.

_Note: we figured that the rule does not handle Symfony env parameters so a fix is added for that case (see
https://symfony.com/doc/current/configuration.html#configuration-based-on-environment-variables)_

### Description:
Explain the purpose of the PR.

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
