### PR TITLE
Added option to specify .gitleaksignore path

### DIFF
--- a/cmd/detect.go
+++ b/cmd/detect.go
@@ -20,7 +20,7 @@ func init() {
 	detectCmd.Flags().Bool("no-git", false, "treat git repo as a regular directory and scan those files, --log-opts has no effect on the scan when --no-git is set")
 	detectCmd.Flags().Bool("pipe", false, "scan input from stdin, ex: `cat some_file | gitleaks detect --pipe`")
 	detectCmd.Flags().Bool("follow-symlinks", false, "scan files that are symlinks to other files")
-
+	detectCmd.Flags().StringP("gitleaks-ignore-path","i",".","path to .gitleaksignore file or folder containing one")
 }
 
 var detectCmd = &cobra.Command{
@@ -79,6 +79,23 @@ func runDetect(cmd *cobra.Command, args []string) {
 	// set color flag
 	if detector.NoColor, err = cmd.Flags().GetBool("no-color"); err != nil {
 		log.Fatal().Err(err).Msg("")
+	}
+
+	gitleaksIgnorePath, err:= cmd.Flags().GetString("gitleaks-ignore-path")
+	if err != nil {
+		log.Fatal().Err(err).Msg("could not get .gitleaksignore path")
+	}
+
+	if fileExists(gitleaksIgnorePath) {
+		if err = detector.AddGitleaksIgnore(gitleaksIgnorePath); err != nil {
+			log.Fatal().Err(err).Msg("could not call AddGitleaksIgnore")
+		}
+	}
+
+	if fileExists(filepath.Join(gitleaksIgnorePath, ".gitleaksignore")) {
+		if err = detector.AddGitleaksIgnore(filepath.Join(gitleaksIgnorePath, ".gitleaksignore")); err != nil {
+			log.Fatal().Err(err).Msg("could not call AddGitleaksIgnore")
+		}
 	}
 
 	if fileExists(filepath.Join(source, ".gitleaksignore")) {

--- a/cmd/protect.go
+++ b/cmd/protect.go
@@ -17,6 +17,7 @@ import (
 func init() {
 	protectCmd.Flags().Bool("staged", false, "detect secrets in a --staged state")
 	protectCmd.Flags().String("log-opts", "", "git log options")
+	protectCmd.Flags().StringP("gitleaks-ignore-path","i",".","path to .gitleaksignore file or folder containing one")
 	rootCmd.AddCommand(protectCmd)
 }
 
@@ -72,6 +73,23 @@ func runProtect(cmd *cobra.Command, args []string) {
 	// set color flag
 	if detector.NoColor, err = cmd.Flags().GetBool("no-color"); err != nil {
 		log.Fatal().Err(err).Msg("")
+	}
+
+	gitleaksIgnorePath, err:= cmd.Flags().GetString("gitleaks-ignore-path")
+	if err != nil {
+		log.Fatal().Err(err).Msg("could not get .gitleaksignore path")
+	}
+
+	if fileExists(gitleaksIgnorePath) {
+		if err = detector.AddGitleaksIgnore(gitleaksIgnorePath); err != nil {
+			log.Fatal().Err(err).Msg("could not call AddGitleaksIgnore")
+		}
+	}
+
+	if fileExists(filepath.Join(gitleaksIgnorePath, ".gitleaksignore")) {
+		if err = detector.AddGitleaksIgnore(filepath.Join(gitleaksIgnorePath, ".gitleaksignore")); err != nil {
+			log.Fatal().Err(err).Msg("could not call AddGitleaksIgnore")
+		}
 	}
 
 	if fileExists(filepath.Join(source, ".gitleaksignore")) {


### PR DESCRIPTION
### Description:
Added a new option for detect/protect actions to allow specify a -gitleaksignore file path or folder containing it

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?

This PR fixes #1178