### PR TITLE
Simplify tests by using T.TempDir

### DIFF
--- a/report/csv_test.go
+++ b/report/csv_test.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,42 +46,35 @@ func TestWriteCSV(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		tmpfile, err := os.Create(filepath.Join(tmpPath, test.testReportName+".csv"))
+		tmpfile, err := os.Create(filepath.Join(t.TempDir(), test.testReportName+".csv"))
 		if err != nil {
-			os.Remove(tmpfile.Name())
 			t.Error(err)
 		}
 		err = writeCsv(test.findings, tmpfile)
 		if err != nil {
-			os.Remove(tmpfile.Name())
 			t.Error(err)
 		}
 		got, err := os.ReadFile(tmpfile.Name())
 		if err != nil {
-			os.Remove(tmpfile.Name())
 			t.Error(err)
 		}
 		if test.wantEmpty {
 			if len(got) > 0 {
 				t.Errorf("Expected empty file, got %s", got)
 			}
-			os.Remove(tmpfile.Name())
 			continue
 		}
 		want, err := os.ReadFile(test.expected)
 		if err != nil {
-			os.Remove(tmpfile.Name())
 			t.Error(err)
 		}
 
-		if string(got) != string(want) {
+		if !bytes.Equal(got, want) {
 			err = os.WriteFile(strings.Replace(test.expected, ".csv", ".got.csv", 1), got, 0644)
 			if err != nil {
 				t.Error(err)
 			}
 			t.Errorf("got %s, want %s", string(got), string(want))
 		}
-
-		os.Remove(tmpfile.Name())
 	}
 }

--- a/report/json_test.go
+++ b/report/json_test.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,44 +47,35 @@ func TestWriteJSON(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		// create tmp file using os.TempDir()
-		tmpfile, err := os.Create(filepath.Join(tmpPath, test.testReportName+".json"))
+		tmpfile, err := os.Create(filepath.Join(t.TempDir(), test.testReportName+".json"))
 		if err != nil {
-			os.Remove(tmpfile.Name())
 			t.Error(err)
 		}
 		err = writeJson(test.findings, tmpfile)
 		if err != nil {
-			os.Remove(tmpfile.Name())
 			t.Error(err)
 		}
 		got, err := os.ReadFile(tmpfile.Name())
 		if err != nil {
-			os.Remove(tmpfile.Name())
 			t.Error(err)
 		}
 		if test.wantEmpty {
 			if len(got) > 0 {
-				os.Remove(tmpfile.Name())
 				t.Errorf("Expected empty file, got %s", got)
 			}
-			os.Remove(tmpfile.Name())
 			continue
 		}
 		want, err := os.ReadFile(test.expected)
 		if err != nil {
-			os.Remove(tmpfile.Name())
 			t.Error(err)
 		}
 
-		if string(got) != string(want) {
+		if !bytes.Equal(got, want) {
 			err = os.WriteFile(strings.Replace(test.expected, ".json", ".got.json", 1), got, 0644)
 			if err != nil {
 				t.Error(err)
 			}
 			t.Errorf("got %s, want %s", string(got), string(want))
 		}
-
-		os.Remove(tmpfile.Name())
 	}
 }

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -11,7 +11,6 @@ import (
 
 const (
 	expectPath = "../testdata/expected/"
-	tmpPath    = "../testdata/tmp"
 )
 
 func TestReport(t *testing.T) {
@@ -80,22 +79,18 @@ func TestReport(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		tmpfile, err := os.Create(filepath.Join(tmpPath, strconv.Itoa(i)+test.ext))
+		tmpfile, err := os.Create(filepath.Join(t.TempDir(), strconv.Itoa(i)+test.ext))
 		if err != nil {
-			os.Remove(tmpfile.Name())
 			t.Error(err)
 		}
 		err = Write(test.findings, config.Config{}, test.ext, tmpfile.Name())
 		if err != nil {
-			os.Remove(tmpfile.Name())
 			t.Error(err)
 		}
 		got, err := os.ReadFile(tmpfile.Name())
 		if err != nil {
-			os.Remove(tmpfile.Name())
 			t.Error(err)
 		}
-		os.Remove(tmpfile.Name())
 
 		if len(got) == 0 && !test.wantEmpty {
 			t.Errorf("got empty file with extension " + test.ext)

--- a/testdata/tmp/note.txt
+++ b/testdata/tmp/note.txt
@@ -1,1 +1,0 @@
-nothing should be saved here


### PR DESCRIPTION
### Description:

This PR simplifies tests by using `T.TempDir` and `bytes.Equal`.

[`T.TempDir`](https://pkg.go.dev/testing#T.TempDir) creates a temporary directory and automatically removes it after each test.
`testdata/tmp` became unnecessary. So, this folder was removed as well.
`bytes.Equal` is used to avoid string conversion.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
