### PR TITLE
Fix closing file in writeJson and writeSarif

### DIFF
--- a/report/json.go
+++ b/report/json.go
@@ -9,6 +9,8 @@ func writeJson(findings []Finding, w io.WriteCloser) error {
 	if len(findings) == 0 {
 		findings = []Finding{}
 	}
+	defer w.Close()
+
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", " ")
 	return encoder.Encode(findings)

--- a/report/sarif.go
+++ b/report/sarif.go
@@ -14,6 +14,7 @@ func writeSarif(cfg config.Config, findings []Finding, w io.WriteCloser) error {
 		Version: "2.1.0",
 		Runs:    getRuns(cfg, findings),
 	}
+	defer w.Close()
 
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", " ")


### PR DESCRIPTION
### Description:

This PR adds `w.Close` to `writeJson` and `writeSarif` to be the same as `writeCsv` which closes a file.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes? - N/A
* [x] Have you lint your code locally prior to submission?
