### PR TITLE
Add `REDACTED` to stopwords for `generic-api-key` rule

### DIFF
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -1986,6 +1986,7 @@ stopwords= [
     "branch",
     "combination",
     "combo",
+    "REDACTED",
 ]
 [[rules]]
 description = "GitHub App Token"


### PR DESCRIPTION
Fixes this false positive:

```
Finding:     ...d: "_env:SALESFORCE_CLIENT_ID:REDACTED""
Secret:      REDACTED
RuleID:      generic-api-key
Entropy:     5.317697
File:        config/settings.yml
Line:        375
Fingerprint: config/settings.yml:generic-api-key:375
```