### PR TITLE
Fixed docker run command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ docker run -v ${path_to_host_folder_to_scan}:/path zricethezav/gitleaks:latest [
 
 # Docker (ghcr.io)
 docker pull ghcr.io/gitleaks/gitleaks:latest
-docker run -v ${path_to_host_folder_to_scan}:/path gitleaks/gitleaks:latest [COMMAND] --source="/path" [OPTIONS]
+docker run -v ${path_to_host_folder_to_scan}:/path ghcr.io/gitleaks/gitleaks:latest [COMMAND] --source="/path" [OPTIONS]
 
 # From Source
 git clone https://github.com/gitleaks/gitleaks.git


### PR DESCRIPTION
### Description:
The docker run command was missing `ghcr.io/` in the image name, which resulted in an error:

Unable to find image 'gitleaks/gitleaks:latest' locally docker: Error response from daemon: pull access denied for gitleaks/gitleaks, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
