### PR TITLE
Fix inconsistent generated values in config

### DIFF
--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -14,7 +14,7 @@ title = "gitleaks config"
 description = "global allow lists"
 paths = [
     '''gitleaks.toml''',
-    '''(.*?)(jpg|gif|doc|docx|zip|xls|pdf|bin|svg|socket)$''',
+    '''(.*?)(jpg|gif|doc|docx|zip|xls|pdf|bin|svg|socket|vsidx|v2|suo|wsuo|.dll|pdb|exe)$''',
     '''(go.mod|go.sum)$''',
     '''gradle.lockfile''',
     '''node_modules''',

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2377,7 +2377,7 @@ id = "openai-api-key"
 regex = '''(?i)\b(sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 secretGroup = 1
 keywords = [
-    "sk-","t3blbkfj",
+    "t3blbkfj",
 ]
 
 [[rules]]


### PR DESCRIPTION
### Description:

There are some changes that keep getting overwritten when generating a config, namely:

```diff
diff --git a/config/gitleaks.toml b/config/gitleaks.toml
index 77fd1e4..c8babf4 100644
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -14,7 +14,7 @@ title = "gitleaks config"
 description = "global allow lists"
 paths = [
     '''gitleaks.toml''',
-    '''(.*?)(jpg|gif|doc|docx|zip|xls|pdf|bin|svg|socket|vsidx|v2|suo|wsuo|.dll|pdb|exe)$''',
+    '''(.*?)(jpg|gif|doc|docx|zip|xls|pdf|bin|svg|socket)$''',
     '''(go.mod|go.sum)$''',
     '''gradle.lockfile''',
     '''node_modules''',
@@ -2386,7 +2386,7 @@ id = "openai-api-key"
 regex = '''(?i)\b(sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 secretGroup = 1
 keywords = [
-    "sk-","t3blbkfj",
+    "t3blbkfj",
 ]
```

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
