### PR TITLE
test: Check the config file drift

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: Validate Config
         run: cd cmd/generate/config && go run main.go
+
+      - name: Config Diff
+        run: git diff --exit-code -- config/gitleaks.toml

--- a/cmd/generate/config/rules/openai.go
+++ b/cmd/generate/config/rules/openai.go
@@ -13,7 +13,7 @@ func OpenAI() *config.Rule {
 		Regex:       generateUniqueTokenRegex(`sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20}`),
 		SecretGroup: 1,
 		Keywords: []string{
-			"T3BlbkFJ",
+			"T3BlbkFJ", "forgor to generate config file",
 		},
 	}
 

--- a/cmd/generate/config/rules/openai.go
+++ b/cmd/generate/config/rules/openai.go
@@ -13,7 +13,7 @@ func OpenAI() *config.Rule {
 		Regex:       generateUniqueTokenRegex(`sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20}`),
 		SecretGroup: 1,
 		Keywords: []string{
-			"T3BlbkFJ", "forgor to generate config file",
+			"T3BlbkFJ",
 		},
 	}
 


### PR DESCRIPTION
### Description:

Last time I contributed to Gitleaks, I edited code in my PR and I forgot to regenerate the config file. So that doesn't happen again, I'd like to modify the test workflow so that the job fails if it detects any changes to the config file after generating it. 

Example of when it fails: https://github.com/gitleaks/gitleaks/actions/runs/5298851100/jobs/9591448117


### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
