### PR TITLE
Add entropy check to plaid client/secret ID rules

### DIFF
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2394,6 +2394,7 @@ description = "Plaid Client ID"
 id = "plaid-client-id"
 regex = '''(?i)(?:plaid)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 secretGroup = 1
+entropy = 3.5
 keywords = [
     "plaid",
 ]
@@ -2403,6 +2404,7 @@ description = "Plaid Secret key"
 id = "plaid-secret-key"
 regex = '''(?i)(?:plaid)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{30})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 secretGroup = 1
+entropy = 3.5
 keywords = [
     "plaid",
 ]


### PR DESCRIPTION
### Description:

The regexes for `plaid-secret-key` and `plaid-client-id` are fairly loose, leading to false positives in (Haskell) function signatures like this:

```
myFunc :: PlaidFunction -> ReallyReallyLongArgument
```

This PR adds entropy to the checks, but I also wonder if the regex section for "this is an assignment operator" could be changed to avoid `->` completely. Let me know what you think and I can move forward with adding tests for this or modifying the regex.

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
