### PR TITLE
fix: no-color option should also affect zerolog output

### DIFF
--- a/cmd/detect.go
+++ b/cmd/detect.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -52,6 +53,17 @@ func runDetect(cmd *cobra.Command, args []string) {
 
 	// Setup detector
 	detector := detect.NewDetector(cfg)
+	// set color flag at first
+	if detector.NoColor, err = cmd.Flags().GetBool("no-color"); err != nil {
+		log.Fatal().Err(err).Msg("")
+	}
+	// also init logger again without color
+	if detector.NoColor {
+		log.Logger = log.Output(zerolog.ConsoleWriter{
+			Out:     os.Stderr,
+			NoColor: detector.NoColor,
+		})
+	}
 	detector.Config.Path, err = cmd.Flags().GetString("config")
 	if err != nil {
 		log.Fatal().Err(err).Msg("")
@@ -74,10 +86,6 @@ func runDetect(cmd *cobra.Command, args []string) {
 		log.Fatal().Err(err).Msg("")
 	}
 	if detector.MaxTargetMegaBytes, err = cmd.Flags().GetInt("max-target-megabytes"); err != nil {
-		log.Fatal().Err(err).Msg("")
-	}
-	// set color flag
-	if detector.NoColor, err = cmd.Flags().GetBool("no-color"); err != nil {
 		log.Fatal().Err(err).Msg("")
 	}
 

--- a/cmd/protect.go
+++ b/cmd/protect.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -46,6 +47,17 @@ func runProtect(cmd *cobra.Command, args []string) {
 
 	// Setup detector
 	detector := detect.NewDetector(cfg)
+	// set color flag at first
+	if detector.NoColor, err = cmd.Flags().GetBool("no-color"); err != nil {
+		log.Fatal().Err(err).Msg("")
+	}
+	// also init logger again without color
+	if detector.NoColor {
+		log.Logger = log.Output(zerolog.ConsoleWriter{
+			Out:     os.Stderr,
+			NoColor: detector.NoColor,
+		})
+	}
 	detector.Config.Path, err = cmd.Flags().GetString("config")
 	if err != nil {
 		log.Fatal().Err(err).Msg("")
@@ -68,10 +80,6 @@ func runProtect(cmd *cobra.Command, args []string) {
 		log.Fatal().Err(err).Msg("")
 	}
 	if detector.MaxTargetMegaBytes, err = cmd.Flags().GetInt("max-target-megabytes"); err != nil {
-		log.Fatal().Err(err).Msg("")
-	}
-	// set color flag
-	if detector.NoColor, err = cmd.Flags().GetBool("no-color"); err != nil {
 		log.Fatal().Err(err).Msg("")
 	}
 


### PR DESCRIPTION
### Description:
Currently `--no-color` options only affects findlings log, but zerolog still output with colors. This MR fixes this behaviour.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
