### PR TITLE
feat: add --ignore-gitleaks-allow cmd flag

### DIFF
--- a/cmd/detect.go
+++ b/cmd/detect.go
@@ -90,6 +90,10 @@ func runDetect(cmd *cobra.Command, args []string) {
 	if detector.MaxTargetMegaBytes, err = cmd.Flags().GetInt("max-target-megabytes"); err != nil {
 		log.Fatal().Err(err).Msg("")
 	}
+	// set ignore gitleaks:allow flag
+	if detector.IgnoreGitleaksAllow, err = cmd.Flags().GetBool("ignore-gitleaks-allow-comments"); err != nil {
+		log.Fatal().Err(err).Msg("")
+	}
 
 	gitleaksIgnorePath, err := cmd.Flags().GetString("gitleaks-ignore-path")
 	if err != nil {

--- a/cmd/protect.go
+++ b/cmd/protect.go
@@ -82,6 +82,10 @@ func runProtect(cmd *cobra.Command, args []string) {
 	if detector.MaxTargetMegaBytes, err = cmd.Flags().GetInt("max-target-megabytes"); err != nil {
 		log.Fatal().Err(err).Msg("")
 	}
+	// set ignore gitleaks:allow flag
+	if detector.IgnoreGitleaksAllow, err = cmd.Flags().GetBool("ignore-gitleaks-allow-comments"); err != nil {
+		log.Fatal().Err(err).Msg("")
+	}
 
 	gitleaksIgnorePath, err := cmd.Flags().GetString("gitleaks-ignore-path")
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,6 +47,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "show verbose output from scan")
 	rootCmd.PersistentFlags().BoolP("no-color", "", false, "turn off color for verbose output")
 	rootCmd.PersistentFlags().Int("max-target-megabytes", 0, "files larger than this will be skipped")
+	rootCmd.PersistentFlags().BoolP("ignore-gitleaks-allow", "", false, "ignore gitleaks:allow comments")
 	rootCmd.PersistentFlags().Uint("redact", 0, "redact secrets from logs and stdout. To redact only parts of the secret just apply a percent value from 0..100. For example --redact=20 (default 100%)")
 	rootCmd.Flag("redact").NoOptDefVal = "100"
 	rootCmd.PersistentFlags().Bool("no-banner", false, "suppress banner")

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -61,6 +61,9 @@ type Detector struct {
 	// NoColor is a flag to disable color output
 	NoColor bool
 
+	// IgnoreGitleaksAllow is a flag to ignore gitleaks:allow comments.
+	IgnoreGitleaksAllow bool
+
 	// commitMap is used to keep track of commits that have been scanned.
 	// This is only used for logging purposes and git scans.
 	commitMap map[string]bool
@@ -282,7 +285,7 @@ func (d *Detector) detectRule(fragment Fragment, rule config.Rule) []report.Find
 		}
 
 		if strings.Contains(fragment.Raw[loc.startLineIndex:loc.endLineIndex],
-			gitleaksAllowSignature) {
+			gitleaksAllowSignature) && !d.IgnoreGitleaksAllow {
 			continue
 		}
 


### PR DESCRIPTION
### Description:
If gitleaks is used as pre-receive hook it's better in some cases to have single source of truth (`.gitleaksignore` file), so we want to turn off `gitleaks:allow` implicitly, otherwise people in big company could abuse it.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
