### PR TITLE
bugfix: reduce false positives for stripe tokens

### DIFF
--- a/cmd/generate/config/rules/stripe.go
+++ b/cmd/generate/config/rules/stripe.go
@@ -1,8 +1,6 @@
 package rules
 
 import (
-	"regexp"
-
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
 	"github.com/zricethezav/gitleaks/v8/config"
 )
@@ -12,7 +10,7 @@ func StripeAccessToken() *config.Rule {
 	r := config.Rule{
 		Description: "Stripe Access Token",
 		RuleID:      "stripe-access-token",
-		Regex:       regexp.MustCompile(`(?i)(sk|pk)_(test|live)_[0-9a-z]{10,32}`),
+		Regex:       generateUniqueTokenRegex(`(sk|pk)_(test|live)_[0-9a-z]{10,32}`, true),
 		Keywords: []string{
 			"sk_test",
 			"pk_test",
@@ -23,5 +21,6 @@ func StripeAccessToken() *config.Rule {
 
 	// validate
 	tps := []string{"stripeToken := \"sk_test_" + secrets.NewSecret(alphaNumeric("30")) + "\""}
-	return validate(r, tps, nil)
+	fps := []string{"nonMatchingToken := \"task_test_" + secrets.NewSecret(alphaNumeric("30")) + "\""}
+	return validate(r, tps, fps)
 }

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2777,7 +2777,7 @@ keywords = [
 [[rules]]
 id = "stripe-access-token"
 description = "Stripe Access Token"
-regex = '''(?i)(sk|pk)_(test|live)_[0-9a-z]{10,32}'''
+regex = '''(?i)\b((sk|pk)_(test|live)_[0-9a-z]{10,32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "sk_test","pk_test","sk_live","pk_live",
 ]


### PR DESCRIPTION
### Description:
Fixes #1276

The regex is now wrapped in word boundaries using the `generateUniqueTokenRegex` helper function. A false positive example was added.

### Checklist:

* [X] Does your PR pass tests?
* [X] Have you written new tests for your changes?
* [X] Have you lint your code locally prior to submission?
