### PR TITLE
Prevent false positives for .net development

### DIFF
--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -19,6 +19,7 @@ paths = [
     '''gradle.lockfile''',
     '''node_modules''',
     '''package-lock.json''',
+    '''(.*?)ruleset''',
     '''yarn.lock''',
     '''pnpm-lock.yaml''',
     '''Database.refactorlog''',
@@ -57,7 +58,8 @@ regexes = [
 {{- with $rule.Allowlist.Commits }}commits = [
     {{ range $j, $commit := . }}"{{ $commit }}",{{ end }}
 ]{{ end }}
-{{- with $rule.Allowlist.StopWords }}stopwords = [{{ range $j, $stopword := . }}
+{{- with $rule.Allowlist.StopWords }}
+stopwords = [{{ range $j, $stopword := . }}
     "{{ $stopword }}",{{ end }}
 ]{{ end }}
 {{ end }}

--- a/cmd/generate/config/rules/generic.go
+++ b/cmd/generate/config/rules/generic.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"regexp"
 	"github.com/zricethezav/gitleaks/v8/config"
 )
 
@@ -34,6 +35,11 @@ func GenericCredential() *config.Rule {
 		},
 		Entropy: 3.5,
 		Allowlist: config.Allowlist{
+			RegexTarget: "line",
+			Regexes: []*regexp.Regexp{
+				regexp.MustCompile("PublicKeyToken"),
+				regexp.MustCompile("InstrumentationKey"),
+			},
 			StopWords: DefaultStopWords,
 		},
 	}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -19,6 +19,7 @@ paths = [
     '''gradle.lockfile''',
     '''node_modules''',
     '''package-lock.json''',
+    '''(.*?)ruleset''',
     '''yarn.lock''',
     '''pnpm-lock.yaml''',
     '''Database.refactorlog''',
@@ -513,6 +514,11 @@ keywords = [
 ]
 
 [rules.allowlist]
+
+regexTarget = "line"
+regexes = [
+    "PublicKeyToken","InstrumentationKey",
+]
 stopwords = [
     "client",
     "endpoint",


### PR DESCRIPTION
### Description:
This PR reduces false positives when it comes to .net development

- Allow .ruleset files (created by SonarQube). This file contains a key= parameter that refers to a SonarQube project Key
- Allow PublicKeyToken regex. The public key token is a unique 16-character key that is given to the assembly when it is built and signed in Microsoft Visual Studio and is not a secret
- Allow InstrumentationKey regex. This is a key used for Azure Application Insights. Is not a secret

### Checklist:

* [X] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [X] Have you lint your code locally prior to submission?
