### PR TITLE
Remove IAM identifiers for non-credential resources in the aws-access-token rule

### DIFF
--- a/cmd/generate/config/rules/aws.go
+++ b/cmd/generate/config/rules/aws.go
@@ -12,16 +12,12 @@ func AWS() *config.Rule {
 		Description: "Identified a pattern that may indicate AWS credentials, risking unauthorized cloud resource access and data breaches on AWS platforms.",
 		RuleID:      "aws-access-token",
 		Regex: regexp.MustCompile(
-			"(?:A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}"),
+			"(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}"),
 		Keywords: []string{
 			"AKIA",
-			"AGPA",
-			"AIDA",
-			"AROA",
-			"AIPA",
-			"ANPA",
-			"ANVA",
 			"ASIA",
+			"ABIA",
+			"ACCA",
 		},
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,7 +23,7 @@ func TestTranslate(t *testing.T) {
 			cfg: Config{
 				Rules: map[string]Rule{"aws-access-key": {
 					Description: "AWS Access Key",
-					Regex:       regexp.MustCompile("(?:A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}"),
+					Regex:       regexp.MustCompile("(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}"),
 					Tags:        []string{"key", "AWS"},
 					Keywords:    []string{},
 					RuleID:      "aws-access-key",
@@ -41,7 +41,7 @@ func TestTranslate(t *testing.T) {
 			cfg: Config{
 				Rules: map[string]Rule{"aws-access-key": {
 					Description: "AWS Access Key",
-					Regex:       regexp.MustCompile("(?:A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}"),
+					Regex:       regexp.MustCompile("(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}"),
 					Tags:        []string{"key", "AWS"},
 					Keywords:    []string{},
 					RuleID:      "aws-access-key",
@@ -57,7 +57,7 @@ func TestTranslate(t *testing.T) {
 			cfg: Config{
 				Rules: map[string]Rule{"aws-access-key": {
 					Description: "AWS Access Key",
-					Regex:       regexp.MustCompile("(?:A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}"),
+					Regex:       regexp.MustCompile("(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}"),
 					Tags:        []string{"key", "AWS"},
 					Keywords:    []string{},
 					RuleID:      "aws-access-key",
@@ -97,7 +97,7 @@ func TestTranslate(t *testing.T) {
 				Rules: map[string]Rule{
 					"aws-access-key": {
 						Description: "AWS Access Key",
-						Regex:       regexp.MustCompile("(?:A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}"),
+						Regex:       regexp.MustCompile("(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}"),
 						Tags:        []string{"key", "AWS"},
 						Keywords:    []string{},
 						RuleID:      "aws-access-key",

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -124,9 +124,9 @@ keywords = [
 [[rules]]
 id = "aws-access-token"
 description = "Identified a pattern that may indicate AWS credentials, risking unauthorized cloud resource access and data breaches on AWS platforms."
-regex = '''(?:A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
+regex = '''(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}'''
 keywords = [
-    "akia","agpa","aida","aroa","aipa","anpa","anva","asia",
+    "akia","asia","abia","acca",
 ]
 
 [[rules]]

--- a/testdata/config/allow_aws_re.toml
+++ b/testdata/config/allow_aws_re.toml
@@ -3,7 +3,7 @@ title = "simple config with allowlist for aws"
 [[rules]]
     description = "AWS Access Key"
     id = "aws-access-key"
-    regex = '''(?:A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
+    regex = '''(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}'''
     tags = ["key", "AWS"]
     [rules.allowlist]
         regexes = ['''AKIALALEMEL33243OLIA''']

--- a/testdata/config/allow_commit.toml
+++ b/testdata/config/allow_commit.toml
@@ -3,7 +3,7 @@ title = "simple config with allowlist for a specific commit"
 [[rules]]
     description = "AWS Access Key"
     id = "aws-access-key"
-    regex = '''(?:A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
+    regex = '''(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}'''
     tags = ["key", "AWS"]
     [rules.allowlist]
         commits = ['''allowthiscommit''']

--- a/testdata/config/allow_global_aws_re.toml
+++ b/testdata/config/allow_global_aws_re.toml
@@ -1,7 +1,7 @@
 [[rules]]
     description = "AWS Access Key"
     id = "aws-access-key"
-    regex = '''(?:A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
+    regex = '''(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}'''
     tags = ["key", "AWS"]
 
 [allowlist]

--- a/testdata/config/allow_path.toml
+++ b/testdata/config/allow_path.toml
@@ -3,7 +3,7 @@ title = "simple config with allowlist for .go files"
 [[rules]]
     description = "AWS Access Key"
     id = "aws-access-key"
-    regex = '''(?:A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
+    regex = '''(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}'''
     tags = ["key", "AWS"]
     [rules.allowlist]
         paths = ['''.go''']

--- a/testdata/config/extend_1.toml
+++ b/testdata/config/extend_1.toml
@@ -6,5 +6,5 @@ path="../testdata/config/extend_2.toml"
 [[rules]]
     description = "AWS Access Key"
     id = "aws-access-key"
-    regex = '''(?:A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
+    regex = '''(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}'''
     tags = ["key", "AWS"]

--- a/testdata/config/simple.toml
+++ b/testdata/config/simple.toml
@@ -4,7 +4,7 @@ title = "gitleaks config"
 [[rules]]
     description = "AWS Access Key"
     id = "aws-access-key"
-    regex = '''(?:A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
+    regex = '''(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}'''
     tags = ["key", "AWS"]
 
 [[rules]]

--- a/testdata/expected/report/sarif_simple.sarif
+++ b/testdata/expected/report/sarif_simple.sarif
@@ -13,7 +13,7 @@
        "id": "aws-access-key",
        "name": "AWS Access Key",
        "shortDescription": {
-        "text": "(?:A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}"
+        "text": "(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}"
        }
       },
       {


### PR DESCRIPTION
### Description:
The purpose of this PR is to reduce the number of False Positive detections by the aws-access-token. This PR addresses issue: https://github.com/gitleaks/gitleaks/issues/1049 

The regex for aws-access-token has been updated to only catch:
 - AWS STS service bearer token (ABIA)
 - Context-specific credential (ACCA)
 - Access key (AKIA)
 - Temporary access key IDs (ASIA)

The following unique IDs are now ignored:
 - User group (AGPA)
 - IAM user (AIDA)
 - IAM role (AROA)
 - Amazon EC2 instance profile  (AIPA)
 - Managed policy (ANPA)
 - Version in a managed policy (ANVA)

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
