### PR TITLE
Update stripe rule to not alert on publishable keys

### DIFF
--- a/cmd/generate/config/rules/stripe.go
+++ b/cmd/generate/config/rules/stripe.go
@@ -10,12 +10,10 @@ func StripeAccessToken() *config.Rule {
 	r := config.Rule{
 		Description: "Found a Stripe Access Token, posing a risk to payment processing services and sensitive financial data.",
 		RuleID:      "stripe-access-token",
-		Regex:       generateUniqueTokenRegex(`(sk|pk)_(test|live)_[0-9a-z]{10,32}`, true),
+		Regex:       generateUniqueTokenRegex(`(sk)_(test|live)_[0-9a-z]{10,32}`, true),
 		Keywords: []string{
 			"sk_test",
-			"pk_test",
 			"sk_live",
-			"pk_live",
 		},
 	}
 

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2688,9 +2688,9 @@ keywords = [
 [[rules]]
 id = "stripe-access-token"
 description = "Found a Stripe Access Token, posing a risk to payment processing services and sensitive financial data."
-regex = '''(?i)\b((sk|pk)_(test|live)_[0-9a-z]{10,32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)\b((sk)_(test|live)_[0-9a-z]{10,32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
-    "sk_test","pk_test","sk_live","pk_live",
+    "sk_test","sk_live",
 ]
 
 [[rules]]


### PR DESCRIPTION
### Description:
Stripe does a weird thing with their secrets: they have publishable keys (PK) and secret keys (SK). These abbreviations are used as the prefix for the key material, e.g., `pk_blahblahblah` and `sk_blahblahblah`. The [publishable key is deliberately not secret](https://stripe.com/docs/keys#obtain-api-keys), and it's used to identify the client to their API. Confusingly named if you're in tech; usually pk means private key.

This rule checks for both sk and pk, and it should only check for sk. I've updated it to reflect only `sk` values, which are actually secret.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
