### PR TITLE
add support for Azure Data Factory SHIR Key

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -192,6 +192,7 @@ func main() {
 		rules.ZendeskSecretKey(),
 		rules.GenericCredential(),
 		rules.InfracostAPIToken(),
+		rules.AzureDataFactory(),
 	}
 
 	// ensure rules have unique ids

--- a/cmd/generate/config/rules/datafactory.go
+++ b/cmd/generate/config/rules/datafactory.go
@@ -1,0 +1,22 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+func AzureDataFactory() *config.Rule {
+	// define rule
+	r := config.Rule{
+		Description: "Uncovered a Data Factory Self-Hosted Integration Runtime Key, which may compromise big data analytics platforms and sensitive data processing.",
+		RuleID:      "datafactory-shir-token",
+		// SHIR Key format: IR@{GUID}@{string_azure _resource_name}@{string_azure_resource_location}@{string_base64}
+		Regex:    generateUniqueTokenRegex(`IR@[0-9a-zA-Z-]{36}@(.*?)@[0-9a-zA-Z\-=]*@[A-Za-z0-9+\/=]{44}`, false),
+		Keywords: []string{"IR"},
+	}
+
+	// validate
+	tps := []string{
+		"IR@40040abc-b2f2-8tyg-ab39-90a490zzzaae@adf-myapp-001@we@uUY/w9WdKTdAWWPDMrEEWdAEZIgeXlrO51GtVUR1/BE=",
+	}
+	return validate(r, tps, nil)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -234,6 +234,14 @@ keywords = [
 ]
 
 [[rules]]
+id = "datafactory-shir-token"
+description = "Uncovered a Data Factory Self-Hosted Integration Runtime Key, which may compromise big data analytics platforms and sensitive data processing."
+regex = '''\b(IR@[0-9a-zA-Z-]{36}@(.*?)@[0-9a-zA-Z\-=]*@[A-Za-z0-9+\/=]{44})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+keywords = [
+    "ir",
+]
+
+[[rules]]
 id = "defined-networking-api-token"
 description = "Identified a Defined Networking API token, which could lead to unauthorized network operations and data breaches."
 regex = '''(?i)(?:dnkey)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:['|\"|\n|\r|\s|\x60|;]|$)'''


### PR DESCRIPTION
### Description:
This PR will detect the Azure Data Factory Self-Hosted Integration Runtime Key, that is used to configure the desktop client that will receive the commands and the data from the ADF control plane to be processed. 
details about this service can be found here: https://learn.microsoft.com/en-us/azure/data-factory/create-self-hosted-integration-runtime?tabs=data-factory#install-and-register-a-self-hosted-ir-from-microsoft-download-center

SHIR Key format: IR@{GUID}@{string_azure _resource_name}@{string_azure_resource_location}@{string_base64}

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
