### PR TITLE
Use latest base images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:latest AS build
+FROM golang:1.21 AS build
 WORKDIR /go/src/github.com/zricethezav/gitleaks
 COPY . .
 RUN VERSION=$(git describe --tags --abbrev=0) && \
 CGO_ENABLED=0 go build -o bin/gitleaks -ldflags "-X="github.com/zricethezav/gitleaks/v8/cmd.Version=${VERSION}
 
-FROM alpine:latest
+FROM alpine:3.19
 RUN apk add --no-cache bash git openssh-client
 COPY --from=build /go/src/github.com/zricethezav/gitleaks/bin/* /usr/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.19 AS build
+FROM golang:latest AS build
 WORKDIR /go/src/github.com/zricethezav/gitleaks
 COPY . .
 RUN VERSION=$(git describe --tags --abbrev=0) && \
 CGO_ENABLED=0 go build -o bin/gitleaks -ldflags "-X="github.com/zricethezav/gitleaks/v8/cmd.Version=${VERSION}
 
-FROM alpine:3.16
+FROM alpine:latest
 RUN apk add --no-cache bash git openssh-client
 COPY --from=build /go/src/github.com/zricethezav/gitleaks/bin/* /usr/bin/
 


### PR DESCRIPTION
### Description:
The current `Dockerfile` uses the golang image of version `1.19` which is deprecated (c.f. https://endoflife.date/go) as well as the alpine image version `3.16` which is soon going to be deprecated (https://endoflife.date/alpine). 
To always have the latest patched versions this PR changes the images to `latest`. If this is not desired, I would recommend that we at least use the latest version explicitly and update it. 
