### PR TITLE
Some passwords are treated as false negatives

### DIFF
--- a/cmd/generate/config/rules/generic.go
+++ b/cmd/generate/config/rules/generic.go
@@ -19,7 +19,7 @@ func GenericCredential() *config.Rule {
 			"password",
 			"auth",
 			"access",
-		}, `[0-9a-z\-_.=]{10,150}`, true),
+		}, `[0-9a-z\-_./+=]{10,150}`, true),
 		Keywords: []string{
 			"key",
 			"api",

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -468,7 +468,7 @@ keywords = [
 [[rules]]
 id = "generic-api-key"
 description = "Detected a Generic API Key, potentially exposing access to various services and sensitive operations."
-regex = '''(?i)(?:key|api|token|secret|client|passwd|password|auth|access)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-z\-_.=]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)(?:key|api|token|secret|client|passwd|password|auth|access)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-z\-_./+=]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3.5
 keywords = [
     "key","api","token","secret","client","passwd","password","auth","access",


### PR DESCRIPTION
### Description:
The "generic-api-key" is modified to take into account the "/" and "+" symbols, since they are very common and with the current rule are causing false negatives.

An example password that would be correctly detected and currently is not:

```
sasl_password=LIkaITK744sG54VgABW/+p4NXFr
```


### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
