### PR TITLE
Add example AWS access keys to allowlist

### DIFF
--- a/cmd/generate/config/rules/aws.go
+++ b/cmd/generate/config/rules/aws.go
@@ -19,6 +19,11 @@ func AWS() *config.Rule {
 			"ABIA",
 			"ACCA",
 		},
+		Allowlist: config.Allowlist{
+			StopWords: []string{
+				"AKIAIOSFODNN7EXAMPLE",
+			},
+		},
 	}
 
 	// validate

--- a/cmd/generate/config/rules/stopwords.go
+++ b/cmd/generate/config/rules/stopwords.go
@@ -1441,6 +1441,7 @@ var DefaultStopWords = []string{
 	"within",
 	"without",
 	"wizard",
+	"wjalrxutnfemi/k7mdeng/bpxrficyexamplekey", // example AWS secret key
 	"word",
 	"wordpres",
 	"work",

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -129,6 +129,11 @@ keywords = [
     "akia","asia","abia","acca",
 ]
 
+[rules.allowlist]
+stopwords = [
+    "AKIAIOSFODNN7EXAMPLE",
+]
+
 [[rules]]
 id = "beamer-api-token"
 description = "Detected a Beamer API token, potentially compromising content management and exposing sensitive notifications and updates."
@@ -1905,6 +1910,7 @@ stopwords = [
     "within",
     "without",
     "wizard",
+    "wjalrxutnfemi/k7mdeng/bpxrficyexamplekey",
     "word",
     "wordpres",
     "work",


### PR DESCRIPTION

### Description:
Hi, I'm working on introducing gitleaks into my company, and gitleaks flagged an AWS access key that is just meant for examples and is used in AWS documentation, e.g., https://docs.aws.amazon.com/STS/latest/APIReference/API_GetAccessKeyInfo.html. 

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes? No, I don't think it's necessary for so a simple a change.
* [x] Have you lint your code locally prior to submission?
