### PR TITLE
Add '-' option to write report to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Flags:
       --no-banner                  suppress banner
       --redact                     redact secrets from logs and stdout
   -f, --report-format string       output format (json, csv, junit, sarif) (default "json")
-  -r, --report-path string         report file
+  -r, --report-path string         report file ("-" to write to stdout)
   -s, --source string              path to source (default ".")
   -v, --verbose                    show verbose output from scan
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("config", "c", "", configDescription)
 	rootCmd.PersistentFlags().Int("exit-code", 1, "exit code when leaks have been encountered")
 	rootCmd.PersistentFlags().StringP("source", "s", ".", "path to source")
-	rootCmd.PersistentFlags().StringP("report-path", "r", "", "report file")
+	rootCmd.PersistentFlags().StringP("report-path", "r", "", "report file (\"-\" to write to stdout)")
 	rootCmd.PersistentFlags().StringP("report-format", "f", "json", "output format (json, csv, junit, sarif)")
 	rootCmd.PersistentFlags().StringP("baseline-path", "b", "", "path to baseline with issues that can be ignored")
 	rootCmd.PersistentFlags().StringP("log-level", "l", "info", "log level (trace, debug, info, warn, error, fatal)")

--- a/report/csv.go
+++ b/report/csv.go
@@ -7,12 +7,11 @@ import (
 	"strings"
 )
 
-// writeCsv writes the list of findings to a writeCloser.
-func writeCsv(f []Finding, w io.WriteCloser) error {
+// writeCsv writes the list of findings to a Writer.
+func writeCsv(f []Finding, w io.Writer) error {
 	if len(f) == 0 {
 		return nil
 	}
-	defer w.Close()
 	cw := csv.NewWriter(w)
 	err := cw.Write([]string{"RuleID",
 		"Commit",

--- a/report/json.go
+++ b/report/json.go
@@ -5,11 +5,10 @@ import (
 	"io"
 )
 
-func writeJson(findings []Finding, w io.WriteCloser) error {
+func writeJson(findings []Finding, w io.Writer) error {
 	if len(findings) == 0 {
 		findings = []Finding{}
 	}
-	defer w.Close()
 
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", " ")

--- a/report/junit.go
+++ b/report/junit.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 )
 
-func writeJunit(findings []Finding, w io.WriteCloser) error {
+func writeJunit(findings []Finding, w io.Writer) error {
 	testSuites := TestSuites{
 		TestSuites: getTestSuites(findings),
 	}

--- a/report/report.go
+++ b/report/report.go
@@ -14,10 +14,18 @@ const (
 )
 
 func Write(findings []Finding, cfg config.Config, ext string, reportPath string) error {
-	file, err := os.Create(reportPath)
-	if err != nil {
-		return err
+	var file *os.File
+	var err error
+	if reportPath == "-" {
+		file = os.Stdout
+	} else {
+		file, err = os.Create(reportPath)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
 	}
+
 	ext = strings.ToLower(ext)
 	switch ext {
 	case ".json", "json":

--- a/report/sarif.go
+++ b/report/sarif.go
@@ -8,13 +8,12 @@ import (
 	"github.com/zricethezav/gitleaks/v8/config"
 )
 
-func writeSarif(cfg config.Config, findings []Finding, w io.WriteCloser) error {
+func writeSarif(cfg config.Config, findings []Finding, w io.Writer) error {
 	sarif := Sarif{
 		Schema:  "https://json.schemastore.org/sarif-2.1.0.json",
 		Version: "2.1.0",
 		Runs:    getRuns(cfg, findings),
 	}
-	defer w.Close()
 
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", " ")


### PR DESCRIPTION
### Description:
When testing out a tool like gitleaks, I find it useful being able to send output to stdout. This PR adds `-` as an option to use for `--report-path` to write to stdout. It's a convention that `-` signifies stdout (or stdin depending on the context).

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
    No, I believe the existing tests in `report_test.go` provide sufficient coverage.
* [x] Have you lint your code locally prior to submission?
