### PR TITLE
Fix age rule id with dashes

### DIFF
--- a/cmd/generate/config/rules/age.go
+++ b/cmd/generate/config/rules/age.go
@@ -10,7 +10,7 @@ func AgeSecretKey() *config.Rule {
 	// define rule
 	r := config.Rule{
 		Description: "Discovered a potential Age encryption tool secret key, risking data decryption and unauthorized access to sensitive information.",
-		RuleID:      "age secret key",
+		RuleID:      "age-secret-key",
 		Regex:       regexp.MustCompile(`AGE-SECRET-KEY-1[QPZRY9X8GF2TVDW0S3JN54KHCE6MUA7L]{58}`),
 		Keywords:    []string{"AGE-SECRET-KEY-1"},
 	}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -50,7 +50,7 @@ keywords = [
 ]
 
 [[rules]]
-id = "age secret key"
+id = "age-secret-key"
 description = "Discovered a potential Age encryption tool secret key, risking data decryption and unauthorized access to sensitive information."
 regex = '''AGE-SECRET-KEY-1[QPZRY9X8GF2TVDW0S3JN54KHCE6MUA7L]{58}'''
 keywords = [


### PR DESCRIPTION
This pull request fixes the rule ID for the age secret key detection. The rule ID was previously set as "age secret key" and has been updated to "age-secret-key" to follow the correct naming convention.