### PR TITLE
fix: secrets found with quotas

### DIFF
--- a/cmd/generate/config/rules/adobe.go
+++ b/cmd/generate/config/rules/adobe.go
@@ -28,6 +28,7 @@ func AdobeClientSecret() *config.Rule {
 		RuleID:      "adobe-client-secret",
 		Regex:       generateUniqueTokenRegex(`(p8e-)(?i)[a-z0-9]{32}`, true),
 		Keywords:    []string{"p8e-"},
+		SecretGroup: 1,
 	}
 
 	// validate

--- a/cmd/generate/config/rules/alibaba.go
+++ b/cmd/generate/config/rules/alibaba.go
@@ -12,6 +12,7 @@ func AlibabaAccessKey() *config.Rule {
 		RuleID:      "alibaba-access-key-id",
 		Regex:       generateUniqueTokenRegex(`(LTAI)(?i)[a-z0-9]{20}`, true),
 		Keywords:    []string{"LTAI"},
+		SecretGroup: 1,
 	}
 
 	// validate

--- a/cmd/generate/config/rules/alibaba_test.go
+++ b/cmd/generate/config/rules/alibaba_test.go
@@ -1,0 +1,10 @@
+package rules
+
+import (
+	"testing"
+)
+
+func TestAlibaba(t *testing.T) {
+	// StripeAccessToken()
+	AlibabaAccessKey()
+}

--- a/cmd/generate/config/rules/hashicorp.go
+++ b/cmd/generate/config/rules/hashicorp.go
@@ -30,8 +30,9 @@ func HashicorpField() *config.Rule {
 	r := config.Rule{
 		Description: "Identified a HashiCorp Terraform password field, risking unauthorized infrastructure configuration and security breaches.",
 		RuleID:      "hashicorp-tf-password",
-		Regex:       generateSemiGenericRegex(keywords, fmt.Sprintf(`"%s"`, alphaNumericExtended("8,20")), true),
+		Regex:       generateSemiGenericRegex(keywords, fmt.Sprintf(`"(%s)"`, alphaNumericExtended("8,20")), true),
 		Keywords:    keywords,
+		SecretGroup: 2,
 	}
 
 	tps := []string{

--- a/cmd/generate/config/rules/lob.go
+++ b/cmd/generate/config/rules/lob.go
@@ -17,6 +17,7 @@ func LobPubAPIToken() *config.Rule {
 			"live_pub",
 			"_pub",
 		},
+		SecretGroup: 1,
 	}
 
 	// validate
@@ -36,6 +37,7 @@ func LobAPIToken() *config.Rule {
 			"test_",
 			"live_",
 		},
+		SecretGroup: 1,
 	}
 
 	// validate

--- a/cmd/generate/config/rules/shippo.go
+++ b/cmd/generate/config/rules/shippo.go
@@ -15,6 +15,7 @@ func ShippoAPIToken() *config.Rule {
 		Keywords: []string{
 			"shippo_",
 		},
+		SecretGroup: 1,
 	}
 
 	// validate

--- a/cmd/generate/config/rules/stripe.go
+++ b/cmd/generate/config/rules/stripe.go
@@ -15,6 +15,7 @@ func StripeAccessToken() *config.Rule {
 			"sk_test",
 			"sk_live",
 		},
+		SecretGroup: 1,
 	}
 
 	// validate

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -77,6 +77,7 @@ keywords = [
 id = "alibaba-access-key-id"
 description = "Detected an Alibaba Cloud AccessKey ID, posing a risk of unauthorized cloud resource access and potential data compromise."
 regex = '''(?i)\b((LTAI)(?i)[a-z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+secretGroup = 1
 keywords = [
     "ltai",
 ]

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -45,6 +45,7 @@ keywords = [
 id = "adobe-client-secret"
 description = "Discovered a potential Adobe Client Secret, which, if exposed, could allow unauthorized Adobe service access and data manipulation."
 regex = '''(?i)\b((p8e-)(?i)[a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+secretGroup = 1
 keywords = [
     "p8e-",
 ]
@@ -2068,7 +2069,8 @@ keywords = [
 [[rules]]
 id = "hashicorp-tf-password"
 description = "Identified a HashiCorp Terraform password field, risking unauthorized infrastructure configuration and security breaches."
-regex = '''(?i)(?:administrator_login_password|password)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}("[a-z0-9=_\-]{8,20}")(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)(?:administrator_login_password|password)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}("([a-z0-9=_\-]{8,20})")(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+secretGroup = 2
 keywords = [
     "administrator_login_password","password",
 ]
@@ -2223,6 +2225,7 @@ keywords = [
 id = "lob-api-key"
 description = "Uncovered a Lob API Key, which could lead to unauthorized access to mailing and address verification services."
 regex = '''(?i)(?:lob)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}((live|test)_[a-f0-9]{35})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+secretGroup = 1
 keywords = [
     "test_","live_",
 ]
@@ -2231,6 +2234,7 @@ keywords = [
 id = "lob-pub-api-key"
 description = "Detected a Lob Publishable API Key, posing a risk of exposing mail and print service integrations."
 regex = '''(?i)(?:lob)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}((test|live)_pub_[a-f0-9]{31})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+secretGroup = 1
 keywords = [
     "test_pub","live_pub","_pub",
 ]
@@ -2537,6 +2541,7 @@ keywords = [
 id = "shippo-api-token"
 description = "Discovered a Shippo API token, potentially compromising shipping services and customer order data."
 regex = '''(?i)\b(shippo_(live|test)_[a-f0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+secretGroup = 1
 keywords = [
     "shippo_",
 ]
@@ -2690,6 +2695,7 @@ keywords = [
 id = "stripe-access-token"
 description = "Found a Stripe Access Token, posing a risk to payment processing services and sensitive financial data."
 regex = '''(?i)\b((sk)_(test|live)_[0-9a-z]{10,32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+secretGroup = 1
 keywords = [
     "sk_test","sk_live",
 ]

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -310,6 +310,13 @@ func (d *Detector) detectRule(fragment Fragment, rule config.Rule) []report.Find
 			secret = groups[rule.SecretGroup]
 			finding.Secret = secret
 		}
+		if strings.HasSuffix(finding.Secret, `"`) {
+			log.Debug().
+				Str("rule", rule.RuleID).
+				Strs("groups", groups).
+				Int("group", rule.SecretGroup).
+				Msg("secret ends with quote")
+		}
 
 		// check if the regexTarget is defined in the allowlist "regexes" entry
 		allowlistTarget := finding.Secret

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -339,13 +339,13 @@ func TestDetect(t *testing.T) {
 			expectedFindings: []report.Finding{
 				{
 					Description: "Detected an Alibaba Cloud AccessKey ID, posing a risk of unauthorized cloud resource access and potential data compromise.",
-					Match:       `LTAIe7322523fb86ed64c836`,
+					Match:       `LTAIe7322523fb86ed64c836"`,
 					Secret:      `LTAIe7322523fb86ed64c836`,
 					Line:        `alibabaKey := "LTAIe7322523fb86ed64c836"`,
 					File:        "tmp.py",
 					RuleID:      "alibaba-access-key-id",
 					Tags:        []string{},
-					Entropy:     3.9132698,
+					Entropy:     3.8239348,
 					StartLine:   0,
 					EndLine:     0,
 					StartColumn: 16,

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -330,6 +330,29 @@ func TestDetect(t *testing.T) {
 			},
 			expectedFindings: []report.Finding{},
 		},
+		{
+			cfgName: "with_quotas",
+			fragment: Fragment{
+				Raw:      `alibabaKey := "LTAIe7322523fb86ed64c836"`,
+				FilePath: "tmp.py",
+			},
+			expectedFindings: []report.Finding{
+				{
+					Description: "Detected an Alibaba Cloud AccessKey ID, posing a risk of unauthorized cloud resource access and potential data compromise.",
+					Match:       `LTAIe7322523fb86ed64c836`,
+					Secret:      `LTAIe7322523fb86ed64c836`,
+					Line:        `alibabaKey := "LTAIe7322523fb86ed64c836"`,
+					File:        "tmp.py",
+					RuleID:      "alibaba-access-key-id",
+					Tags:        []string{},
+					Entropy:     3.9132698,
+					StartLine:   0,
+					EndLine:     0,
+					StartColumn: 16,
+					EndColumn:   40,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/testdata/config/with_quotas.toml
+++ b/testdata/config/with_quotas.toml
@@ -4,6 +4,7 @@ title = "gitleaks config"
 id = "alibaba-access-key-id"
 description = "Detected an Alibaba Cloud AccessKey ID, posing a risk of unauthorized cloud resource access and potential data compromise."
 regex = '''(?i)\b((LTAI)(?i)[a-z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+secretGroup = 1
 keywords = [
     "ltai",
 ]

--- a/testdata/config/with_quotas.toml
+++ b/testdata/config/with_quotas.toml
@@ -1,0 +1,10 @@
+title = "gitleaks config"
+
+[[rules]]
+id = "alibaba-access-key-id"
+description = "Detected an Alibaba Cloud AccessKey ID, posing a risk of unauthorized cloud resource access and potential data compromise."
+regex = '''(?i)\b((LTAI)(?i)[a-z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+keywords = [
+    "ltai",
+]
+


### PR DESCRIPTION
I found some rules that returns the value ended with `"`. This happened because missing `secretGroup` value.

It is an _hot fix_.

For the future, I think we need:
1. Refactor the `validate` function or create another suite of tests with declaration of the expected found secret.
1. Fix the suffix regex to not include the `"`, because even with my change, it only fixes the `Secret` but not the `Match`