### PR TITLE
Add go.work and go.work.sum to global allowlist

### DIFF
--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -15,7 +15,7 @@ description = "global allow lists"
 paths = [
     '''gitleaks.toml''',
     '''(.*?)(jpg|gif|doc|docx|zip|xls|pdf|bin|svg|socket|vsidx|v2|suo|wsuo|.dll|pdb|exe)$''',
-    '''(go.mod|go.sum)$''',
+    '''(go.mod|go.sum|go.work|go.work.sum)$''',
     '''gradle.lockfile''',
     '''node_modules''',
     '''package-lock.json''',

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -15,7 +15,7 @@ description = "global allow lists"
 paths = [
     '''gitleaks.toml''',
     '''(.*?)(jpg|gif|doc|docx|zip|xls|pdf|bin|svg|socket|vsidx|v2|suo|wsuo|.dll|pdb|exe)$''',
-    '''(go.mod|go.sum)$''',
+    '''(go.mod|go.sum|go.work|go.work.sum)$''',
     '''gradle.lockfile''',
     '''node_modules''',
     '''package-lock.json''',


### PR DESCRIPTION
### Description:
Explain the purpose of the PR.

Since Go 1.18, workspace files can be used to manage workspaces with multiple Go modules. Using workspaces leads to the generation of go.work and go.work.sum files, which behave similarly to go.mod and go.sum files. Since the other Go-specific files are in the global allowlist, I think it makes sense to also add  these files.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
