### PR TITLE
ignore go.sum file on generic-api-key

### DIFF
--- a/cmd/generate/config/rules/generic.go
+++ b/cmd/generate/config/rules/generic.go
@@ -1,6 +1,8 @@
 package rules
 
 import (
+	"regexp"
+
 	"github.com/zricethezav/gitleaks/v8/config"
 )
 
@@ -34,6 +36,7 @@ func GenericCredential() *config.Rule {
 		Entropy: 3.5,
 		Allowlist: config.Allowlist{
 			StopWords: DefaultStopWords,
+			Paths:     []*regexp.Regexp{regexp.MustCompile(`go\.sum$`)},
 		},
 	}
 
@@ -43,6 +46,8 @@ func GenericCredential() *config.Rule {
 		generateSampleSecret("generic", "Zf3D0LXCM3EIMbgJpUNnkRtOfOueHznB"),
 		`"client_id" : "0afae57f3ccfd9d7f5767067bc48b30f719e271ba470488056e37ab35d4b6506"`,
 		`"client_secret" : "6da89121079f83b2eb6acccf8219ea982c3d79bccc3e9c6a85856480661f8fde",`,
+		`golang.org/x/oauth2 v0.15.0 h1:s8pnnxNVzjWyrvYdFUQq5llS1PX2zhPXmccZv99h7uQ=`,   // from go.sum file. should be ignored by the filename
+		`google.golang.org/api v0.81.0 h1:o8WF5AvfidafWbFjsRyupxyEQJNUWxLZJCK5NXrxZZ8=`, // from go.sum file
 	}
 	fps := []string{
 		`client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.client-vpn-endpoint.id`,

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -475,7 +475,9 @@ keywords = [
 ]
 
 [rules.allowlist]
-stopwords = [
+paths = [
+    "go\.sum$",
+]stopwords = [
     "000000",
     "aaaaaa",
     "about",


### PR DESCRIPTION
### Description:
I scanned my Golang project and it found secrets in the `go.sum` file. These tokens are checksum and not a secret.

Since the go.sum is autogenerated, I think it will be good to ignore it.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?  
  Do we have an "e2e" tests to test against a complete file?
* [x] Have you lint your code locally prior to submission?
