### PR TITLE
Improved Telegram bot token rule regex and added more test cases

### DIFF
--- a/cmd/generate/config/rules/telegram.go
+++ b/cmd/generate/config/rules/telegram.go
@@ -13,7 +13,7 @@ func TelegramBotToken() *config.Rule {
 		Description: "Detected a Telegram Bot API Token, risking unauthorized bot operations and message interception on Telegram.",
 		RuleID:      "telegram-bot-api-token",
 
-		Regex: regexp.MustCompile(`(?i)(?:^|[^0-9])([0-9]{5,16}:A[a-zA-Z0-9_\-]{34})(?:$|[^a-zA-Z0-9_\-])`),
+		Regex: regexp.MustCompile(`(?i)(?:^|\b|bot)([0-9]{5,16}:A[a-z0-9_\-]{34})(?:$|\b[^_\-])`),
 		Keywords: []string{
 			"telegram",
 			"api",
@@ -24,9 +24,12 @@ func TelegramBotToken() *config.Rule {
 	}
 
 	// validate
-	validToken := secrets.NewSecret(numeric("8") + ":A" + alphaNumericExtendedShort("34"))
-	minToken := secrets.NewSecret(numeric("5") + ":A" + alphaNumericExtendedShort("34"))
-	maxToken := secrets.NewSecret(numeric("16") + ":A" + alphaNumericExtendedShort("34"))
+	var (
+		validToken   = secrets.NewSecret(numeric("8") + ":A" + alphaNumericExtendedShort("34"))
+		minToken     = secrets.NewSecret(numeric("5") + ":A" + alphaNumericExtendedShort("34"))
+		maxToken     = secrets.NewSecret(numeric("16") + ":A" + alphaNumericExtendedShort("34"))
+		xsdWithToken = secrets.NewSecret(`<xsd:element name="AgencyIdentificationCode" type="` + numeric("5") + `:A` + alphaNumericExtendedShort("34") + `"/>`)
+	)
 	tps := []string{
 		// variable assignment
 		generateSampleSecret("telegram", validToken),
@@ -42,15 +45,39 @@ func TelegramBotToken() *config.Rule {
 		generateSampleSecret("telegram", minToken),
 		// Token with max bot_id
 		generateSampleSecret("telegram", maxToken),
+		// Valid token in XSD document
+		generateSampleSecret("telegram", xsdWithToken),
 	}
 
-	tooSmallToken := secrets.NewSecret(numeric("4") + ":A" + alphaNumericExtendedShort("34"))
-	tooBigToken := secrets.NewSecret(numeric("17") + ":A" + alphaNumericExtendedShort("34"))
+	var (
+		tooSmallToken                = secrets.NewSecret(numeric("4") + ":A" + alphaNumericExtendedShort("34"))
+		tooBigToken                  = secrets.NewSecret(numeric("17") + ":A" + alphaNumericExtendedShort("34"))
+		xsdAgencyIdentificationCode1 = secrets.NewSecret(`<xsd:element name="AgencyIdentificationCode" type="clm`+numeric("5")+":AgencyIdentificationCodeContentType") + `"/>`
+		xsdAgencyIdentificationCode2 = secrets.NewSecret(`token:"clm` + numeric("5") + `:AgencyIdentificationCodeContentType"`)
+		xsdAgencyIdentificationCode3 = secrets.NewSecret(`<xsd:element name="AgencyIdentificationCode" type="clm` + numeric("8") + `:AgencyIdentificationCodeContentType"/>`)
+		prefixedToken1               = secrets.NewSecret(`telegram_api_token = \"` + numeric("8") + `:Ahello` + alphaNumericExtendedShort("34") + `\"`)
+		prefixedToken2               = secrets.NewSecret(`telegram_api_token = \"` + numeric("8") + `:A-some-other-thing-` + alphaNumericExtendedShort("34") + `\"`)
+		prefixedToken3               = secrets.NewSecret(`telegram_api_token = \"` + numeric("8") + `:A_` + alphaNumericExtendedShort("34") + `\"`)
+		suffixedToken1               = secrets.NewSecret(`telegram_api_token = \"` + numeric("8") + `:A` + alphaNumericExtendedShort("34") + `hello\"`)
+		suffixedToken2               = secrets.NewSecret(`telegram_api_token = \"` + numeric("8") + `:A` + alphaNumericExtendedShort("34") + `-some-other-thing\"`)
+		suffixedToken3               = secrets.NewSecret(`telegram_api_token = \"` + numeric("8") + `:A_` + alphaNumericExtendedShort("34") + `_\"`)
+	)
 	fps := []string{
 		// Token with too small bot_id
 		generateSampleSecret("telegram", tooSmallToken),
 		// Token with too big bot_id
 		generateSampleSecret("telegram", tooBigToken),
+		// XSD file containing the string AgencyIdentificationCodeContentType
+		generateSampleSecret("telegram", xsdAgencyIdentificationCode1),
+		generateSampleSecret("telegram", xsdAgencyIdentificationCode2),
+		generateSampleSecret("telegram", xsdAgencyIdentificationCode3),
+		// Prefix and suffix variations that shouldn't match
+		generateSampleSecret("telegram", prefixedToken1),
+		generateSampleSecret("telegram", prefixedToken2),
+		generateSampleSecret("telegram", prefixedToken3),
+		generateSampleSecret("telegram", suffixedToken1),
+		generateSampleSecret("telegram", suffixedToken2),
+		generateSampleSecret("telegram", suffixedToken3),
 	}
 
 	return validate(r, tps, fps)

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2758,7 +2758,7 @@ keywords = [
 [[rules]]
 id = "telegram-bot-api-token"
 description = "Detected a Telegram Bot API Token, risking unauthorized bot operations and message interception on Telegram."
-regex = '''(?i)(?:^|[^0-9])([0-9]{5,16}:A[a-zA-Z0-9_\-]{34})(?:$|[^a-zA-Z0-9_\-])'''
+regex = '''(?i)(?:^|\b|bot)([0-9]{5,16}:A[a-z0-9_\-]{34})(?:$|\b[^_\-])'''
 keywords = [
     "telegram","api","bot","token","url",
 ]


### PR DESCRIPTION
### Description:
At work we came across an edge-case where the Telegram bot token rule would match lots of XML schema definitions in which `clm12345:AgencyIdentificationCodeContentType` appears which happens be the exact same length the regex is looking for (`A[a-zA-Z0-9_\-]{34}`) prefixed with the right amount of digits (`[0-9]{5,16}`) . To fix it I've modified the regex to take boundaries into account and simplified `a-zA-Z0-9` parts to `a-z0-9` because the entire regex is already case insensitive (`(?i)`). Also added a few more test cases.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
