### PR TITLE
extend FB access token discovery

### DIFF
--- a/cmd/generate/config/rules/facebook.go
+++ b/cmd/generate/config/rules/facebook.go
@@ -32,7 +32,7 @@ func FacebookAccessToken() *config.Rule {
 	r := config.Rule{
 		Description: "Discovered a Facebook Access Token, posing a risk of unauthorized access to Facebook accounts and personal data exposure.",
 		RuleID:      "facebook-access-token",
-		Regex:       generateUniqueTokenRegex(`\d{15,16}\|[0-9a-z\-_]{27}`, true),
+		Regex:       generateUniqueTokenRegex(`\d{15,16}(\||%)[0-9a-z\-_]{27,}`, true),
 	}
 
 	// validate

--- a/cmd/generate/config/rules/facebook.go
+++ b/cmd/generate/config/rules/facebook.go
@@ -32,7 +32,7 @@ func FacebookAccessToken() *config.Rule {
 	r := config.Rule{
 		Description: "Discovered a Facebook Access Token, posing a risk of unauthorized access to Facebook accounts and personal data exposure.",
 		RuleID:      "facebook-access-token",
-		Regex:       generateUniqueTokenRegex(`\d{15,16}(\||%)[0-9a-z\-_]{27,}`, true),
+		Regex:       generateUniqueTokenRegex(`\d{15,16}(\||%)[0-9a-z\-_]{27,40}`, true),
 	}
 
 	// validate

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -396,7 +396,7 @@ keywords = [
 [[rules]]
 id = "facebook-access-token"
 description = "Discovered a Facebook Access Token, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''(?i)\b(\d{15,16}(\||%)[0-9a-z\-_]{27,})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)\b(\d{15,16}(\||%)[0-9a-z\-_]{27,40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 
 [[rules]]
 id = "facebook-page-access-token"

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -396,7 +396,7 @@ keywords = [
 [[rules]]
 id = "facebook-access-token"
 description = "Discovered a Facebook Access Token, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''(?i)\b(\d{15,16}\|[0-9a-z\-_]{27})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)\b(\d{15,16}(\||%)[0-9a-z\-_]{27,})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 
 [[rules]]
 id = "facebook-page-access-token"


### PR DESCRIPTION
### Description:
- There are cases where Facebook account ID and token are separated with `%` (and not only by `|`).
- Facebook token sometimes is longer than 27 characters (mine is 29).

