### PR TITLE
Add intra42 client secret

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -106,6 +106,7 @@ func main() {
 		rules.HuggingFaceAccessToken(),
 		rules.HuggingFaceOrganizationApiToken(),
 		rules.Intercom(),
+		rules.Intra42ClientSecret(),
 		rules.JFrogAPIKey(),
 		rules.JFrogIdentityToken(),
 		rules.JWT(),

--- a/cmd/generate/config/rules/intra42.go
+++ b/cmd/generate/config/rules/intra42.go
@@ -1,0 +1,29 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+func Intra42ClientSecret() *config.Rule {
+	// define rule
+	r := config.Rule{
+		Description: "Found a Intra42 client secret, which could lead to unauthorized access to the 42School API and sensitive data.",
+		RuleID:      "intra42-client-secret",
+		Regex:       generateUniqueTokenRegex(`s-s4t2(?:ud|af)-[abcdef0123456789]{64}`, true),
+		Keywords: []string{
+			"intra",
+			"s-s4t2ud-",
+			"s-s4t2af-",
+		},
+	}
+
+	// validate
+	tps := []string{
+		"clientSecret := \"s-s4t2ud-" + secrets.NewSecret(hex("64")) + "\"",
+		"clientSecret := \"s-s4t2af-" + secrets.NewSecret(hex("64")) + "\"",
+		"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", // gitleaks:allow
+		"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", // gitleaks:allow
+	}
+	return validate(r, tps, nil)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2160,6 +2160,14 @@ keywords = [
 ]
 
 [[rules]]
+id = "intra42-client-secret"
+description = "Found a Intra42 client secret, which could lead to unauthorized access to the 42School API and sensitive data."
+regex = '''(?i)\b(s-s4t2(?:ud|af)-[abcdef0123456789]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+keywords = [
+    "intra","s-s4t2ud-","s-s4t2af-",
+]
+
+[[rules]]
 id = "jfrog-api-key"
 description = "Found a JFrog API Key, posing a risk of unauthorized access to software artifact repositories and build pipelines."
 regex = '''(?i)(?:jfrog|artifactory|bintray|xray)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{73})(?:['|\"|\n|\r|\s|\x60|;]|$)'''


### PR DESCRIPTION
### Description:
This PR adds a new rule: `intra42-client-secret`
intra42 is the intranet and API of "42 School", a Computer-Science school.  
The API is open to all students in 57 campus around the world. It is thus often subject to credentials leaks on GitHub.
See https://github.com/search?q=s-s4t2ud-&type=code&ref=advsearch for an example.

Public website: https://42.fr
API doc: https://api.intra.42.fr/ 

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
