### PR TITLE
Limit hashicorp-tf-password to .tf/.hcl files

### DIFF
--- a/cmd/generate/config/rules/hashicorp.go
+++ b/cmd/generate/config/rules/hashicorp.go
@@ -35,15 +35,17 @@ func HashicorpField() *config.Rule {
 		Path:        regexp.MustCompile(`\.(tf|hcl)$`),
 	}
 
-	tps := []string{
+	tps := map[string]string{
 		// Example from: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/sql_server.html
-		"administrator_login_password = " + `"thisIsDog11"`,
+		"file.tf": "administrator_login_password = " + `"thisIsDog11"`,
 		// https://registry.terraform.io/providers/petoju/mysql/latest/docs
-		"password       = " + `"rootpasswd"`,
+		"file.hcl": "password       = " + `"rootpasswd"`,
 	}
-	fps := []string{
-		"administrator_login_password = var.db_password",
-		`password = "${aws_db_instance.default.password}"`,
+	fps := map[string]string{
+		"file.tf":      "administrator_login_password = var.db_password",
+		"file.hcl":     `password = "${aws_db_instance.default.password}"`,
+		"unrelated.js": "password       = " + `"rootpasswd"`,
 	}
-	return validate(r, tps, fps)
+
+	return validateWithPaths(r, tps, fps)
 }

--- a/cmd/generate/config/rules/hashicorp.go
+++ b/cmd/generate/config/rules/hashicorp.go
@@ -32,6 +32,7 @@ func HashicorpField() *config.Rule {
 		RuleID:      "hashicorp-tf-password",
 		Regex:       generateSemiGenericRegex(keywords, fmt.Sprintf(`"%s"`, alphaNumericExtended("8,20")), true),
 		Keywords:    keywords,
+		Path:        regexp.MustCompile(`\.(tf|hcl)$`),
 	}
 
 	tps := []string{

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2105,6 +2105,7 @@ keywords = [
 id = "hashicorp-tf-password"
 description = "Identified a HashiCorp Terraform password field, risking unauthorized infrastructure configuration and security breaches."
 regex = '''(?i)(?:administrator_login_password|password)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}("[a-z0-9=_\-]{8,20}")(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+path = '''\.(tf|hcl)$'''
 keywords = [
     "administrator_login_password","password",
 ]


### PR DESCRIPTION
### Description:
Related to #1418 #1302

Limit the rule hashicorp-tf-password to only look at HCL files to avoid a lot of false positives, such as this typescript code

None of the built-in rules use a `path` to limit results so I added a new validation method to validate such rules. 

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
