### PR TITLE
fix#1432: made changes to the reading logic

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -22,6 +22,7 @@ import (
 const (
 	gitleaksAllowSignature = "gitleaks:allow"
 	chunkSize              = 10 * 1_000 // 10kb
+	lastNBytes             = 100        // 100 bytes
 )
 
 // Detector is the main detector struct


### PR DESCRIPTION
The issue was seen because we are providing a constant buffer size while reading the file https://github.com/gitleaks/gitleaks/blob/master/detect/detect.go#L24.

We are reading the large file (or any file for that sake of matter, if the size is > 10kb) in chunks. It is possible that the current chunk has some portion of the keyword and the subsequent buffer has the remaining portion of it. Eg. current buffer ends with "pass" and next buffer starts with "word". To handle such cases add last few bytes from the current buffer and append it at the beginning of the next buffer.

Test cases and verification:
Verified changes for below case
https://github.com/gitleaks/gitleaks/issues/1432

Before fix:
<img width="1325" alt="Screenshot 2024-06-29 at 10 52 31 PM" src="https://github.com/gitleaks/gitleaks/assets/57838820/2ee2289d-864f-49d8-bd54-1bd79b085e9b">

After fix:
<img width="1355" alt="Screenshot 2024-06-29 at 10 53 13 PM" src="https://github.com/gitleaks/gitleaks/assets/57838820/241d4885-6c2f-40ba-8572-a58a891c3c33">