### PR TITLE
openai: detect project API keys

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -139,6 +139,7 @@ func main() {
 		rules.NytimesAccessToken(),
 		rules.OktaAccessToken(),
 		rules.OpenAI(),
+		rules.OpenAIProject(),
 		rules.PlaidAccessID(),
 		rules.PlaidSecretKey(),
 		rules.PlaidAccessToken(),

--- a/cmd/generate/config/rules/openai.go
+++ b/cmd/generate/config/rules/openai.go
@@ -11,7 +11,6 @@ func OpenAI() *config.Rule {
 		RuleID:      "openai-api-key",
 		Description: "Found an OpenAI API Key, posing a risk of unauthorized access to AI services and data manipulation.",
 		Regex:       generateUniqueTokenRegex(`sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20}`, true),
-
 		Keywords: []string{
 			"T3BlbkFJ",
 		},
@@ -21,5 +20,29 @@ func OpenAI() *config.Rule {
 	tps := []string{
 		generateSampleSecret("openaiApiKey", "sk-"+secrets.NewSecret(alphaNumeric("20"))+"T3BlbkFJ"+secrets.NewSecret(alphaNumeric("20"))),
 	}
-	return validate(r, tps, nil)
+	fps := []string{
+		generateSampleSecret("openaiApiKey", "sk-proj-"+secrets.NewSecret(alphaNumeric("20"))+"T3BlbkFJ"+secrets.NewSecret(alphaNumeric("20"))),
+	}
+	return validate(r, tps, fps)
+}
+
+func OpenAIProject() *config.Rule {
+	// define rule
+	r := config.Rule{
+		RuleID:      "openai-project-api-key",
+		Description: "Found an OpenAI API Project Key, posing a risk of unauthorized access to AI services and data manipulation.",
+		Regex:       generateUniqueTokenRegex(`sk-proj-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20}`, true),
+		Keywords: []string{
+			"T3BlbkFJ",
+		},
+	}
+
+	// validate
+	tps := []string{
+		generateSampleSecret("openaiApiKey", "sk-proj-"+secrets.NewSecret(alphaNumeric("20"))+"T3BlbkFJ"+secrets.NewSecret(alphaNumeric("20"))),
+	}
+	fps := []string{
+		generateSampleSecret("openaiApiKey", "sk-"+secrets.NewSecret(alphaNumeric("20"))+"T3BlbkFJ"+secrets.NewSecret(alphaNumeric("20"))),
+	}
+	return validate(r, tps, fps)
 }

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2433,6 +2433,14 @@ keywords = [
 ]
 
 [[rules]]
+id = "openai-project-api-key"
+description = "Found an OpenAI API Project Key, posing a risk of unauthorized access to AI services and data manipulation."
+regex = '''(?i)\b(sk-proj-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+keywords = [
+    "t3blbkfj",
+]
+
+[[rules]]
 id = "plaid-api-token"
 description = "Discovered a Plaid API Token, potentially compromising financial data aggregation and banking services."
 regex = '''(?i)(?:plaid)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''


### PR DESCRIPTION
### Description:
OpenAI has project API keys that use a different prefix and is not currently detected by GitLeaks.

Since these are more scoped down than user API keys, I added a new rule for them.

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
