### PR TITLE
Add rule for OpenShift 4 user tokens

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -139,6 +139,7 @@ func main() {
 		rules.NytimesAccessToken(),
 		rules.OktaAccessToken(),
 		rules.OpenAI(),
+		rules.OpenshiftUserToken(),
 		rules.PlaidAccessID(),
 		rules.PlaidSecretKey(),
 		rules.PlaidAccessToken(),

--- a/cmd/generate/config/rules/openshift.go
+++ b/cmd/generate/config/rules/openshift.go
@@ -1,0 +1,37 @@
+package rules
+
+import (
+	"regexp"
+
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+// OpenShift 4 user tokens are prefixed with `sha256~`.
+// https://docs.redhat.com/en/documentation/openshift_container_platform/4.10/html-single/authentication_and_authorization/index#oauth-view-details-tokens_managing-oauth-access-tokens
+func OpenshiftUserToken() *config.Rule {
+	r := config.Rule{
+		RuleID:      "openshift-user-token",
+		Description: "Found an OpenShift user token, potentially compromising an OpenShift/Kubernetes cluster.",
+		// TODO: Do tokens vary in length or are they always 43?
+		Regex:       regexp.MustCompile(`\b(sha256~[\w-]{43})(?:[^\w-]|\z)`),
+		Entropy:     3.5,
+		SecretGroup: 0,
+		Keywords: []string{
+			"sha256~",
+		},
+	}
+
+	// validate
+	tps := []string{
+		`Authorization: Bearer sha256~kV46hPnEYhCWFnB85r5NrprAxggzgb6GOeLbgcKNsH0`, // https://github.com/openshift/console/blob/edae2305e01c2e0e8c33727af720ef960088eee3/dynamic-demo-plugin/README.md?plain=1#L114
+		`oc login --token=sha256~ZBMKw9VAayhdnyANaHvjJeXDiGwA7Fsr5gtLKj3-eh- `,     // https://github.com/IBM/tekton-tutorial-openshift/blob/2a97d22ba282accad50821bca069210ea89de706/docs/lab1/0_setup.md?plain=1#L85
+		"sha256~" + secrets.NewSecret(`[\w-]{43}`),
+	}
+	fps := []string{
+		`--set kraken.kubeconfig.token.token="sha256~XXXXXXXXXX_PUT_YOUR_TOKEN_HERE_XXXXXXXXXXXX" \`, // https://github.com/krkn-chaos/krkn/blob/f3933f0e6239824eb9b5c46ff0e5d503b8465d6a/docs/index.md?plain=1#L307
+		`oc login --token=sha256~_xxxxxx_xxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxx-X \
+    --server=https://api.${zone}.appuio.cloud:6443`,
+	}
+	return validate(r, tps, fps)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2433,6 +2433,15 @@ keywords = [
 ]
 
 [[rules]]
+id = "openshift-user-token"
+description = "Found an OpenShift user token, potentially compromising an OpenShift/Kubernetes cluster."
+regex = '''\b(sha256~[\w-]{43})(?:[^\w-]|\z)'''
+entropy = 3.5
+keywords = [
+    "sha256~",
+]
+
+[[rules]]
 id = "plaid-api-token"
 description = "Discovered a Plaid API Token, potentially compromising financial data aggregation and banking services."
 regex = '''(?i)(?:plaid)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''


### PR DESCRIPTION
### Description:
This adds a pattern for [OpenShift 4 user tokens](https://docs.redhat.com/en/documentation/openshift_container_platform/4.10/html-single/authentication_and_authorization/index#oauth-view-details-tokens_managing-oauth-access-tokens).

Example:
```
$ oc describe useroauthaccesstokens <token_name>

Name:                        <token_name>
Namespace:
Labels:                      <none>
Annotations:                 <none>
API Version:                 oauth.openshift.io/v1
Authorize Token:             sha256~Ksckkug-9Fg_RWn_AUysPoIg-_HqmFI9zUL_CgD8wr8
```

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
