### PR TITLE
Use first non-empty group if `secretGroup` isn't set

### DIFF
--- a/cmd/generate/config/rules/privatekey.go
+++ b/cmd/generate/config/rules/privatekey.go
@@ -11,7 +11,7 @@ func PrivateKey() *config.Rule {
 	r := config.Rule{
 		Description: "Identified a Private Key, which may compromise cryptographic security and sensitive data encryption.",
 		RuleID:      "private-key",
-		Regex:       regexp.MustCompile(`(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY( BLOCK)?-----[\s\S-]*KEY( BLOCK)?----`),
+		Regex:       regexp.MustCompile(`(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY(?: BLOCK)?-----[\s\S-]*KEY(?: BLOCK)?----`),
 		Keywords:    []string{"-----BEGIN"},
 	}
 

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2529,7 +2529,7 @@ keywords = [
 [[rules]]
 id = "private-key"
 description = "Identified a Private Key, which may compromise cryptographic security and sensitive data encryption."
-regex = '''(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY( BLOCK)?-----[\s\S-]*KEY( BLOCK)?----'''
+regex = '''(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY(?: BLOCK)?-----[\s\S-]*KEY(?: BLOCK)?----'''
 keywords = [
     "-----begin",
 ]

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -291,24 +291,31 @@ func (d *Detector) detectRule(fragment Fragment, rule config.Rule) []report.Find
 			continue
 		}
 
-		// by default if secret group is not set, we will check to see if there
-		// are any capture groups. If there are, we will use the first capture to start
-		groups := rule.Regex.FindStringSubmatch(secret)
-		if rule.SecretGroup == 0 {
-			// if len(groups) == 2 that means there is only one capture group
-			// the first element in groups is the full match, the second is the
-			// first capture group
-			if len(groups) == 2 {
-				secret = groups[1]
-				finding.Secret = secret
+		// Set the value of |secret|, if the pattern contains at least one capture group.
+		// (The first element is the full match, hence we check >= 2.)
+		groups := rule.Regex.FindStringSubmatch(finding.Secret)
+		if len(groups) >= 2 {
+			if rule.SecretGroup > 0 {
+				if len(groups) <= rule.SecretGroup {
+					// Config validation should prevent this
+					continue
+				}
+				finding.Secret = groups[rule.SecretGroup]
+			} else {
+				// If |secretGroup| is not set, we will use the first suitable capture group.
+				if len(groups) == 2 {
+					// Use the only group.
+					finding.Secret = groups[1]
+				} else {
+					// Use the first non-empty group.
+					for _, s := range groups[1:] {
+						if len(s) > 0 {
+							finding.Secret = s
+							break
+						}
+					}
+				}
 			}
-		} else {
-			if len(groups) <= rule.SecretGroup || len(groups) == 0 {
-				// Config validation should prevent this
-				continue
-			}
-			secret = groups[rule.SecretGroup]
-			finding.Secret = secret
 		}
 
 		// check if the regexTarget is defined in the allowlist "regexes" entry
@@ -354,7 +361,7 @@ func (d *Detector) detectRule(fragment Fragment, rule config.Rule) []report.Find
 			// secret contains both digits and alphabetical characters.
 			// TODO: this should be replaced with stop words
 			if strings.HasPrefix(rule.RuleID, "generic") {
-				if !containsDigit(secret) {
+				if !containsDigit(finding.Secret) {
 					continue
 				}
 			}

--- a/report/sarif_test.go
+++ b/report/sarif_test.go
@@ -76,7 +76,7 @@ func TestWriteSarif(t *testing.T) {
 			}
 			want, err := os.ReadFile(test.expected)
 			require.NoError(t, err)
-			assert.Equal(t, want, got)
+			assert.Equal(t, string(want), string(got))
 		})
 	}
 }

--- a/testdata/config/simple.toml
+++ b/testdata/config/simple.toml
@@ -79,13 +79,13 @@ title = "gitleaks config"
 [[rules]]
     id = "slack"
     description = "Slack"
-    regex = '''xox[baprs]-([0-9a-zA-Z]{10,48})?'''
+    regex = '''xox[baprs]-(?:[0-9a-zA-Z]{10,48})?'''
     tags = ["key", "Slack"]
 
 [[rules]]
     id = "apkey"
     description = "Asymmetric Private Key"
-    regex = '''-----BEGIN ((EC|PGP|DSA|RSA|OPENSSH) )?PRIVATE KEY( BLOCK)?-----'''
+    regex = '''-----BEGIN (?:(?:EC|PGP|DSA|RSA|OPENSSH) )?PRIVATE KEY(?: BLOCK)?-----'''
     tags = ["key", "AsymmetricPrivateKey"]
 
 [[rules]]

--- a/testdata/expected/report/sarif_simple.sarif
+++ b/testdata/expected/report/sarif_simple.sarif
@@ -104,14 +104,14 @@
        "id": "slack",
        "name": "Slack",
        "shortDescription": {
-        "text": "xox[baprs]-([0-9a-zA-Z]{10,48})?"
+        "text": "xox[baprs]-(?:[0-9a-zA-Z]{10,48})?"
        }
       },
       {
        "id": "apkey",
        "name": "Asymmetric Private Key",
        "shortDescription": {
-        "text": "-----BEGIN ((EC|PGP|DSA|RSA|OPENSSH) )?PRIVATE KEY( BLOCK)?-----"
+        "text": "-----BEGIN (?:(?:EC|PGP|DSA|RSA|OPENSSH) )?PRIVATE KEY(?: BLOCK)?-----"
        }
       },
       {


### PR DESCRIPTION
### Description:

This fixes #1457.

It updates the `secretGroup` logic to use the first non-empty group if **a)** `secretGroup == 0` and **b)** the pattern has more than one capture . This allows defining patterns with slight variations, such as excluding surrounding quotes, without having to create separate rules.

## Example

Without this change, the rule would either return the entire match OR require three separate rules. Neither are ideal.

**Rule**

```yaml
[[rules]]
id = "password-test"
description = "test."
regex = '''(?i)\bpassword:\s*(?:"([^"]+)"|'([^']+)'|([[:graph:]]+))'''
keywords = [
    "password",
]
```

**File**
```
password: "NZ|u67a6'%Q?"

password: 'iY63;\7,>Tj!'

password: 1t8N9'%!uj}
```

**Output**

```bash
./gitleaks detect -c config/gitleaks.toml --no-git -s /tmp/gltest --verbose

    ○
    │╲
    │ ○
    ○ ░
    ░    gitleaks

Finding:     password: "NZ|u67a6'%Q?"
Secret:      NZ|u67a6'%Q?
RuleID:      password-test
Entropy:     3.418296
File:        /tmp/gltest/gltest.txt
Line:        1
Fingerprint: /tmp/gltest/gltest.txt:password-test:1

Finding:     password: 'iY63;\7,>Tj!'
Secret:      iY63;\7,>Tj!
RuleID:      password-test
Entropy:     3.584963
File:        /tmp/gltest/gltest.txt
Line:        3
Fingerprint: /tmp/gltest/gltest.txt:password-test:3

Finding:     password: 1t8N9'%!uj}
Secret:      1t8N9'%!uj}
RuleID:      password-test
Entropy:     3.459432
File:        /tmp/gltest/gltest.txt
Line:        5
Fingerprint: /tmp/gltest/gltest.txt:password-test:5

10:16AM INF scan completed in 9.99ms
10:16AM WRN leaks found: 3
```


### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
