### PR TITLE
Return non-0 exit code  from `DetectGit`

### DIFF
--- a/cmd/detect.go
+++ b/cmd/detect.go
@@ -39,7 +39,7 @@ func runDetect(cmd *cobra.Command, args []string) {
 	// grab source
 	source, err := cmd.Flags().GetString("source")
 	if err != nil {
-		log.Fatal().Err(err).Msg("")
+		log.Fatal().Err(err).Msg("could not get source")
 	}
 	detector := Detector(cmd, cfg, source)
 
@@ -58,7 +58,7 @@ func runDetect(cmd *cobra.Command, args []string) {
 	}
 	fromPipe, err := cmd.Flags().GetBool("pipe")
 	if err != nil {
-		log.Fatal().Err(err)
+		log.Fatal().Err(err).Msg("could not call GetBool() for pipe")
 	}
 
 	// start the detector scan
@@ -72,14 +72,14 @@ func runDetect(cmd *cobra.Command, args []string) {
 		findings, err = detector.DetectFiles(paths)
 		if err != nil {
 			// don't exit on error, just log it
-			log.Error().Err(err).Msg("")
+			log.Error().Err(err).Msg("failed scan directory")
 		}
 	} else if fromPipe {
 		findings, err = detector.DetectReader(os.Stdin, 10)
 		if err != nil {
 			// log fatal to exit, no need to continue since a report
 			// will not be generated when scanning from a pipe...for now
-			log.Fatal().Err(err).Msg("")
+			log.Fatal().Err(err).Msg("failed scan input from stdin")
 		}
 	} else {
 		var (
@@ -88,16 +88,16 @@ func runDetect(cmd *cobra.Command, args []string) {
 		)
 		logOpts, err = cmd.Flags().GetString("log-opts")
 		if err != nil {
-			log.Fatal().Err(err).Msg("")
+			log.Fatal().Err(err).Msg("could not call GetString() for log-opts")
 		}
 		gitCmd, err = sources.NewGitLogCmd(source, logOpts)
 		if err != nil {
-			log.Fatal().Err(err).Msg("")
+			log.Fatal().Err(err).Msg("could not create Git cmd")
 		}
 		findings, err = detector.DetectGit(gitCmd)
 		if err != nil {
 			// don't exit on error, just log it
-			log.Error().Err(err).Msg("")
+			log.Error().Err(err).Msg("failed to scan Git repository")
 		}
 	}
 

--- a/cmd/detect.go
+++ b/cmd/detect.go
@@ -63,10 +63,12 @@ func runDetect(cmd *cobra.Command, args []string) {
 
 	// start the detector scan
 	if noGit {
-		paths, err := sources.DirectoryTargets(source, detector.Sema, detector.FollowSymlinks)
+		var paths <-chan sources.ScanTarget
+		paths, err = sources.DirectoryTargets(source, detector.Sema, detector.FollowSymlinks)
 		if err != nil {
 			log.Fatal().Err(err)
 		}
+
 		findings, err = detector.DetectFiles(paths)
 		if err != nil {
 			// don't exit on error, just log it
@@ -80,12 +82,15 @@ func runDetect(cmd *cobra.Command, args []string) {
 			log.Fatal().Err(err).Msg("")
 		}
 	} else {
-		var logOpts string
+		var (
+			gitCmd  *sources.GitCmd
+			logOpts string
+		)
 		logOpts, err = cmd.Flags().GetString("log-opts")
 		if err != nil {
 			log.Fatal().Err(err).Msg("")
 		}
-		gitCmd, err := sources.NewGitLogCmd(source, logOpts)
+		gitCmd, err = sources.NewGitLogCmd(source, logOpts)
 		if err != nil {
 			log.Fatal().Err(err).Msg("")
 		}


### PR DESCRIPTION
### Description:
This fixes #1450.

The issue _appears_ to be that `err` in the outer scope is being shadowed, meaning that `findingSummaryAndExit` always receives a `nil` value.

https://github.com/gitleaks/gitleaks/blob/0334ec10760314034822710507631d0f6d3acecb/cmd/detect.go#L28-L31

https://github.com/gitleaks/gitleaks/blob/0334ec10760314034822710507631d0f6d3acecb/cmd/detect.go#L88

https://github.com/gitleaks/gitleaks/blob/0334ec10760314034822710507631d0f6d3acecb/cmd/detect.go#L99

**New Behaviour**

```sh
$ ./gitleaks detect --log-opts="--invalid"  --verbose -s /tmp/gitleaks

    ○
    │╲
    │ ○
    ○ ░
    ░    gitleaks

7:51PM ERR [git] fatal: unrecognized argument: --invalid
7:51PM ERR failed to scan Git repository error="stderr is not empty"
7:51PM WRN partial scan completed in 17.8ms
7:51PM WRN no leaks found in partial scan

$ echo $?
1
```

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
