### PR TITLE
Use rule id for config validation error

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -82,6 +82,10 @@ func (vc *ViperConfig) Translate() (Config, error) {
 	rulesMap := make(map[string]Rule)
 
 	for _, r := range vc.Rules {
+		if strings.TrimSpace(r.ID) == "" {
+			return Config{}, fmt.Errorf("rule ID is missing or empty, regex: %s", r.Regex)
+		}
+
 		var allowlistRegexes []*regexp.Regexp
 		for _, a := range r.Allowlist.Regexes {
 			allowlistRegexes = append(allowlistRegexes, regexp.MustCompile(a))
@@ -135,7 +139,7 @@ func (vc *ViperConfig) Translate() (Config, error) {
 		orderedRules = append(orderedRules, r.RuleID)
 
 		if r.Regex != nil && r.SecretGroup > r.Regex.NumSubexp() {
-			return Config{}, fmt.Errorf("%s invalid regex secret group %d, max regex secret group %d", r.RuleID, r.SecretGroup, r.Regex.NumSubexp())
+			return Config{}, fmt.Errorf("%s: invalid regex secret group %d, max regex secret group %d", r.RuleID, r.SecretGroup, r.Regex.NumSubexp())
 		}
 		rulesMap[r.RuleID] = r
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -135,7 +135,7 @@ func (vc *ViperConfig) Translate() (Config, error) {
 		orderedRules = append(orderedRules, r.RuleID)
 
 		if r.Regex != nil && r.SecretGroup > r.Regex.NumSubexp() {
-			return Config{}, fmt.Errorf("%s invalid regex secret group %d, max regex secret group %d", r.Description, r.SecretGroup, r.Regex.NumSubexp())
+			return Config{}, fmt.Errorf("%s invalid regex secret group %d, max regex secret group %d", r.RuleID, r.SecretGroup, r.Regex.NumSubexp())
 		}
 		rulesMap[r.RuleID] = r
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -87,9 +87,14 @@ func TestTranslate(t *testing.T) {
 			},
 		},
 		{
+			cfgName:   "missing_id",
+			cfg:       Config{},
+			wantError: fmt.Errorf("rule ID is missing or empty, regex: (?i)(discord[a-z0-9_ .\\-,]{0,25})(=|>|:=|\\|\\|:|<=|=>|:).{0,5}['\\\"]([a-h0-9]{64})['\\\"]"),
+		},
+		{
 			cfgName:   "bad_entropy_group",
 			cfg:       Config{},
-			wantError: fmt.Errorf("Discord API key invalid regex secret group 5, max regex secret group 3"),
+			wantError: fmt.Errorf("discord-api-key: invalid regex secret group 5, max regex secret group 3"),
 		},
 		{
 			cfgName: "base",

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -295,7 +295,7 @@ func TestDetect(t *testing.T) {
 				FilePath: "tmp.go",
 			},
 			expectedFindings: []report.Finding{},
-			wantError:        fmt.Errorf("Discord API key invalid regex secret group 5, max regex secret group 3"),
+			wantError:        fmt.Errorf("discord-api-key: invalid regex secret group 5, max regex secret group 3"),
 		},
 		{
 			cfgName: "simple",

--- a/testdata/config/missing_id.toml
+++ b/testdata/config/missing_id.toml
@@ -1,0 +1,7 @@
+title = "gitleaks config"
+
+[[rules]]
+description = "Discord API key"
+regex = '''(?i)(discord[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-h0-9]{64})['\"]'''
+secretGroup = 5
+entropy = 3.5


### PR DESCRIPTION
### Description:
This updates a validation error to use the rule ID instead of the description. It also adds a check to ensure that the ID isn't blank.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
