### PR TITLE
Update config rule validation logic

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -89,7 +89,12 @@ func TestTranslate(t *testing.T) {
 		{
 			cfgName:   "missing_id",
 			cfg:       Config{},
-			wantError: fmt.Errorf("rule ID is missing or empty, regex: (?i)(discord[a-z0-9_ .\\-,]{0,25})(=|>|:=|\\|\\|:|<=|=>|:).{0,5}['\\\"]([a-h0-9]{64})['\\\"]"),
+			wantError: fmt.Errorf("rule |id| is missing or empty, regex: (?i)(discord[a-z0-9_ .\\-,]{0,25})(=|>|:=|\\|\\|:|<=|=>|:).{0,5}['\\\"]([a-h0-9]{64})['\\\"]"),
+		},
+		{
+			cfgName:   "no_regex_or_path",
+			cfg:       Config{},
+			wantError: fmt.Errorf("discord-api-key: both |regex| and |path| are empty, this rule will have no effect"),
 		},
 		{
 			cfgName:   "bad_entropy_group",
@@ -127,18 +132,20 @@ func TestTranslate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		viper.Reset()
-		viper.AddConfigPath(configPath)
-		viper.SetConfigName(tt.cfgName)
-		viper.SetConfigType("toml")
-		err := viper.ReadInConfig()
-		require.NoError(t, err)
+		t.Run(tt.cfgName, func(t *testing.T) {
+			viper.Reset()
+			viper.AddConfigPath(configPath)
+			viper.SetConfigName(tt.cfgName)
+			viper.SetConfigType("toml")
+			err := viper.ReadInConfig()
+			require.NoError(t, err)
 
-		var vc ViperConfig
-		err = viper.Unmarshal(&vc)
-		require.NoError(t, err)
-		cfg, err := vc.Translate()
-		assert.Equal(t, tt.wantError, err)
-		assert.Equal(t, cfg.Rules, tt.cfg.Rules)
+			var vc ViperConfig
+			err = viper.Unmarshal(&vc)
+			require.NoError(t, err)
+			cfg, err := vc.Translate()
+			assert.Equal(t, tt.wantError, err)
+			assert.Equal(t, cfg.Rules, tt.cfg.Rules)
+		})
 	}
 }

--- a/config/rule.go
+++ b/config/rule.go
@@ -1,16 +1,18 @@
 package config
 
 import (
+	"fmt"
 	"regexp"
+	"strings"
 )
 
 // Rules contain information that define details on how to detect secrets
 type Rule struct {
-	// Description is the description of the rule.
-	Description string
-
 	// RuleID is a unique identifier for this rule
 	RuleID string
+
+	// Description is the description of the rule.
+	Description string
 
 	// Entropy is a float representing the minimum shannon
 	// entropy a regex group must have to be considered a secret.
@@ -40,4 +42,33 @@ type Rule struct {
 	// Allowlist allows a rule to be ignored for specific
 	// regexes, paths, and/or commits
 	Allowlist Allowlist
+}
+
+// Validate guards against common misconfigurations.
+func (r Rule) Validate() error {
+	// Ensure |id| is present.
+	if strings.TrimSpace(r.RuleID) == "" {
+		// Try to provide helpful context, since |id| is empty.
+		var context string
+		if r.Regex != nil {
+			context = ", regex: " + r.Regex.String()
+		} else if r.Path != nil {
+			context = ", path: " + r.Path.String()
+		} else if r.Description != "" {
+			context = ", description: " + r.Description
+		}
+		return fmt.Errorf("rule |id| is missing or empty" + context)
+	}
+
+	// Ensure the rule actually matches something.
+	if r.Regex == nil && r.Path == nil {
+		return fmt.Errorf("%s: both |regex| and |path| are empty, this rule will have no effect", r.RuleID)
+	}
+
+	// Ensure |secretGroup| works.
+	if r.Regex != nil && r.SecretGroup > r.Regex.NumSubexp() {
+		return fmt.Errorf("%s: invalid regex secret group %d, max regex secret group %d", r.RuleID, r.SecretGroup, r.Regex.NumSubexp())
+	}
+
+	return nil
 }

--- a/testdata/config/no_regex_or_path.toml
+++ b/testdata/config/no_regex_or_path.toml
@@ -1,0 +1,5 @@
+title = "gitleaks config"
+
+[[rules]]
+id = 'discord-api-key'
+description = "Discord API key"


### PR DESCRIPTION
### Description:
This adds a check preventing both `regex` and `path` from being undefined.

It also moves the validation logic into its own function. I think that makes more sense but LMK. 

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
