### PR TITLE
Remove more useless capture groups

### DIFF
--- a/cmd/generate/config/rules/adobe.go
+++ b/cmd/generate/config/rules/adobe.go
@@ -27,7 +27,7 @@ func AdobeClientSecret() *config.Rule {
 	r := config.Rule{
 		Description: "Discovered a potential Adobe Client Secret, which, if exposed, could allow unauthorized Adobe service access and data manipulation.",
 		RuleID:      "adobe-client-secret",
-		Regex:       utils.GenerateUniqueTokenRegex(`(p8e-)(?i)[a-z0-9]{32}`, true),
+		Regex:       utils.GenerateUniqueTokenRegex(`p8e-[a-zA-Z0-9]{32}`, false),
 		Keywords:    []string{"p8e-"},
 	}
 
@@ -35,5 +35,8 @@ func AdobeClientSecret() *config.Rule {
 	tps := []string{
 		"adobeClient := \"p8e-" + secrets.NewSecret(utils.Hex("32")) + "\"",
 	}
-	return utils.Validate(r, tps, nil)
+	fps := []string{
+		`P8E-` + secrets.NewSecret(utils.Hex("32")),
+	}
+	return utils.Validate(r, tps, fps)
 }

--- a/cmd/generate/config/rules/alibaba.go
+++ b/cmd/generate/config/rules/alibaba.go
@@ -11,7 +11,7 @@ func AlibabaAccessKey() *config.Rule {
 	r := config.Rule{
 		Description: "Detected an Alibaba Cloud AccessKey ID, posing a risk of unauthorized cloud resource access and potential data compromise.",
 		RuleID:      "alibaba-access-key-id",
-		Regex:       utils.GenerateUniqueTokenRegex(`(LTAI)(?i)[a-z0-9]{20}`, true),
+		Regex:       utils.GenerateUniqueTokenRegex(`LTAI[a-zA-Z0-9]{20}`, false),
 		Keywords:    []string{"LTAI"},
 	}
 
@@ -19,7 +19,10 @@ func AlibabaAccessKey() *config.Rule {
 	tps := []string{
 		"alibabaKey := \"LTAI" + secrets.NewSecret(utils.Hex("20")) + "\"",
 	}
-	return utils.Validate(r, tps, nil)
+	fps := []string{
+		"https://mp.weixin.qq.com/s?__biz=ltAiJTIfmTcHF0Z3fohrsVLP&wx_header=1&scene=27#wechat_redirect)",
+	}
+	return utils.Validate(r, tps, fps)
 }
 
 // TODO

--- a/cmd/generate/config/rules/facebook.go
+++ b/cmd/generate/config/rules/facebook.go
@@ -33,7 +33,7 @@ func FacebookAccessToken() *config.Rule {
 	r := config.Rule{
 		Description: "Discovered a Facebook Access Token, posing a risk of unauthorized access to Facebook accounts and personal data exposure.",
 		RuleID:      "facebook-access-token",
-		Regex:       utils.GenerateUniqueTokenRegex(`\d{15,16}(\||%)[0-9a-z\-_]{27,40}`, true),
+		Regex:       utils.GenerateUniqueTokenRegex(`\d{15,16}[|%][0-9a-z\-_]{27,40}`, true),
 	}
 
 	// validate

--- a/cmd/generate/config/rules/lob.go
+++ b/cmd/generate/config/rules/lob.go
@@ -11,8 +11,7 @@ func LobPubAPIToken() *config.Rule {
 	r := config.Rule{
 		Description: "Detected a Lob Publishable API Key, posing a risk of exposing mail and print service integrations.",
 		RuleID:      "lob-pub-api-key",
-		Regex:       utils.GenerateSemiGenericRegex([]string{"lob"}, `(test|live)_pub_[a-f0-9]{31}`, true),
-
+		Regex:       utils.GenerateSemiGenericRegex([]string{"lob"}, `(?:test|live)_pub_[a-fA-F0-9]{31}`, false),
 		Keywords: []string{
 			"test_pub",
 			"live_pub",
@@ -32,7 +31,7 @@ func LobAPIToken() *config.Rule {
 	r := config.Rule{
 		Description: "Uncovered a Lob API Key, which could lead to unauthorized access to mailing and address verification services.",
 		RuleID:      "lob-api-key",
-		Regex:       utils.GenerateSemiGenericRegex([]string{"lob"}, `(live|test)_[a-f0-9]{35}`, true),
+		Regex:       utils.GenerateSemiGenericRegex([]string{"lob"}, `(?:live|test)_[a-fA-F0-9]{35}`, false),
 		Keywords: []string{
 			"test_",
 			"live_",

--- a/cmd/generate/config/rules/mailgun.go
+++ b/cmd/generate/config/rules/mailgun.go
@@ -11,8 +11,7 @@ func MailGunPrivateAPIToken() *config.Rule {
 	r := config.Rule{
 		RuleID:      "mailgun-private-api-token",
 		Description: "Found a Mailgun private API token, risking unauthorized email service operations and data breaches.",
-		Regex:       utils.GenerateSemiGenericRegex([]string{"mailgun"}, `key-[a-f0-9]{32}`, true),
-
+		Regex:       utils.GenerateSemiGenericRegex([]string{"mailgun"}, `key-(?i:[a-f0-9]{32})`, false),
 		Keywords: []string{
 			"mailgun",
 		},

--- a/cmd/generate/config/rules/mapbox.go
+++ b/cmd/generate/config/rules/mapbox.go
@@ -11,9 +11,8 @@ func MapBox() *config.Rule {
 	r := config.Rule{
 		Description: "Detected a MapBox API token, posing a risk to geospatial services and sensitive location data exposure.",
 		RuleID:      "mapbox-api-token",
-		Regex:       utils.GenerateSemiGenericRegex([]string{"mapbox"}, `pk\.[a-z0-9]{60}\.[a-z0-9]{22}`, true),
-
-		Keywords: []string{"mapbox"},
+		Regex:       utils.GenerateSemiGenericRegex([]string{"mapbox"}, `(?-i:pk)\.[a-z0-9]{60}\.[a-z0-9]{22}`, true),
+		Keywords:    []string{"mapbox"},
 	}
 
 	// validate

--- a/cmd/generate/config/rules/shippo.go
+++ b/cmd/generate/config/rules/shippo.go
@@ -11,7 +11,7 @@ func ShippoAPIToken() *config.Rule {
 	r := config.Rule{
 		RuleID:      "shippo-api-token",
 		Description: "Discovered a Shippo API token, potentially compromising shipping services and customer order data.",
-		Regex:       utils.GenerateUniqueTokenRegex(`shippo_(live|test)_[a-f0-9]{40}`, true),
+		Regex:       utils.GenerateUniqueTokenRegex(`shippo_(?:live|test)_(?i:[a-f0-9]{40})`, false),
 
 		Keywords: []string{
 			"shippo_",

--- a/cmd/generate/config/rules/slack.go
+++ b/cmd/generate/config/rules/slack.go
@@ -259,7 +259,7 @@ func SlackWebHookUrl() *config.Rule {
 		RuleID:      "slack-webhook-url",
 		// If this generates too many false-positives we should define an allowlist (e.g., "xxxx", "00000").
 		Regex: regexp.MustCompile(
-			`(https?:\/\/)?hooks.slack.com\/(services|workflows)\/[A-Za-z0-9+\/]{43,46}`),
+			`(?:https?:\/\/)?hooks.slack.com\/(?:services|workflows)\/[A-Za-z0-9+\/]{43,46}`),
 		Keywords: []string{
 			"hooks.slack.com",
 		},

--- a/cmd/generate/config/rules/square.go
+++ b/cmd/generate/config/rules/square.go
@@ -11,13 +11,13 @@ func SquareAccessToken() *config.Rule {
 	r := config.Rule{
 		RuleID:      "square-access-token",
 		Description: "Detected a Square Access Token, risking unauthorized payment processing and financial transaction exposure.",
-		Regex:       utils.GenerateUniqueTokenRegex(`(EAAA|sq0atp-)[0-9A-Za-z\-_]{22,60}`, true),
+		Regex:       utils.GenerateUniqueTokenRegex(`(?:EAAA|sq0atp-)[\w-]{22,60}`, false),
 		Keywords:    []string{"sq0atp-", "EAAA"},
 	}
 
 	// validate
 	tps := []string{
-		utils.GenerateSampleSecret("square", secrets.NewSecret(`sq0atp-[0-9A-Za-z\-_]{22}`)),
+		utils.GenerateSampleSecret("square", secrets.NewSecret(`sq0atp-[\w-]{22}`)),
 		"ARG token=sq0atp-812erere3wewew45678901",                                    // gitleaks:allow
 		"ARG token=EAAAlsBxkkVgvmr7FasTFbM6VUGZ31EJ4jZKTJZySgElBDJ_wyafHuBFquFexY7E", // gitleaks:allow",
 	}

--- a/cmd/generate/config/rules/stripe.go
+++ b/cmd/generate/config/rules/stripe.go
@@ -11,7 +11,7 @@ func StripeAccessToken() *config.Rule {
 	r := config.Rule{
 		Description: "Found a Stripe Access Token, posing a risk to payment processing services and sensitive financial data.",
 		RuleID:      "stripe-access-token",
-		Regex:       utils.GenerateUniqueTokenRegex(`(sk|rk)_(test|live|prod)_[0-9a-z]{10,99}`, true),
+		Regex:       utils.GenerateUniqueTokenRegex(`(?:sk|rk)_(?:test|live|prod)_(?i:[0-9a-z]{10,99})`, false),
 		Keywords: []string{
 			"sk_test",
 			"sk_live",

--- a/cmd/generate/config/rules/teams.go
+++ b/cmd/generate/config/rules/teams.go
@@ -14,7 +14,7 @@ func TeamsWebhook() *config.Rule {
 		Description: "Uncovered a Microsoft Teams Webhook, which could lead to unauthorized access to team collaboration tools and data leaks.",
 		RuleID:      "microsoft-teams-webhook",
 		Regex: regexp.MustCompile(
-			`https:\/\/[a-z0-9]+\.webhook\.office\.com\/webhookb2\/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}@[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}\/IncomingWebhook\/[a-z0-9]{32}\/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}`),
+			`https:\/\/[a-z0-9]+\.webhook\.office\.com\/webhookb2\/[a-z0-9]{8}-(?:[a-z0-9]{4}-){3}[a-z0-9]{12}@[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}\/IncomingWebhook\/[a-z0-9]{32}\/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}`),
 		Keywords: []string{
 			"webhook.office.com",
 			"webhookb2",

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -46,7 +46,7 @@ keywords = [
 [[rules]]
 id = "adobe-client-secret"
 description = "Discovered a potential Adobe Client Secret, which, if exposed, could allow unauthorized Adobe service access and data manipulation."
-regex = '''(?i)\b((p8e-)(?i)[a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(p8e-[a-zA-Z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "p8e-",
 ]
@@ -78,7 +78,7 @@ keywords = [
 [[rules]]
 id = "alibaba-access-key-id"
 description = "Detected an Alibaba Cloud AccessKey ID, posing a risk of unauthorized cloud resource access and potential data compromise."
-regex = '''(?i)\b((LTAI)(?i)[a-z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(LTAI[a-zA-Z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "ltai",
 ]
@@ -398,7 +398,7 @@ keywords = [
 [[rules]]
 id = "facebook-access-token"
 description = "Discovered a Facebook Access Token, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''(?i)\b(\d{15,16}(\||%)[0-9a-z\-_]{27,40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)\b(\d{15,16}[|%][0-9a-z\-_]{27,40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 
 [[rules]]
 id = "facebook-page-access-token"
@@ -2296,7 +2296,7 @@ keywords = [
 [[rules]]
 id = "lob-api-key"
 description = "Uncovered a Lob API Key, which could lead to unauthorized access to mailing and address verification services."
-regex = '''(?i)(?:lob)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}((live|test)_[a-f0-9]{35})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i:(?:lob)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}((?:live|test)_[a-fA-F0-9]{35})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "test_","live_",
 ]
@@ -2304,7 +2304,7 @@ keywords = [
 [[rules]]
 id = "lob-pub-api-key"
 description = "Detected a Lob Publishable API Key, posing a risk of exposing mail and print service integrations."
-regex = '''(?i)(?:lob)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}((test|live)_pub_[a-f0-9]{31})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i:(?:lob)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}((?:test|live)_pub_[a-fA-F0-9]{31})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "test_pub","live_pub","_pub",
 ]
@@ -2320,7 +2320,7 @@ keywords = [
 [[rules]]
 id = "mailgun-private-api-token"
 description = "Found a Mailgun private API token, risking unauthorized email service operations and data breaches."
-regex = '''(?i)(?:mailgun)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(key-[a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i:(?:mailgun)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(key-(?i:[a-f0-9]{32}))(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "mailgun",
 ]
@@ -2344,7 +2344,7 @@ keywords = [
 [[rules]]
 id = "mapbox-api-token"
 description = "Detected a MapBox API token, posing a risk to geospatial services and sensitive location data exposure."
-regex = '''(?i)(?:mapbox)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(pk\.[a-z0-9]{60}\.[a-z0-9]{22})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)(?:mapbox)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}((?-i:pk)\.[a-z0-9]{60}\.[a-z0-9]{22})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "mapbox",
 ]
@@ -2376,7 +2376,7 @@ keywords = [
 [[rules]]
 id = "microsoft-teams-webhook"
 description = "Uncovered a Microsoft Teams Webhook, which could lead to unauthorized access to team collaboration tools and data leaks."
-regex = '''https:\/\/[a-z0-9]+\.webhook\.office\.com\/webhookb2\/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}@[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}\/IncomingWebhook\/[a-z0-9]{32}\/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}'''
+regex = '''https:\/\/[a-z0-9]+\.webhook\.office\.com\/webhookb2\/[a-z0-9]{8}-(?:[a-z0-9]{4}-){3}[a-z0-9]{12}@[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}\/IncomingWebhook\/[a-z0-9]{32}\/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}'''
 keywords = [
     "webhook.office.com","webhookb2","incomingwebhook",
 ]
@@ -2627,7 +2627,7 @@ keywords = [
 [[rules]]
 id = "shippo-api-token"
 description = "Discovered a Shippo API token, potentially compromising shipping services and customer order data."
-regex = '''(?i)\b(shippo_(live|test)_[a-f0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(shippo_(?:live|test)_(?i:[a-f0-9]{40}))(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "shippo_",
 ]
@@ -2747,7 +2747,7 @@ keywords = [
 [[rules]]
 id = "slack-webhook-url"
 description = "Discovered a Slack Webhook, which could lead to unauthorized message posting and data leakage in Slack channels."
-regex = '''(https?:\/\/)?hooks.slack.com\/(services|workflows)\/[A-Za-z0-9+\/]{43,46}'''
+regex = '''(?:https?:\/\/)?hooks.slack.com\/(?:services|workflows)\/[A-Za-z0-9+\/]{43,46}'''
 keywords = [
     "hooks.slack.com",
 ]
@@ -2763,7 +2763,7 @@ keywords = [
 [[rules]]
 id = "square-access-token"
 description = "Detected a Square Access Token, risking unauthorized payment processing and financial transaction exposure."
-regex = '''(?i)\b((EAAA|sq0atp-)[0-9A-Za-z\-_]{22,60})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b((?:EAAA|sq0atp-)[\w-]{22,60})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "sq0atp-","eaaa",
 ]
@@ -2779,7 +2779,7 @@ keywords = [
 [[rules]]
 id = "stripe-access-token"
 description = "Found a Stripe Access Token, posing a risk to payment processing services and sensitive financial data."
-regex = '''(?i)\b((sk|rk)_(test|live|prod)_[0-9a-z]{10,99})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b((?:sk|rk)_(?:test|live|prod)_(?i:[0-9a-z]{10,99}))(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "sk_test","sk_live","sk_prod","rk_test","rk_live","rk_prod",
 ]


### PR DESCRIPTION
### Description:
This is a follow-up to #1460. 

It also tweaks some rules that use `generateUniqueTokenRegex` with `caseInsensitive=true` in a way that doesn't work as intended. e.g., lowercase prefix followed by `(?i)`

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
