### PR TITLE
Fix private key matching greedily

### DIFF
--- a/cmd/generate/config/rules/privatekey.go
+++ b/cmd/generate/config/rules/privatekey.go
@@ -12,7 +12,7 @@ func PrivateKey() *config.Rule {
 	r := config.Rule{
 		Description: "Identified a Private Key, which may compromise cryptographic security and sensitive data encryption.",
 		RuleID:      "private-key",
-		Regex:       regexp.MustCompile(`(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY(?: BLOCK)?-----[\s\S-]*KEY(?: BLOCK)?----`),
+		Regex:       regexp.MustCompile(`(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY(?: BLOCK)?-----[\s\S-]*?KEY(?: BLOCK)?----`),
 		Keywords:    []string{"-----BEGIN"},
 	}
 

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2531,7 +2531,7 @@ keywords = [
 [[rules]]
 id = "private-key"
 description = "Identified a Private Key, which may compromise cryptographic security and sensitive data encryption."
-regex = '''(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY(?: BLOCK)?-----[\s\S-]*KEY(?: BLOCK)?----'''
+regex = '''(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY(?: BLOCK)?-----[\s\S-]*?KEY(?: BLOCK)?----'''
 keywords = [
     "-----begin",
 ]


### PR DESCRIPTION
### Description:
This fixes #1475.

Tested in a file with: CERTIFICATE + RANDOM STUFF + CERTIFICATE

**Before**

```
    ○
    │╲
    │ ○
    ○ ░
    ░    gitleaks

Finding:     -----BEGIN PRIVATE KEY-----\\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDIoKFd/7IdLTgA\\np8+...
Secret:      -----BEGIN PRIVATE KEY-----\\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDIoKFd/7IdLTgA\\np8+...
RuleID:      private-key
Entropy:     6.017724
File:        /tmp/gltest/pkey.test
Line:        1
Fingerprint: /tmp/gltest/pkey.test:private-key:1

```

**After**
```
    ○
    │╲
    │ ○
    ○ ░
    ░    gitleaks

Finding:     -----BEGIN PRIVATE KEY-----\\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDIoKFd/7IdLTgA\\np8+...
Secret:      -----BEGIN PRIVATE KEY-----\\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDIoKFd/7IdLTgA\\np8+...
RuleID:      private-key
Entropy:     6.007486
File:        /tmp/gltest/pkey.test
Line:        1
Fingerprint: /tmp/gltest/pkey.test:private-key:1

Finding:     -----BEGIN PRIVATE KEY-----\\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDIoKFd/7IdLTgA\\np8+...
Secret:      -----BEGIN PRIVATE KEY-----\\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDIoKFd/7IdLTgA\\np8+...
RuleID:      private-key
Entropy:     6.007486
File:        /tmp/gltest/pkey.test
Line:        4
Fingerprint: /tmp/gltest/pkey.test:private-key:4

5:15PM INF scan completed in 8.42ms
5:15PM WRN leaks found: 2

```
### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
