### PR TITLE
Log warning message when file takes a long time

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/zricethezav/gitleaks/v8/config"
 	"github.com/zricethezav/gitleaks/v8/logging"
@@ -25,6 +26,10 @@ import (
 const (
 	gitleaksAllowSignature = "gitleaks:allow"
 	chunkSize              = 100 * 1_000 // 100kb
+
+	// SlowWarningThreshold is the amount of time to wait before logging that a file is slow.
+	// This is useful for identifying problematic files and tuning the allowlist.
+	SlowWarningThreshold = 5 * time.Second
 )
 
 var (


### PR DESCRIPTION
### Description:
An earlier version of GitLeaks logged a warning message when a fragment was slow to scan.

This was helpful for identifying problematic files and tuning the ignorelist. I feel like it would still be useful today.

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
