### PR TITLE
Update gcp-api-key rule

### DIFF
--- a/cmd/generate/config/rules/gcp.go
+++ b/cmd/generate/config/rules/gcp.go
@@ -30,8 +30,8 @@ func GCPAPIKey() *config.Rule {
 	r := config.Rule{
 		RuleID:      "gcp-api-key",
 		Description: "Uncovered a GCP API key, which could lead to unauthorized access to Google Cloud services and data breaches.",
-		Regex:       utils.GenerateUniqueTokenRegex(`AIza[0-9A-Za-z\\-_]{35}`, true),
-
+		Regex:       utils.GenerateUniqueTokenRegex(`AIza[\w-]{35}`, false),
+		Entropy:     3.0,
 		Keywords: []string{
 			"AIza",
 		},
@@ -39,7 +39,15 @@ func GCPAPIKey() *config.Rule {
 
 	// validate
 	tps := []string{
-		utils.GenerateSampleSecret("gcp", secrets.NewSecret(`AIza[0-9A-Za-z\\-_]{35}`)),
+		utils.GenerateSampleSecret("gcp", secrets.NewSecret(`AIza[\w-]{35}`)),
+		// non-word character at end
+		`AIzaSyNHxIf32IQ1a1yjl3ZJIqKZqzLAK1XhDk-`, // gitleaks:allow
 	}
-	return utils.Validate(r, tps, nil)
+	fps := []string{
+		`GWw4hjABFzZCGiRpmlDyDdo87Jn9BN9THUA47muVRNunLxsa82tMAdvmrhOqNkRKiYMEAFbTJAIzaTesb6Tscfcni8vIpWZqNCXFDFslJtVSvFDq`, // text boundary start
+		`AIzaTesb6Tscfcni8vIpWZqNCXFDFslJtVSvFDqabcd123`,                                                                   // text boundary end
+		`apiKey: "AIzaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`,                                                                // not enough entropy
+		`AIZASYCO2CXRMC9ELSKLHLHRMBSWDEVEDZTLO2O`,                                                                          // incorrect case
+	}
+	return utils.Validate(r, tps, fps)
 }

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -499,7 +499,8 @@ keywords = [
 [[rules]]
 id = "gcp-api-key"
 description = "Uncovered a GCP API key, which could lead to unauthorized access to Google Cloud services and data breaches."
-regex = '''(?i)\b(AIza[0-9A-Za-z\\-_]{35})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(AIza[\w-]{35})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+entropy = 3
 keywords = [
     "aiza",
 ]


### PR DESCRIPTION
### Description:
This tweaks the `gcp-api-key` rule and fixes a bug that caused keys containing `-` to not be detected.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
