### PR TITLE
Update Hashicorp Vault token pattern

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -100,7 +100,7 @@ func main() {
 		rules.GrafanaCloudApiToken(),
 		rules.GrafanaServiceAccountToken(),
 		rules.HarnessApiKey(),
-		rules.Hashicorp(),
+		rules.HashiCorpTerraform(),
 		rules.HashicorpField(),
 		rules.Heroku(),
 		rules.HubSpot(),

--- a/cmd/generate/config/rules/hashicorp.go
+++ b/cmd/generate/config/rules/hashicorp.go
@@ -8,20 +8,25 @@ import (
 	"github.com/zricethezav/gitleaks/v8/config"
 )
 
-func Hashicorp() *config.Rule {
+func HashiCorpTerraform() *config.Rule {
 	// define rule
 	r := config.Rule{
 		Description: "Uncovered a HashiCorp Terraform user/org API token, which may lead to unauthorized infrastructure management and security breaches.",
 		RuleID:      "hashicorp-tf-api-token",
-		Regex:       regexp.MustCompile(`(?i)[a-z0-9]{14}\.atlasv1\.[a-z0-9\-_=]{60,70}`),
+		Regex:       regexp.MustCompile(`(?i)[a-z0-9]{14}\.(?-i:atlasv1)\.[a-z0-9\-_=]{60,70}`),
+		Entropy:     3.5,
 		Keywords:    []string{"atlasv1"},
 	}
 
 	// validate
 	tps := []string{
 		generateSampleSecret("hashicorpToken", secrets.NewSecret(hex("14"))+".atlasv1."+secrets.NewSecret(alphaNumericExtended("60,70"))),
+		`#token = "hE1hlYILrSqpqh.atlasv1.ARjZuyzl33F71WR55s6ln5GQ1HWIwTDDH3MiRjz7OnpCfaCb1RCF5zGaSncCWmJdcYA"`,
 	}
-	return validate(r, tps, nil)
+	fps := []string{
+		`token        = "xxxxxxxxxxxxxx.atlasv1.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"`, // low entropy
+	}
+	return validate(r, tps, fps)
 }
 
 func HashicorpField() *config.Rule {

--- a/cmd/generate/config/rules/vault.go
+++ b/cmd/generate/config/rules/vault.go
@@ -8,17 +8,31 @@ import (
 func VaultServiceToken() *config.Rule {
 	// define rule
 	r := config.Rule{
-		Description: "Identified a Vault Service Token, potentially compromising infrastructure security and access to sensitive credentials.",
 		RuleID:      "vault-service-token",
-		Regex:       generateUniqueTokenRegex(`hvs\.[a-z0-9_-]{90,100}`, true),
-		Keywords:    []string{"hvs"},
+		Description: "Identified a Vault Service Token, potentially compromising infrastructure security and access to sensitive credentials.",
+		Regex:       generateUniqueTokenRegex(`(?:hvs\.[\w-]{90,120}|s\.(?i:[a-z0-9]{24}))`, false),
+		Entropy:     3.5,
+		Keywords:    []string{"hvs", "s."},
 	}
 
 	// validate
 	tps := []string{
+		// Old
+		generateSampleSecret("vault", "s."+secrets.NewSecret(alphaNumeric("24"))),
+		`token: s.ZC9Ecf4M5g9o34Q6RkzGsj0z`,
+		// New
 		generateSampleSecret("vault", "hvs."+secrets.NewSecret(alphaNumericExtendedShort("90"))),
+		`-vaultToken hvs.CAESIP2jTxc9S2K7Z6CtcFWQv7-044m_oSsxnPE1H3nF89l3GiYKHGh2cy5sQmlIZVNyTWJNcDRsYWJpQjlhYjVlb1cQh6PL8wEYAg"`, // longer than 100 chars
 	}
-	return validate(r, tps, nil)
+	fps := []string{
+		// Old
+		`  credentials: new AWS.SharedIniFileCredentials({ profile: '<YOUR_PROFILE>' })`,                              // word boundary start
+		`INFO 4 --- [           main] o.s.b.f.s.DefaultListableBeanFactory     : Overriding bean definition for bean`, // word boundary end
+		`s.xxxxxxxxxxxxxxxxxxxxxxxx`, // low entropy
+		// New
+		`hvs.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`, // low entropy
+	}
+	return validate(r, tps, fps)
 }
 
 func VaultBatchToken() *config.Rule {

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2899,9 +2899,10 @@ keywords = [
 [[rules]]
 id = "vault-service-token"
 description = "Identified a Vault Service Token, potentially compromising infrastructure security and access to sensitive credentials."
-regex = '''(?i)\b(hvs\.[a-z0-9_-]{90,100})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b((?:hvs\.[\w-]{90,120}|s\.(?i:[a-z0-9]{24})))(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+entropy = 3.5
 keywords = [
-    "hvs",
+    "hvs","s.",
 ]
 
 [[rules]]

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2106,7 +2106,8 @@ keywords = [
 [[rules]]
 id = "hashicorp-tf-api-token"
 description = "Uncovered a HashiCorp Terraform user/org API token, which may lead to unauthorized infrastructure management and security breaches."
-regex = '''(?i)[a-z0-9]{14}\.atlasv1\.[a-z0-9\-_=]{60,70}'''
+regex = '''(?i)[a-z0-9]{14}\.(?-i:atlasv1)\.[a-z0-9\-_=]{60,70}'''
+entropy = 3.5
 keywords = [
     "atlasv1",
 ]


### PR DESCRIPTION
### Description:
This updates the Hashicorp Vault and Terraform patterns.

1. Adds the old vault `s.` format
2. Tweaks the new vault `hvs.` format, including making it a bit longer as I've found instances in the wild > 100 chars
3. Adds entropy to terraform

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
