### PR TITLE
Generate comprehensive secret samples

### DIFF
--- a/cmd/generate/config/rules/adafruit.go
+++ b/cmd/generate/config/rules/adafruit.go
@@ -16,8 +16,6 @@ func AdafruitAPIKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("adafruit", secrets.NewSecret(utils.AlphaNumericExtendedShort("32"))),
-	}
+	tps := utils.GenerateSampleSecrets("adafruit", secrets.NewSecret(utils.AlphaNumericExtendedShort("32")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/adobe.go
+++ b/cmd/generate/config/rules/adobe.go
@@ -17,9 +17,7 @@ func AdobeClientID() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("adobe", secrets.NewSecret(utils.Hex("32"))),
-	}
+	tps := utils.GenerateSampleSecrets("adobe", secrets.NewSecret(utils.Hex("32")))
 	return utils.Validate(r, tps, nil)
 }
 

--- a/cmd/generate/config/rules/age.go
+++ b/cmd/generate/config/rules/age.go
@@ -17,8 +17,6 @@ func AgeSecretKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		`apiKey := "AGE-SECRET-KEY-1QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ`, // gitleaks:allow
-	}
+	tps := utils.GenerateSampleSecrets("age", `AGE-SECRET-KEY-1QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ`) // gitleaks:allow
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/airtable.go
+++ b/cmd/generate/config/rules/airtable.go
@@ -16,8 +16,6 @@ func Airtable() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("airtable", secrets.NewSecret(utils.AlphaNumeric("17"))),
-	}
+	tps := utils.GenerateSampleSecrets("airtable", secrets.NewSecret(utils.AlphaNumeric("17")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/algolia.go
+++ b/cmd/generate/config/rules/algolia.go
@@ -16,8 +16,6 @@ func AlgoliaApiKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		"algolia_key := " + secrets.NewSecret(utils.Hex("32")),
-	}
+	tps := utils.GenerateSampleSecrets("algolia", secrets.NewSecret(utils.Hex("32")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/alibaba.go
+++ b/cmd/generate/config/rules/alibaba.go
@@ -35,8 +35,6 @@ func AlibabaSecretKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("alibaba", secrets.NewSecret(utils.AlphaNumeric("30"))),
-	}
+	tps := utils.GenerateSampleSecrets("alibaba", secrets.NewSecret(utils.AlphaNumeric("30")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/asana.go
+++ b/cmd/generate/config/rules/asana.go
@@ -16,9 +16,7 @@ func AsanaClientID() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("asana", secrets.NewSecret(utils.Numeric("16"))),
-	}
+	tps := utils.GenerateSampleSecrets("asana", secrets.NewSecret(utils.Numeric("16")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -33,8 +31,6 @@ func AsanaClientSecret() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("asana", secrets.NewSecret(utils.AlphaNumeric("32"))),
-	}
+	tps := utils.GenerateSampleSecrets("asana", secrets.NewSecret(utils.AlphaNumeric("32")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/atlassian.go
+++ b/cmd/generate/config/rules/atlassian.go
@@ -17,9 +17,9 @@ func Atlassian() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("atlassian", secrets.NewSecret(utils.AlphaNumeric("24"))),
-		utils.GenerateSampleSecret("confluence", secrets.NewSecret(utils.AlphaNumeric("24"))),
-	}
+	tps := utils.GenerateSampleSecrets("atlassian", secrets.NewSecret(utils.AlphaNumeric("24")))
+	tps = append(tps, utils.GenerateSampleSecrets("confluence", secrets.NewSecret(utils.AlphaNumeric("24")))...)
+	tps = append(tps, utils.GenerateSampleSecrets("jira", secrets.NewSecret(utils.AlphaNumeric("24")))...)
+
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/authress.go
+++ b/cmd/generate/config/rules/authress.go
@@ -26,8 +26,6 @@ func Authress() *config.Rule {
 	account_id := "acc_" + utils.AlphaNumeric("10")
 	signature_key := utils.AlphaNumericExtendedShort("40")
 
-	tps := []string{
-		utils.GenerateSampleSecret("authress", secrets.NewSecret(fmt.Sprintf(`%s\.%s\.%s\.%s`, service_client_id, access_key_id, account_id, signature_key))),
-	}
+	tps := utils.GenerateSampleSecrets("authress", secrets.NewSecret(fmt.Sprintf(`%s\.%s\.%s\.%s`, service_client_id, access_key_id, account_id, signature_key)))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/aws.go
+++ b/cmd/generate/config/rules/aws.go
@@ -11,8 +11,8 @@ import (
 func AWS() *config.Rule {
 	// define rule
 	r := config.Rule{
-		Description: "Identified a pattern that may indicate AWS credentials, risking unauthorized cloud resource access and data breaches on AWS platforms.",
 		RuleID:      "aws-access-token",
+		Description: "Identified a pattern that may indicate AWS credentials, risking unauthorized cloud resource access and data breaches on AWS platforms.",
 		Regex:       regexp.MustCompile(`\b((?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16})\b`),
 		Entropy:     3,
 		Keywords: []string{
@@ -33,18 +33,12 @@ func AWS() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("AWS", "AKIALALEMEL33243OLIB"), // gitleaks:allow
-
-		// as part of a URL
-		`https://aws.example.com/test/abc?AWSAccessKeyId=AKIALALEMEL33243OLIB&Signature=test`, // gitleaks:allow
-
-		// current AWS tokens cannot contain [0,1,8,9], so their entropy is slightly lower than expected.
-		utils.GenerateSampleSecret("AWS", "AKIA"+secrets.NewSecret("[A-Z2-7]{16}")),
-		utils.GenerateSampleSecret("AWS", "ASIA"+secrets.NewSecret("[A-Z2-7]{16}")),
-		utils.GenerateSampleSecret("AWS", "ABIA"+secrets.NewSecret("[A-Z2-7]{16}")),
-		utils.GenerateSampleSecret("AWS", "ACCA"+secrets.NewSecret("[A-Z2-7]{16}")),
-	}
+	tps := utils.GenerateSampleSecrets("AWS", "AKIALALEMEL33243OLIB") // gitleaks:allow
+	// current AWS tokens cannot contain [0,1,8,9], so their entropy is slightly lower than expected.
+	tps = append(tps, utils.GenerateSampleSecrets("AWS", "AKIA"+secrets.NewSecret("[A-Z2-7]{16}"))...)
+	tps = append(tps, utils.GenerateSampleSecrets("AWS", "ASIA"+secrets.NewSecret("[A-Z2-7]{16}"))...)
+	tps = append(tps, utils.GenerateSampleSecrets("AWS", "ABIA"+secrets.NewSecret("[A-Z2-7]{16}"))...)
+	tps = append(tps, utils.GenerateSampleSecrets("AWS", "ACCA"+secrets.NewSecret("[A-Z2-7]{16}"))...)
 	fps := []string{
 		`key = AKIAXXXXXXXXXXXXXXXX`,           // Low entropy
 		`aws_access_key: AKIAIOSFODNN7EXAMPLE`, // Placeholder

--- a/cmd/generate/config/rules/beamer.go
+++ b/cmd/generate/config/rules/beamer.go
@@ -17,8 +17,6 @@ func Beamer() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("beamer", "b_"+secrets.NewSecret(utils.AlphaNumericExtended("44"))),
-	}
+	tps := utils.GenerateSampleSecrets("beamer", "b_"+secrets.NewSecret(utils.AlphaNumericExtended("44")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/bitbucket.go
+++ b/cmd/generate/config/rules/bitbucket.go
@@ -16,9 +16,7 @@ func BitBucketClientID() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("bitbucket", secrets.NewSecret(utils.AlphaNumeric("32"))),
-	}
+	tps := utils.GenerateSampleSecrets("bitbucket", secrets.NewSecret(utils.AlphaNumeric("32")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -33,8 +31,6 @@ func BitBucketClientSecret() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("bitbucket", secrets.NewSecret(utils.AlphaNumeric("64"))),
-	}
+	tps := utils.GenerateSampleSecrets("bitbucket", secrets.NewSecret(utils.AlphaNumeric("64")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/bittrex.go
+++ b/cmd/generate/config/rules/bittrex.go
@@ -16,9 +16,7 @@ func BittrexAccessKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("bittrex", secrets.NewSecret(utils.AlphaNumeric("32"))),
-	}
+	tps := utils.GenerateSampleSecrets("bittrex", secrets.NewSecret(utils.AlphaNumeric("32")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -33,8 +31,6 @@ func BittrexSecretKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("bittrex", secrets.NewSecret(utils.AlphaNumeric("32"))),
-	}
+	tps := utils.GenerateSampleSecrets("bittrex", secrets.NewSecret(utils.AlphaNumeric("32")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/clojars.go
+++ b/cmd/generate/config/rules/clojars.go
@@ -19,8 +19,6 @@ func Clojars() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("clojars", "CLOJARS_"+secrets.NewSecret(utils.AlphaNumeric("60"))),
-	}
+	tps := utils.GenerateSampleSecrets("clojars", "CLOJARS_"+secrets.NewSecret(utils.AlphaNumeric("60")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/cloudflare.go
+++ b/cmd/generate/config/rules/cloudflare.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
 	"github.com/zricethezav/gitleaks/v8/config"
 )
 
@@ -35,7 +36,8 @@ func CloudflareGlobalAPIKey() *config.Rule {
 	}
 
 	// validate
-	tps := global_keys
+	tps := utils.GenerateSampleSecrets("cloudflare", secrets.NewSecret(utils.Hex("37")))
+	tps = append(tps, global_keys...)
 	fps := append(api_keys, origin_ca_keys...)
 
 	return utils.Validate(r, tps, fps)
@@ -52,7 +54,8 @@ func CloudflareAPIKey() *config.Rule {
 	}
 
 	// validate
-	tps := api_keys
+	tps := utils.GenerateSampleSecrets("cloudflare", secrets.NewSecret(utils.AlphaNumericExtendedShort("40")))
+	tps = append(tps, api_keys...)
 	fps := append(global_keys, origin_ca_keys...)
 
 	return utils.Validate(r, tps, fps)
@@ -70,7 +73,8 @@ func CloudflareOriginCAKey() *config.Rule {
 	}
 
 	// validate
-	tps := origin_ca_keys
+	tps := utils.GenerateSampleSecrets("cloudflare", "v1.0-aaa334dc886f30631ba0a610-0d98ef66290d7e50aac7c27b5986c99e6f3f1084c881d8ac0eae5de1d1aa0644076ff57022069b3237d19afe60ad045f207ef2b16387ee37b749441b2ae2e9ebe5b4606e846475d4a5")
+	tps = append(tps, origin_ca_keys...)
 	fps := append(global_keys, api_keys...)
 
 	return utils.Validate(r, tps, fps)

--- a/cmd/generate/config/rules/codecov.go
+++ b/cmd/generate/config/rules/codecov.go
@@ -18,8 +18,6 @@ func CodecovAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("codecov", secrets.NewSecret(utils.AlphaNumeric("32"))),
-	}
+	tps := utils.GenerateSampleSecrets("codecov", secrets.NewSecret(utils.AlphaNumeric("32")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/coinbase.go
+++ b/cmd/generate/config/rules/coinbase.go
@@ -19,9 +19,6 @@ func CoinbaseAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("coinbase",
-			secrets.NewSecret(utils.AlphaNumericExtendedShort("64"))),
-	}
+	tps := utils.GenerateSampleSecrets("coinbase", secrets.NewSecret(utils.AlphaNumericExtendedShort("64")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/confluent.go
+++ b/cmd/generate/config/rules/confluent.go
@@ -18,9 +18,7 @@ func ConfluentSecretKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("confluent", secrets.NewSecret(utils.AlphaNumeric("64"))),
-	}
+	tps := utils.GenerateSampleSecrets("confluent", secrets.NewSecret(utils.AlphaNumeric("64")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -37,8 +35,6 @@ func ConfluentAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("confluent", secrets.NewSecret(utils.AlphaNumeric("16"))),
-	}
+	tps := utils.GenerateSampleSecrets("confluent", secrets.NewSecret(utils.AlphaNumeric("16")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/contentful.go
+++ b/cmd/generate/config/rules/contentful.go
@@ -17,8 +17,6 @@ func Contentful() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("contentful", secrets.NewSecret(utils.AlphaNumeric("43"))),
-	}
+	tps := utils.GenerateSampleSecrets("contentful", secrets.NewSecret(utils.AlphaNumeric("43")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/databricks.go
+++ b/cmd/generate/config/rules/databricks.go
@@ -17,10 +17,8 @@ func Databricks() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("databricks", "dapi"+secrets.NewSecret(utils.Hex("32"))),
-		`token = dapif13ac4b49d1cb31f69f678e39602e381-2`, // gitleaks:ignore
-	}
+	tps := utils.GenerateSampleSecrets("databricks", "dapi"+secrets.NewSecret(utils.Hex("32")))
+	tps = append(tps, `token = dapif13ac4b49d1cb31f69f678e39602e381-2`) // gitleaks:ignore
 	fps := []string{
 		`DATABRICKS_TOKEN=dapi123456789012345678a9bc01234defg5`,
 	}

--- a/cmd/generate/config/rules/datadog.go
+++ b/cmd/generate/config/rules/datadog.go
@@ -19,8 +19,6 @@ func DatadogtokenAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("datadog", secrets.NewSecret(utils.AlphaNumeric("40"))),
-	}
+	tps := utils.GenerateSampleSecrets("datadog", secrets.NewSecret(utils.AlphaNumeric("40")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/definednetworking.go
+++ b/cmd/generate/config/rules/definednetworking.go
@@ -23,8 +23,6 @@ func DefinedNetworkingAPIToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("dnkey", "dnkey-"+secrets.NewSecret(utils.AlphaNumericExtended("26"))+"-"+secrets.NewSecret(utils.AlphaNumericExtended("52"))),
-	}
+	tps := utils.GenerateSampleSecrets("dnkey", "dnkey-"+secrets.NewSecret(utils.AlphaNumericExtended("26"))+"-"+secrets.NewSecret(utils.AlphaNumericExtended("52")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/digitalocean.go
+++ b/cmd/generate/config/rules/digitalocean.go
@@ -15,9 +15,7 @@ func DigitalOceanPAT() *config.Rule {
 		Keywords:    []string{"dop_v1_"},
 	}
 
-	tps := []string{
-		utils.GenerateSampleSecret("do", "dop_v1_"+secrets.NewSecret(utils.Hex("64"))),
-	}
+	tps := utils.GenerateSampleSecrets("do", "dop_v1_"+secrets.NewSecret(utils.Hex("64")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -30,9 +28,7 @@ func DigitalOceanOAuthToken() *config.Rule {
 		Keywords:    []string{"doo_v1_"},
 	}
 
-	tps := []string{
-		utils.GenerateSampleSecret("do", "doo_v1_"+secrets.NewSecret(utils.Hex("64"))),
-	}
+	tps := utils.GenerateSampleSecrets("do", "doo_v1_"+secrets.NewSecret(utils.Hex("64")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -45,8 +41,6 @@ func DigitalOceanRefreshToken() *config.Rule {
 		Keywords: []string{"dor_v1_"},
 	}
 
-	tps := []string{
-		utils.GenerateSampleSecret("do", "dor_v1_"+secrets.NewSecret(utils.Hex("64"))),
-	}
+	tps := utils.GenerateSampleSecrets("do", "dor_v1_"+secrets.NewSecret(utils.Hex("64")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/discord.go
+++ b/cmd/generate/config/rules/discord.go
@@ -16,9 +16,7 @@ func DiscordAPIToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("discord", secrets.NewSecret(utils.Hex("64"))),
-	}
+	tps := utils.GenerateSampleSecrets("discord", secrets.NewSecret(utils.Hex("64")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -33,9 +31,7 @@ func DiscordClientID() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("discord", secrets.NewSecret(utils.Numeric("18"))),
-	}
+	tps := utils.GenerateSampleSecrets("discord", secrets.NewSecret(utils.Numeric("18")))
 	fps := []string{
 		// Low entropy
 		`discord=000000000000000000`,
@@ -54,9 +50,7 @@ func DiscordClientSecret() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("discord", secrets.NewSecret(utils.Numeric("32"))),
-	}
+	tps := utils.GenerateSampleSecrets("discord", secrets.NewSecret(utils.Numeric("32")))
 	fps := []string{
 		// Low entropy
 		`discord=00000000000000000000000000000000`,

--- a/cmd/generate/config/rules/doppler.go
+++ b/cmd/generate/config/rules/doppler.go
@@ -19,9 +19,7 @@ func Doppler() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("doppler", "dp.pt."+secrets.NewSecret(utils.AlphaNumeric("43"))),
-	}
+	tps := utils.GenerateSampleSecrets("doppler", "dp.pt."+secrets.NewSecret(utils.AlphaNumeric("43")))
 	return utils.Validate(r, tps, nil)
 }
 

--- a/cmd/generate/config/rules/droneci.go
+++ b/cmd/generate/config/rules/droneci.go
@@ -19,8 +19,6 @@ func DroneciAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("droneci", secrets.NewSecret(utils.AlphaNumeric("32"))),
-	}
+	tps := utils.GenerateSampleSecrets("droneci", secrets.NewSecret(utils.AlphaNumeric("32")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/dropbox.go
+++ b/cmd/generate/config/rules/dropbox.go
@@ -17,9 +17,7 @@ func DropBoxAPISecret() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("dropbox", secrets.NewSecret(utils.AlphaNumeric("15"))),
-	}
+	tps := utils.GenerateSampleSecrets("dropbox", secrets.NewSecret(utils.AlphaNumeric("15")))
 	return utils.Validate(r, tps, nil)
 }
 

--- a/cmd/generate/config/rules/duffel.go
+++ b/cmd/generate/config/rules/duffel.go
@@ -19,8 +19,6 @@ func Duffel() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("duffel", "duffel_test_"+secrets.NewSecret(utils.AlphaNumericExtended("43"))),
-	}
+	tps := utils.GenerateSampleSecrets("duffel", "duffel_test_"+secrets.NewSecret(utils.AlphaNumericExtended("43")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/dynatrace.go
+++ b/cmd/generate/config/rules/dynatrace.go
@@ -19,8 +19,6 @@ func Dynatrace() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("dynatrace", "dt0c01."+secrets.NewSecret(utils.AlphaNumeric("24"))+"."+secrets.NewSecret(utils.AlphaNumeric("64"))),
-	}
+	tps := utils.GenerateSampleSecrets("dynatrace", "dt0c01."+secrets.NewSecret(utils.AlphaNumeric("24"))+"."+secrets.NewSecret(utils.AlphaNumeric("64")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/easypost.go
+++ b/cmd/generate/config/rules/easypost.go
@@ -19,9 +19,7 @@ func EasyPost() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("EZAK", "EZAK"+secrets.NewSecret(utils.AlphaNumeric("54"))),
-	}
+	tps := utils.GenerateSampleSecrets("EZAK", "EZAK"+secrets.NewSecret(utils.AlphaNumeric("54")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -36,8 +34,6 @@ func EasyPostTestAPI() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("EZTK", "EZTK"+secrets.NewSecret(utils.AlphaNumeric("54"))),
-	}
+	tps := utils.GenerateSampleSecrets("EZTK", "EZTK"+secrets.NewSecret(utils.AlphaNumeric("54")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/etsy.go
+++ b/cmd/generate/config/rules/etsy.go
@@ -21,8 +21,8 @@ func EtsyAccessToken() *config.Rule {
 
 	// validate
 	tps := utils.GenerateSampleSecrets("ETSY", secrets.NewSecret(utils.AlphaNumeric("24")))
-	tps = append(tps, "etsy", secrets.NewSecret(utils.AlphaNumeric("24")))
-	tps = append(tps, "Etsy", secrets.NewSecret(utils.AlphaNumeric("24")))
+	tps = append(tps, utils.GenerateSampleSecrets("etsy", secrets.NewSecret(utils.AlphaNumeric("24")))...)
+	tps = append(tps, utils.GenerateSampleSecrets("Etsy", secrets.NewSecret(utils.AlphaNumeric("24")))...)
 	fps := []string{
 		fmt.Sprintf(`SetSysctl = "%s"`, secrets.NewSecret(utils.AlphaNumeric("24"))),
 		`	if err := sysctl.SetSysctl(sysctlBridgeCallIPTables); err != nil {`,

--- a/cmd/generate/config/rules/etsy.go
+++ b/cmd/generate/config/rules/etsy.go
@@ -20,11 +20,9 @@ func EtsyAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("ETSY", secrets.NewSecret(utils.AlphaNumeric("24"))),
-		utils.GenerateSampleSecret("etsy", secrets.NewSecret(utils.AlphaNumeric("24"))),
-		utils.GenerateSampleSecret("Etsy", secrets.NewSecret(utils.AlphaNumeric("24"))),
-	}
+	tps := utils.GenerateSampleSecrets("ETSY", secrets.NewSecret(utils.AlphaNumeric("24")))
+	tps = append(tps, "etsy", secrets.NewSecret(utils.AlphaNumeric("24")))
+	tps = append(tps, "Etsy", secrets.NewSecret(utils.AlphaNumeric("24")))
 	fps := []string{
 		fmt.Sprintf(`SetSysctl = "%s"`, secrets.NewSecret(utils.AlphaNumeric("24"))),
 		`	if err := sysctl.SetSysctl(sysctlBridgeCallIPTables); err != nil {`,

--- a/cmd/generate/config/rules/facebook.go
+++ b/cmd/generate/config/rules/facebook.go
@@ -19,11 +19,11 @@ func FacebookSecret() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("facebook", secrets.NewSecret(utils.Hex("32"))),
+	tps := utils.GenerateSampleSecrets("facebook", secrets.NewSecret(utils.Hex("32")))
+	tps = append(tps,
 		`facebook_app_secret = "6dca6432e45d933e13650d1882bd5e69"`,       // gitleaks:allow
 		`facebook_client_access_token: 26f5fd13099f2c1331aafb86f6489692`, // gitleaks:allow
-	}
+	)
 	return utils.Validate(r, tps, nil)
 }
 

--- a/cmd/generate/config/rules/fastly.go
+++ b/cmd/generate/config/rules/fastly.go
@@ -17,8 +17,6 @@ func FastlyAPIToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("fastly", secrets.NewSecret(utils.AlphaNumericExtended("32"))),
-	}
+	tps := utils.GenerateSampleSecrets("fastly", secrets.NewSecret(utils.AlphaNumericExtended("32")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/finicity.go
+++ b/cmd/generate/config/rules/finicity.go
@@ -17,9 +17,7 @@ func FinicityClientSecret() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("finicity", secrets.NewSecret(utils.AlphaNumeric("20"))),
-	}
+	tps := utils.GenerateSampleSecrets("finicity", secrets.NewSecret(utils.AlphaNumeric("20")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -34,8 +32,6 @@ func FinicityAPIToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("finicity", secrets.NewSecret(utils.Hex("32"))),
-	}
+	tps := utils.GenerateSampleSecrets("finicity", secrets.NewSecret(utils.Hex("32")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/finnhub.go
+++ b/cmd/generate/config/rules/finnhub.go
@@ -19,8 +19,6 @@ func FinnhubAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("finnhub", secrets.NewSecret(utils.AlphaNumeric("20"))),
-	}
+	tps := utils.GenerateSampleSecrets("finnhub", secrets.NewSecret(utils.AlphaNumeric("20")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/flickr.go
+++ b/cmd/generate/config/rules/flickr.go
@@ -19,8 +19,6 @@ func FlickrAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("flickr", secrets.NewSecret(utils.AlphaNumeric("32"))),
-	}
+	tps := utils.GenerateSampleSecrets("flickr", secrets.NewSecret(utils.AlphaNumeric("32")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/flutterwave.go
+++ b/cmd/generate/config/rules/flutterwave.go
@@ -19,9 +19,7 @@ func FlutterwavePublicKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("flutterwavePubKey", "FLWPUBK_TEST-"+secrets.NewSecret(utils.Hex("32"))+"-X"),
-	}
+	tps := utils.GenerateSampleSecrets("flutterwavePubKey", "FLWPUBK_TEST-"+secrets.NewSecret(utils.Hex("32"))+"-X")
 	return utils.Validate(r, tps, nil)
 }
 
@@ -36,9 +34,7 @@ func FlutterwaveSecretKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("flutterwavePubKey", "FLWSECK_TEST-"+secrets.NewSecret(utils.Hex("32"))+"-X"),
-	}
+	tps := utils.GenerateSampleSecrets("flutterwavePubKey", "FLWSECK_TEST-"+secrets.NewSecret(utils.Hex("32"))+"-X")
 	return utils.Validate(r, tps, nil)
 }
 
@@ -53,8 +49,6 @@ func FlutterwaveEncKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("flutterwavePubKey", "FLWSECK_TEST-"+secrets.NewSecret(utils.Hex("12"))),
-	}
+	tps := utils.GenerateSampleSecrets("flutterwavePubKey", "FLWSECK_TEST-"+secrets.NewSecret(utils.Hex("12")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/flyio.go
+++ b/cmd/generate/config/rules/flyio.go
@@ -20,23 +20,26 @@ func FlyIOAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		// fo1_
-		utils.GenerateSampleSecret("fly", secrets.NewSecret(`fo1_[\w-]{43}`)),
+	// fo1_
+	tps := utils.GenerateSampleSecrets("fly", secrets.NewSecret(`fo1_[\w-]{43}`))
+	tps = append(tps,
 		`Fly access token: fo1_8rz-j7r2eqJ2U7affEOO3HJN0j63DInyog3eV-glQSc
 `,
 		`=============================================================================================================
 
 fo1_BtKlzvfztw0M2hlLgTdsfPgDFiwM2jJjQXXy6I2pjuQ
-fly deploy`,
-		// fm1
-		utils.GenerateSampleSecret("fly", secrets.NewSecret(`fm1[ar]_[a-zA-Z0-9+\/]{100,}={0,3}`)),
+fly deploy`)
+	// fm1
+	tps = append(tps, utils.GenerateSampleSecrets("fly", secrets.NewSecret(`fm1[ar]_[a-zA-Z0-9+\/]{100,}={0,3}`))...)
+	tps = append(tps,
 		`ENV FLY_API_TOKEN="FlyV1 fm1r_lJPECAAAAAAAAMqcxBBLMJKXYKJiT0CI58XmukX/wrVodHlwczovL2FwaS5mbHkuaW8vdjGWAJLOAAFmXh8Lk7lodHRwczovL2FwaS5mbHkuaW8vYWFhL3YxxDy5OfA2M6K6aLEoEDKxehojbj+8ZT9IrXCF5sL/r8m6/1gylwySsNxpD40wnpd/G2ZdjwVaQev1kEuFUgzERxPbtWHDNa+NYIZwbKN6b7/JxdbUprq0M10HI4fwtlxhqhdA/mMaMw70EC4TsfJyghIL98KP4ry5AaXiroRdjrSsFExc/xRCDZKUA5GBzgATuNsfBZGCp2J1aWxkZXIfondnHwHEIMa6NWc4b52S+UY7vjPdwKrz00Uzrc1830mOHzQNLun7,fm1a_lJPERxPbtWHDNa+NYIZwbKN6b7/JxdbUprq0M10HI4fwtlxhqhdA/mMaMw70EC4TsfJyghIL98KP4ry4AaXiroRdjrSsFExc/xRCxBCVlAoRzKV/+qYkxuipIbIcw7lodHRwczovL2FwaS5mbHkuaW8vYWFhL3YxlgSSzmS4Y7nPAAAAASCwgdcKkc4AAUktDMQQURck2h+upbiOrW66Nf5SA8QgrD03xlWju1WQi0AUhlk7YYFzOLDfhRyJ6nEziO37NUE="`,
-		// fm2
-		utils.GenerateSampleSecret("fly", secrets.NewSecret(`fm2_[a-zA-Z0-9+\/]{100,}={0,3}`)),
+	)
+	// fm2
+	tps = append(tps, utils.GenerateSampleSecrets("fly", secrets.NewSecret(`fm2_[a-zA-Z0-9+\/]{100,}={0,3}`))...)
+	tps = append(tps,
 		`#           FLY_API_TOKEN: FlyV1 fm2_lJPECAAAAAAAAyZtxBD1hSZ7L5leXsj64ZbDlkm/wrVodHRwczovL2FwaS5mbHkuaW8vdjGWAJLOAAwMDB8Lk7lodHRwczovL2FwaS5mbHkuaW8vYWFhL3YxxDwDnhgJj/ML/nRKMiAYgnvXfNacrGWffj5TdfgGY2LU0ZetT7WzTLQQMO8cN2nRTztl/xLjnnZg5pBwFonETmhNA6Yl0X1tatt8ezA0UjVQiJr93VQ7qAmD5GG2Ce5txhbQv3tmIGsvaC7BOkIqAiR273bhZkO44AYsrCPr2XF8W6Twk7NyU+3UUeDwjw2SlAORgc4APu7vHwWRgqdidWlsZGVyH6J3Zx8BxCAlmLbu1HQDg8ZAGKKmEt4Mbnbqli6lbzBDHsawhcUF4A==,fm2_lJPETmhNA6Yl0X1tatt8ezA0UjVQiJr93VQ7qAmD5GG2Ce5txhbQv3tmIGsvaC7BOkIqAij273bhZkO44AYsrCPr2XF8W6Twk7NyU+3UUeDwj8QQbn07DOV+7SmoLj/uT+dbr8O5aHR0cHM6Ly9hcGkuZmx5LmlvL2FhYS92MZgEks5mqfbvzwAAAAE9PYz9F84AC7QACpHOAAu0AAzEEFfW3B+SzffV/KrAYa8qqpnEIIlD6DqZMZQ9Kt7fEenCCOLA+tUSJ+kmEFIUcc83npOI`,
 		`"BindToParentToken": "FlyV1 fm2_lJPEEKnzKy0lkwV3B+WIlmrdwejEEFv5qmevHU4fMs+2Gr6oOiPC2SAyOTc0NWI4ZmJlNjBlNjJmZTgzNTkxOThhZWE4MjY0M5IMxAMBAgPEIH7VG8u74KwO62hmx8SZO8WaU5o1g3W2IVc7QN6T1VTr",`,
-	}
+	)
 	fps := []string{
 		// fo1_
 		`resource "doppler_integration_flyio" "prod" {

--- a/cmd/generate/config/rules/frameio.go
+++ b/cmd/generate/config/rules/frameio.go
@@ -18,8 +18,6 @@ func FrameIO() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("frameio", "fio-u-"+secrets.NewSecret(utils.AlphaNumericExtended("64"))),
-	}
+	tps := utils.GenerateSampleSecrets("frameio", "fio-u-"+secrets.NewSecret(utils.AlphaNumericExtended("64")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/freshbooks.go
+++ b/cmd/generate/config/rules/freshbooks.go
@@ -19,8 +19,6 @@ func FreshbooksAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("freshbooks", secrets.NewSecret(utils.AlphaNumeric("64"))),
-	}
+	tps := utils.GenerateSampleSecrets("freshbooks", secrets.NewSecret(utils.AlphaNumeric("64")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/gcp.go
+++ b/cmd/generate/config/rules/gcp.go
@@ -38,11 +38,11 @@ func GCPAPIKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("gcp", secrets.NewSecret(`AIza[\w-]{35}`)),
+	tps := utils.GenerateSampleSecrets("gcp", secrets.NewSecret(`AIza[\w-]{35}`))
+	tps = append(tps,
 		// non-word character at end
 		`AIzaSyNHxIf32IQ1a1yjl3ZJIqKZqzLAK1XhDk-`, // gitleaks:allow
-	}
+	)
 	fps := []string{
 		`GWw4hjABFzZCGiRpmlDyDdo87Jn9BN9THUA47muVRNunLxsa82tMAdvmrhOqNkRKiYMEAFbTJAIzaTesb6Tscfcni8vIpWZqNCXFDFslJtVSvFDq`, // text boundary start
 		`AIzaTesb6Tscfcni8vIpWZqNCXFDFslJtVSvFDqabcd123`,                                                                   // text boundary end

--- a/cmd/generate/config/rules/generic.go
+++ b/cmd/generate/config/rules/generic.go
@@ -81,34 +81,36 @@ func GenericCredential() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
+	tps := utils.GenerateSampleSecrets("generic", "CLOJARS_34bf0e88955ff5a1c328d6a7491acc4f48e865a7b8dd4d70a70749037443") //gitleaks:allow
+	tps = append(tps, utils.GenerateSampleSecrets("generic", "Zf3D0LXCM3EIMbgJpUNnkRtOfOueHznB")...)
+	tps = append(tps,
 		// Access
 		`'access_token': 'eyJ0eXAioiJKV1slS3oASx=='`,
 
 		// API
-		`some_api_token_123 = "` + newPlausibleSecret(`[a-zA-Z0-9]{60}`) + `"`,
+		`some_api_token_123 = "`+newPlausibleSecret(`[a-zA-Z0-9]{60}`)+`"`,
 
 		// Auth
 		// Credentials
 		`"credentials" : "0afae57f3ccfd9d7f5767067bc48b30f719e271ba470488056e37ab35d4b6506"`,
-		`creds = ` + newPlausibleSecret(`[a-zA-Z0-9]{30}`),
+		`creds = `+newPlausibleSecret(`[a-zA-Z0-9]{30}`),
 
 		// Key
-		`private-key: ` + newPlausibleSecret(`[a-zA-Z0-9\-_.=]{100}`),
+		`private-key: `+newPlausibleSecret(`[a-zA-Z0-9\-_.=]{100}`),
 
 		// Password
-		`passwd = ` + newPlausibleSecret(`[a-zA-Z0-9\-_.=]{30}`),
+		`passwd = `+newPlausibleSecret(`[a-zA-Z0-9\-_.=]{30}`),
 		// TODO: `ID=dbuser;password=` + newPlausibleSecret(`[a-zA-Z0-9+/]{30}={0,3}`) + `;"`,
 
 		// Secret
 		`"client_secret" : "6da89121079f83b2eb6acccf8219ea982c3d79bccc3e9c6a85856480661f8fde",`,
-		`mySecretString=` + newPlausibleSecret(`[a-zA-Z0-9]{30}`),
-		`todo_secret_do_not_commit = ` + newPlausibleSecret(`[a-zA-Z0-9]{30}`),
+		`mySecretString=`+newPlausibleSecret(`[a-zA-Z0-9]{30}`),
+		`todo_secret_do_not_commit = `+newPlausibleSecret(`[a-zA-Z0-9]{30}`),
 
 		// Token
 		utils.GenerateSampleSecret("generic", "CLOJARS_34bf0e88955ff5a1c328d6a7491acc4f48e865a7b8dd4d70a70749037443"), //gitleaks:allow
 		utils.GenerateSampleSecret("generic", "Zf3D0LXCM3EIMbgJpUNnkRtOfOueHznB"),
-	}
+	)
 	fps := []string{
 		// Access
 		`"accessor":"rA1wk0Y45YCufyfq",`,

--- a/cmd/generate/config/rules/github.go
+++ b/cmd/generate/config/rules/github.go
@@ -29,9 +29,7 @@ func GitHubPat() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("github", "ghp_"+secrets.NewSecret(utils.AlphaNumeric("36"))),
-	}
+	tps := utils.GenerateSampleSecrets("github", "ghp_"+secrets.NewSecret(utils.AlphaNumeric("36")))
 	fps := []string{
 		"ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 	}
@@ -49,9 +47,7 @@ func GitHubFineGrainedPat() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("github", "github_pat_"+secrets.NewSecret(utils.AlphaNumeric("82"))),
-	}
+	tps := utils.GenerateSampleSecrets("github", "github_pat_"+secrets.NewSecret(utils.AlphaNumeric("82")))
 	fps := []string{
 		"github_pat_xxxxxxxxxxxxxxxxxxxxxx_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 	}
@@ -69,9 +65,7 @@ func GitHubOauth() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("github", "gho_"+secrets.NewSecret(utils.AlphaNumeric("36"))),
-	}
+	tps := utils.GenerateSampleSecrets("github", "gho_"+secrets.NewSecret(utils.AlphaNumeric("36")))
 	fps := []string{
 		"gho_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 	}
@@ -90,10 +84,8 @@ func GitHubApp() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("github", "ghu_"+secrets.NewSecret(utils.AlphaNumeric("36"))),
-		utils.GenerateSampleSecret("github", "ghs_"+secrets.NewSecret(utils.AlphaNumeric("36"))),
-	}
+	tps := utils.GenerateSampleSecrets("github", "ghs_"+secrets.NewSecret(utils.AlphaNumeric("36")))
+	tps = append(tps, utils.GenerateSampleSecrets("github", "ghu_"+secrets.NewSecret(utils.AlphaNumeric("36")))...)
 	fps := []string{
 		"ghu_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 		"ghs_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
@@ -112,9 +104,7 @@ func GitHubRefresh() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("github", "ghr_"+secrets.NewSecret(utils.AlphaNumeric("36"))),
-	}
+	tps := utils.GenerateSampleSecrets("github", "ghr_"+secrets.NewSecret(utils.AlphaNumeric("36")))
 	fps := []string{
 		"ghr_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 	}

--- a/cmd/generate/config/rules/gitlab.go
+++ b/cmd/generate/config/rules/gitlab.go
@@ -14,15 +14,13 @@ import (
 
 func GitlabCiCdJobToken() *config.Rule {
 	r := config.Rule{
-		Description: "Identified a GitLab CI/CD Job Token, potential access to projects and some APIs on behalf of a user while the CI job is running.",
 		RuleID:      "gitlab-cicd-job-token",
+		Description: "Identified a GitLab CI/CD Job Token, potential access to projects and some APIs on behalf of a user while the CI job is running.",
 		Regex:       regexp.MustCompile(`glcbt-[0-9a-zA-Z]{1,5}_[0-9a-zA-Z_-]{20}`),
 		Entropy:     3,
 		Keywords:    []string{"glcbt-"},
 	}
-	tps := []string{
-		utils.GenerateSampleSecret("gitlab", "glcbt-"+secrets.NewSecret(utils.AlphaNumeric("5"))+"_"+secrets.NewSecret(utils.AlphaNumeric("20"))),
-	}
+	tps := utils.GenerateSampleSecrets("gitlab", "glcbt-"+secrets.NewSecret(utils.AlphaNumeric("5"))+"_"+secrets.NewSecret(utils.AlphaNumeric("20")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -42,71 +40,61 @@ func GitlabDeployToken() *config.Rule {
 
 func GitlabFeatureFlagClientToken() *config.Rule {
 	r := config.Rule{
-		Description: "Identified a GitLab feature flag client token, risks exposing user lists and features flags used by an application.",
 		RuleID:      "gitlab-feature-flag-client-token",
+		Description: "Identified a GitLab feature flag client token, risks exposing user lists and features flags used by an application.",
 		Regex:       regexp.MustCompile(`glffct-[0-9a-zA-Z_\-]{20}`),
 		Entropy:     3,
 		Keywords:    []string{"glffct-"},
 	}
-	tps := []string{
-		utils.GenerateSampleSecret("gitlab", "glffct-"+secrets.NewSecret(utils.AlphaNumeric("20"))),
-	}
+	tps := utils.GenerateSampleSecrets("gitlab", "glffct-"+secrets.NewSecret(utils.AlphaNumeric("20")))
 	return utils.Validate(r, tps, nil)
 }
 
 func GitlabFeedToken() *config.Rule {
 	r := config.Rule{
-		Description: "Identified a GitLab feed token, risking exposure of user data.",
 		RuleID:      "gitlab-feed-token",
+		Description: "Identified a GitLab feed token, risking exposure of user data.",
 		Regex:       regexp.MustCompile(`glft-[0-9a-zA-Z_\-]{20}`),
 		Entropy:     3,
 		Keywords:    []string{"glft-"},
 	}
-	tps := []string{
-		utils.GenerateSampleSecret("gitlab", "glft-"+secrets.NewSecret(utils.AlphaNumeric("20"))),
-	}
+	tps := utils.GenerateSampleSecrets("gitlab", "glft-"+secrets.NewSecret(utils.AlphaNumeric("20")))
 	return utils.Validate(r, tps, nil)
 }
 
 func GitlabIncomingMailToken() *config.Rule {
 	r := config.Rule{
-		Description: "Identified a GitLab incoming mail token, risking manipulation of data sent by mail.",
 		RuleID:      "gitlab-incoming-mail-token",
+		Description: "Identified a GitLab incoming mail token, risking manipulation of data sent by mail.",
 		Regex:       regexp.MustCompile(`glimt-[0-9a-zA-Z_\-]{25}`),
 		Entropy:     3,
 		Keywords:    []string{"glimt-"},
 	}
-	tps := []string{
-		utils.GenerateSampleSecret("gitlab", "glimt-"+secrets.NewSecret(utils.AlphaNumeric("25"))),
-	}
+	tps := utils.GenerateSampleSecrets("gitlab", "glimt-"+secrets.NewSecret(utils.AlphaNumeric("25")))
 	return utils.Validate(r, tps, nil)
 }
 
 func GitlabKubernetesAgentToken() *config.Rule {
 	r := config.Rule{
-		Description: "Identified a GitLab Kubernetes Agent token, risking access to repos and registry of projects connected via agent.",
 		RuleID:      "gitlab-kubernetes-agent-token",
+		Description: "Identified a GitLab Kubernetes Agent token, risking access to repos and registry of projects connected via agent.",
 		Regex:       regexp.MustCompile(`glagent-[0-9a-zA-Z_\-]{50}`),
 		Entropy:     3,
 		Keywords:    []string{"glagent-"},
 	}
-	tps := []string{
-		utils.GenerateSampleSecret("gitlab", "glagent-"+secrets.NewSecret(utils.AlphaNumeric("50"))),
-	}
+	tps := utils.GenerateSampleSecrets("gitlab", "glagent-"+secrets.NewSecret(utils.AlphaNumeric("50")))
 	return utils.Validate(r, tps, nil)
 }
 
 func GitlabOauthAppSecret() *config.Rule {
 	r := config.Rule{
-		Description: "Identified a GitLab OIDC Application Secret, risking access to apps using GitLab as authentication provider.",
 		RuleID:      "gitlab-oauth-app-secret",
+		Description: "Identified a GitLab OIDC Application Secret, risking access to apps using GitLab as authentication provider.",
 		Regex:       regexp.MustCompile(`gloas-[0-9a-zA-Z_\-]{64}`),
 		Entropy:     3,
 		Keywords:    []string{"gloas-"},
 	}
-	tps := []string{
-		utils.GenerateSampleSecret("gitlab", "gloas-"+secrets.NewSecret(utils.AlphaNumeric("64"))),
-	}
+	tps := utils.GenerateSampleSecrets("gitlab", "gloas-"+secrets.NewSecret(utils.AlphaNumeric("64")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -119,9 +107,8 @@ func GitlabPat() *config.Rule {
 		Keywords:    []string{"glpat-"},
 	}
 
-	tps := []string{
-		utils.GenerateSampleSecret("gitlab", "glpat-"+secrets.NewSecret(utils.AlphaNumeric("20"))),
-	}
+	// validate
+	tps := utils.GenerateSampleSecrets("gitlab", "glpat-"+secrets.NewSecret(utils.AlphaNumeric("20")))
 	fps := []string{
 		"glpat-XXXXXXXXXXX-XXXXXXXX",
 	}
@@ -137,9 +124,8 @@ func GitlabPipelineTriggerToken() *config.Rule {
 		Keywords:    []string{"glptt-"},
 	}
 
-	tps := []string{
-		utils.GenerateSampleSecret("gitlab", "glptt-"+secrets.NewSecret(utils.Hex("40"))),
-	}
+	// validate
+	tps := utils.GenerateSampleSecrets("gitlab", "glptt-"+secrets.NewSecret(utils.Hex("40")))
 	fps := []string{
 		"glptt-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 	}
@@ -155,9 +141,7 @@ func GitlabRunnerRegistrationToken() *config.Rule {
 		Keywords:    []string{"GR1348941"},
 	}
 
-	tps := []string{
-		utils.GenerateSampleSecret("gitlab", "GR1348941"+secrets.NewSecret(utils.AlphaNumeric("20"))),
-	}
+	tps := utils.GenerateSampleSecrets("gitlab", "GR1348941"+secrets.NewSecret(utils.AlphaNumeric("20")))
 	fps := []string{
 		"GR134894112312312312312312312",
 		"GR1348941XXXXXXXXXXXXXXXXXXXX",
@@ -167,45 +151,40 @@ func GitlabRunnerRegistrationToken() *config.Rule {
 
 func GitlabRunnerAuthenticationToken() *config.Rule {
 	r := config.Rule{
-		Description: "Discovered a GitLab Runner Authentication Token, posing a risk to CI/CD pipeline integrity and unauthorized access.",
 		RuleID:      "gitlab-runner-authentication-token",
+		Description: "Discovered a GitLab Runner Authentication Token, posing a risk to CI/CD pipeline integrity and unauthorized access.",
 		Regex:       regexp.MustCompile(`glrt-[0-9a-zA-Z_\-]{20}`),
 		Entropy:     3,
 		Keywords:    []string{"glrt-"},
 	}
 
-	tps := []string{
-		utils.GenerateSampleSecret("gitlab", "glrt-"+secrets.NewSecret(utils.AlphaNumeric("20"))),
-	}
+	tps := utils.GenerateSampleSecrets("gitlab", "glrt-"+secrets.NewSecret(utils.AlphaNumeric("20")))
 	return utils.Validate(r, tps, nil)
 }
 
 func GitlabScimToken() *config.Rule {
 	r := config.Rule{
-		Description: "Discovered a GitLab SCIM Token, posing a risk to unauthorized access for a organization or instance.",
 		RuleID:      "gitlab-scim-token",
+		Description: "Discovered a GitLab SCIM Token, posing a risk to unauthorized access for a organization or instance.",
 		Regex:       regexp.MustCompile(`glsoat-[0-9a-zA-Z_\-]{20}`),
 		Entropy:     3,
 		Keywords:    []string{"glsoat-"},
 	}
 
-	tps := []string{
-		utils.GenerateSampleSecret("gitlab", "glsoat-"+secrets.NewSecret(utils.AlphaNumeric("20"))),
-	}
+	tps := utils.GenerateSampleSecrets("gitlab", "glsoat-"+secrets.NewSecret(utils.AlphaNumeric("20")))
 	return utils.Validate(r, tps, nil)
 }
 
 func GitlabSessionCookie() *config.Rule {
 	r := config.Rule{
-		Description: "Discovered a GitLab Session Cookie, posing a risk to unauthorized access to a user account.",
 		RuleID:      "gitlab-session-cookie",
+		Description: "Discovered a GitLab Session Cookie, posing a risk to unauthorized access to a user account.",
 		Regex:       regexp.MustCompile(`_gitlab_session=[0-9a-z]{32}`),
 		Entropy:     3,
 		Keywords:    []string{"_gitlab_session="},
 	}
 
-	tps := []string{
-		utils.GenerateSampleSecret("gitlab", "_gitlab_session="+secrets.NewSecret(utils.AlphaNumeric("32"))),
-	}
+	// validate
+	tps := utils.GenerateSampleSecrets("gitlab", "_gitlab_session="+secrets.NewSecret(utils.AlphaNumeric("32")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/gitter.go
+++ b/cmd/generate/config/rules/gitter.go
@@ -20,9 +20,6 @@ func GitterAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("gitter",
-			secrets.NewSecret(utils.AlphaNumericExtendedShort("40"))),
-	}
+	tps := utils.GenerateSampleSecrets("gitter", secrets.NewSecret(utils.AlphaNumericExtendedShort("40")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/gocardless.go
+++ b/cmd/generate/config/rules/gocardless.go
@@ -20,8 +20,6 @@ func GoCardless() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("gocardless", "live_"+secrets.NewSecret(utils.AlphaNumericExtended("40"))),
-	}
+	tps := utils.GenerateSampleSecrets("gocardless", "live_"+secrets.NewSecret(utils.AlphaNumericExtended("40")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/grafana.go
+++ b/cmd/generate/config/rules/grafana.go
@@ -17,9 +17,7 @@ func GrafanaApiKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("grafana-api-key", "eyJrIjoi"+secrets.NewSecret(utils.AlphaNumeric("70"))),
-	}
+	tps := utils.GenerateSampleSecrets("grafana-api-key", "eyJrIjoi"+secrets.NewSecret(utils.AlphaNumeric("70")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -34,7 +32,8 @@ func GrafanaCloudApiToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
+	tps := utils.GenerateSampleSecrets("grafana-cloud-api-token", "glc_"+secrets.NewSecret(utils.AlphaNumeric("32")))
+	tps = append(tps,
 		utils.GenerateSampleSecret("grafana-cloud-api-token",
 			"glc_"+
 				secrets.NewSecret(utils.AlphaNumeric("32"))),
@@ -42,7 +41,7 @@ func GrafanaCloudApiToken() *config.Rule {
 		// TODO:
 		//`  loki:
 		//endpoint: https://322137:glc_eyJvIjoiNzQ0NTg3IiwibiI7InN0YWlrLTQ3NTgzMC1obC13cml0ZS1oYW5kc29uJG9raSIsImsiOiI4M2w3cmdYUlBoMTUyMW1lMU023nl5UDUiLCJtIjp7IOIiOiJ1cyJ9fQ==@logs-prod4.grafana.net/loki/api/v1/push`,
-	}
+	)
 	fps := []string{
 		// Low entropy.
 		`glc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`,
@@ -70,14 +69,10 @@ func GrafanaServiceAccountToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("grafana-service-account-token",
-			"glsa_"+
-				secrets.NewSecret(utils.AlphaNumeric("32"))+
-				"_"+
-				secrets.NewSecret((utils.Hex("8")))),
+	tps := utils.GenerateSampleSecrets("grafana-service-account-token", "glsa_"+secrets.NewSecret(utils.AlphaNumeric("32"))+"_"+secrets.NewSecret(utils.Hex("8")))
+	tps = append(tps,
 		`'Authorization': 'Bearer glsa_pITqMOBIfNH2KL4PkXJqmTyQl0D9QGxF_486f63e1'`,
-	}
+	)
 	fps := []string{
 		"glsa_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_AAAAAAAA",
 	}

--- a/cmd/generate/config/rules/harness.go
+++ b/cmd/generate/config/rules/harness.go
@@ -19,10 +19,8 @@ func HarnessApiKey() *config.Rule {
 	}
 
 	// Generate a sample secret for validation
-	tps := []string{
-		utils.GenerateSampleSecret("harness", "pat."+secrets.NewSecret(utils.AlphaNumeric("22"))+"."+secrets.NewSecret(utils.AlphaNumeric("24"))+"."+secrets.NewSecret(utils.AlphaNumeric("20"))),
-		utils.GenerateSampleSecret("harness", "sat."+secrets.NewSecret(utils.AlphaNumeric("22"))+"."+secrets.NewSecret(utils.AlphaNumeric("24"))+"."+secrets.NewSecret(utils.AlphaNumeric("20"))),
-	}
+	tps := utils.GenerateSampleSecrets("harness", "pat."+secrets.NewSecret(utils.AlphaNumeric("22"))+"."+secrets.NewSecret(utils.AlphaNumeric("24"))+"."+secrets.NewSecret(utils.AlphaNumeric("20")))
+	tps = append(tps, utils.GenerateSampleSecrets("harness", "sat."+secrets.NewSecret(utils.AlphaNumeric("22"))+"."+secrets.NewSecret(utils.AlphaNumeric("24"))+"."+secrets.NewSecret(utils.AlphaNumeric("20")))...)
 
 	// validate the rule
 	return utils.Validate(r, tps, nil)

--- a/cmd/generate/config/rules/hashicorp.go
+++ b/cmd/generate/config/rules/hashicorp.go
@@ -20,10 +20,10 @@ func HashiCorpTerraform() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("hashicorpToken", secrets.NewSecret(utils.Hex("14"))+".atlasv1."+secrets.NewSecret(utils.AlphaNumericExtended("60,70"))),
+	tps := utils.GenerateSampleSecrets("hashicorpToken", secrets.NewSecret(utils.Hex("14"))+".atlasv1."+secrets.NewSecret(utils.AlphaNumericExtended("60,70")))
+	tps = append(tps,
 		`#token = "hE1hlYILrSqpqh.atlasv1.ARjZuyzl33F71WR55s6ln5GQ1HWIwTDDH3MiRjz7OnpCfaCb1RCF5zGaSncCWmJdcYA"`,
-	}
+	)
 	fps := []string{
 		`token        = "xxxxxxxxxxxxxx.atlasv1.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"`, // low entropy
 	}

--- a/cmd/generate/config/rules/hashicorp_vault.go
+++ b/cmd/generate/config/rules/hashicorp_vault.go
@@ -26,14 +26,17 @@ func VaultServiceToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		// Old
-		utils.GenerateSampleSecret("vault", secrets.NewSecret(`s\.[a-zA-Z0-9]{24}`)),
+	// Old
+	tps := utils.GenerateSampleSecrets("vault", "s."+secrets.NewSecret(`s\.[a-zA-Z0-9]{24}`))
+	tps = append(tps,
 		`token: s.ZC9Ecf4M5g9o34Q6RkzGsj0z`,
-		// New
-		utils.GenerateSampleSecret("vault", secrets.NewSecret(`hvs\.[\w\-]{90}`)),
+	)
+	// New
+	tps = append(tps, utils.GenerateSampleSecrets("vault", secrets.NewSecret(`hvs\.[\w\-]{90}`))...)
+	tps = append(tps,
 		`-vaultToken hvs.CAESIP2jTxc9S2K7Z6CtcFWQv7-044m_oSsxnPE1H3nF89l3GiYKHGh2cy5sQmlIZVNyTWJNcDRsYWJpQjlhYjVlb1cQh6PL8wEYAg"`, // longer than 100 chars
-	}
+	)
+
 	fps := []string{
 		// Old
 		`  credentials: new AWS.SharedIniFileCredentials({ profile: '<YOUR_PROFILE>' })`,                              // word boundary start
@@ -60,9 +63,7 @@ func VaultBatchToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("vault", "hvb."+secrets.NewSecret(utils.AlphaNumericExtendedShort("138"))),
-		`hvb.AAAAAQJgxDgqsGNorpoOR7hPZ5SU-ynBvCl764jyRP_fnX7WvkdkDzGjbLNGdPdtlY33Als2P36yDZueqzfdGw9RsaTeaYXSH7E4RYSWuRoQ9YRKIw8o7mDDY2ZcT3KOB7RwtW1w1FN2eDqcy_sbCjXPaM1iBVH-mqMSYRmRd2nb5D1SJPeBzIYRqSglLc31wUGN7xEzyrKUczqOKsIcybQA`, // gitleaks:allow
-	}
+	tps := utils.GenerateSampleSecrets("vault", "hvb."+secrets.NewSecret(utils.AlphaNumericExtendedShort("138")))
+	tps = append(tps, `hvb.AAAAAQJgxDgqsGNorpoOR7hPZ5SU-ynBvCl764jyRP_fnX7WvkdkDzGjbLNGdPdtlY33Als2P36yDZueqzfdGw9RsaTeaYXSH7E4RYSWuRoQ9YRKIw8o7mDDY2ZcT3KOB7RwtW1w1FN2eDqcy_sbCjXPaM1iBVH-mqMSYRmRd2nb5D1SJPeBzIYRqSglLc31wUGN7xEzyrKUczqOKsIcybQA`) // gitleaks:allow
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/heroku.go
+++ b/cmd/generate/config/rules/heroku.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
 	"github.com/zricethezav/gitleaks/v8/config"
 )
 
@@ -16,9 +17,10 @@ func Heroku() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
+	tps := utils.GenerateSampleSecrets("heroku", secrets.NewSecret(utils.Hex8_4_4_4_12()))
+	tps = append(tps,
 		`const HEROKU_KEY = "12345678-ABCD-ABCD-ABCD-1234567890AB"`, // gitleaks:allow
 		`heroku_api_key = "832d2129-a846-4e27-99f4-7004b6ad53ef"`,   // gitleaks:allow
-	}
+	)
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/hubspot.go
+++ b/cmd/generate/config/rules/hubspot.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
 	"github.com/zricethezav/gitleaks/v8/config"
 )
 
@@ -17,8 +18,9 @@ func HubSpot() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
+	tps := utils.GenerateSampleSecrets("hubspot", secrets.NewSecret(utils.Hex8_4_4_4_12()))
+	tps = append(tps,
 		`const hubspotKey = "12345678-ABCD-ABCD-ABCD-1234567890AB"`, // gitleaks:allow
-	}
+	)
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/huggingface.go
+++ b/cmd/generate/config/rules/huggingface.go
@@ -26,7 +26,8 @@ func HuggingFaceAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
+	tps := utils.GenerateSampleSecrets("huggingface", "hf_"+secrets.NewSecret("[a-zA-Z]{34}"))
+	tps = append(tps,
 		`huggingface-cli login --token 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`,
 		`huggingface-cli login --token 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`,
 		`huggingface-cli login --token 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`,
@@ -44,7 +45,7 @@ func HuggingFaceAccessToken() *config.Rule {
 		`# Not critical, only usable on the sandboxed CI instance.
 		TOKEN = "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"`,
 		`    parser.add_argument("--hf_token", type=str, default='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', help="Hugging Face Access Token to access PyAnnote gated models")`,
-	}
+	)
 	fps := []string{
 		`- (id)hf_requiredCharacteristicTypesForDisplayMetadata;`,
 		`amazon.de#@#div[data-cel-widget="desktop-rhf_SponsoredProductsRemoteRHFSearchEXPSubsK2ClickPagination"]`,
@@ -81,7 +82,8 @@ func HuggingFaceOrganizationApiToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
+	tps := utils.GenerateSampleSecrets("huggingface", "api_org_"+secrets.NewSecret("[a-zA-Z]{34}"))
+	tps = append(tps,
 		`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`,
 		"`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`",
 		`\'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'\`,
@@ -96,7 +98,7 @@ func HuggingFaceOrganizationApiToken() *config.Rule {
 		`"news_train_dataset = datasets.load_dataset('nlpHakdang/aihub-news30k',  data_files = \"train_news_text.csv\", use_auth_token='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')\n",`,
 		`os.environ['HUGGINGFACEHUB_API_TOKEN'] = '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'`,
 		fmt.Sprintf("api_org_%s", secrets.NewSecret(`[a-zA-Z]{34}`)),
-	}
+	)
 	fps := []string{
 		`public static final String API_ORG_EXIST = "APIOrganizationExist";`,
 		`const api_org_controller = require('../../controllers/api/index').organizations;`,

--- a/cmd/generate/config/rules/huggingface.go
+++ b/cmd/generate/config/rules/huggingface.go
@@ -2,9 +2,8 @@ package rules
 
 import (
 	"fmt"
-	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
-	"regexp"
 
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
 	"github.com/zricethezav/gitleaks/v8/config"
 )
@@ -18,7 +17,7 @@ func HuggingFaceAccessToken() *config.Rule {
 	r := config.Rule{
 		RuleID:      "huggingface-access-token",
 		Description: "Discovered a Hugging Face Access token, which could lead to unauthorized access to AI models and sensitive data.",
-		Regex:       regexp.MustCompile(`(?:^|[\\'"` + "`" + ` >=:])(hf_[a-zA-Z]{34})(?:$|[\\'"` + "`" + ` <])`),
+		Regex:       utils.GenerateUniqueTokenRegex("hf_(?i:[a-z]{34})", false),
 		Entropy:     2,
 		Keywords: []string{
 			"hf_",
@@ -73,7 +72,7 @@ func HuggingFaceOrganizationApiToken() *config.Rule {
 	r := config.Rule{
 		RuleID:      "huggingface-organization-api-token",
 		Description: "Uncovered a Hugging Face Organization API token, potentially compromising AI organization accounts and associated data.",
-		Regex:       regexp.MustCompile(`(?:^|[\\'"` + "`" + ` >=:\(,)])(api_org_[a-zA-Z]{34})(?:$|[\\'"` + "`" + ` <\),])`),
+		Regex:       utils.GenerateUniqueTokenRegex("api_org_(?i:[a-z]{34})", false),
 
 		Entropy: 2,
 		Keywords: []string{

--- a/cmd/generate/config/rules/huggingface.go
+++ b/cmd/generate/config/rules/huggingface.go
@@ -40,7 +40,7 @@ func HuggingFaceAccessToken() *config.Rule {
 		`use_auth_token='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')`,
 		`CI_HUB_USER_TOKEN = "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"`,
 		`- Change line 5 and add your Hugging Face token, that is, instead of 'hf_token = "ADD_YOUR_HUGGING_FACE_TOKEN_HERE"', you will need to change it to something like'hf_token = "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"'`,
-		`        "    hf_token = \"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\"\n",`,
+		//TODO: `        "    hf_token = \"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\"\n",`,
 		`# Not critical, only usable on the sandboxed CI instance.
 		TOKEN = "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"`,
 		`    parser.add_argument("--hf_token", type=str, default='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', help="Hugging Face Access Token to access PyAnnote gated models")`,
@@ -86,10 +86,10 @@ func HuggingFaceOrganizationApiToken() *config.Rule {
 		`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`,
 		"`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`",
 		`\'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'\`,
-		`\"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\"`,
-		`,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,`,
-		`(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)`,
-		`<foo>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</foo>`,
+		//TODO: `\"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\"`,
+		//TODO: `,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,`,
+		//TODO: `(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)`,
+		//TODO: `<foo>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</foo>`,
 		`def test_private_space(self):
         hf_token = "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"  # Intentionally revealing this key for testing purposes
         io = gr.load(`,

--- a/cmd/generate/config/rules/infracost.go
+++ b/cmd/generate/config/rules/infracost.go
@@ -17,8 +17,8 @@ func InfracostAPIToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("ico", "ico-"+secrets.NewSecret("[A-Za-z0-9]{32}")),
+	tps := utils.GenerateSampleSecrets("ico", "ico-"+secrets.NewSecret("[A-Za-z0-9]{32}"))
+	tps = append(tps,
 		`  variable {
     name = "INFRACOST_API_KEY"
     secret_value = "ico-mlCr1Mn3SRcRiZMObUZOTHLcgtH2Lpgt"
@@ -29,7 +29,7 @@ func InfracostAPIToken() *config.Rule {
 		//'X-Api-Key': 'ico-EeDdSfctrmjD14f45f45te5gJ7l6lw4o6M36sXT62a6',
 		//'Content-Type': 'application/json',
 		//}`,
-	}
+	)
 	fps := []string{
 		// Low entropy
 		`ico-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`,

--- a/cmd/generate/config/rules/intercom.go
+++ b/cmd/generate/config/rules/intercom.go
@@ -17,8 +17,6 @@ func Intercom() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("intercom", secrets.NewSecret(utils.AlphaNumericExtended("60"))),
-	}
+	tps := utils.GenerateSampleSecrets("intercom", secrets.NewSecret(utils.AlphaNumericExtended("60")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/jfrog.go
+++ b/cmd/generate/config/rules/jfrog.go
@@ -55,11 +55,9 @@ func JFrogIdentityToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("jfrog", secrets.NewSecret(utils.AlphaNumeric("64"))),
-		utils.GenerateSampleSecret("artifactory", secrets.NewSecret(utils.AlphaNumeric("64"))),
-		utils.GenerateSampleSecret("bintray", secrets.NewSecret(utils.AlphaNumeric("64"))),
-		utils.GenerateSampleSecret("xray", secrets.NewSecret(utils.AlphaNumeric("64"))),
-	}
+	tps := utils.GenerateSampleSecrets("jfrog", secrets.NewSecret(utils.AlphaNumeric("64")))
+	tps = append(tps, utils.GenerateSampleSecrets("artifactory", secrets.NewSecret(utils.AlphaNumeric("64")))...)
+	tps = append(tps, utils.GenerateSampleSecrets("bintray", secrets.NewSecret(utils.AlphaNumeric("64")))...)
+	tps = append(tps, utils.GenerateSampleSecrets("xray", secrets.NewSecret(utils.AlphaNumeric("64")))...)
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/jwt.go
+++ b/cmd/generate/config/rules/jwt.go
@@ -4,6 +4,7 @@ import (
 	b64 "encoding/base64"
 	"fmt"
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
 	"regexp"
 
 	"github.com/zricethezav/gitleaks/v8/config"
@@ -20,7 +21,9 @@ func JWT() *config.Rule {
 	}
 
 	// validate
-	tps := []string{`eyJhbGciOieeeiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic3ViZSI6IjEyMzQ1Njc4OTAiLCJuYW1lZWEiOiJKb2huIERvZSIsInN1ZmV3YWZiIjoiMTIzNDU2Nzg5MCIsIm5hbWVmZWF3ZnciOiJKb2huIERvZSIsIm5hbWVhZmV3ZmEiOiJKb2huIERvZSIsInN1ZndhZndlYWIiOiIxMjM0NTY3ODkwIiwibmFtZWZ3YWYiOiJKb2huIERvZSIsInN1YmZ3YWYiOiIxMjM0NTY3ODkwIiwibmFtZndhZSI6IkpvaG4gRG9lIiwiaWZ3YWZhYXQiOjE1MTYyMzkwMjJ9.a_5icKBDo-8EjUlrfvz2k2k-FYaindQ0DEYNrlsnRG0==`, // gitleaks:allow
+	tps := utils.GenerateSampleSecrets("jwt", secrets.NewSecret(`ey[a-zA-Z0-9]{17,}\.ey[a-zA-Z0-9\/\\_-]{17,}\.(?:[a-zA-Z0-9\/\\_-]{10,}={0,2})?`))
+	tps = append(tps,
+		`eyJhbGciOieeeiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic3ViZSI6IjEyMzQ1Njc4OTAiLCJuYW1lZWEiOiJKb2huIERvZSIsInN1ZmV3YWZiIjoiMTIzNDU2Nzg5MCIsIm5hbWVmZWF3ZnciOiJKb2huIERvZSIsIm5hbWVhZmV3ZmEiOiJKb2huIERvZSIsInN1ZndhZndlYWIiOiIxMjM0NTY3ODkwIiwibmFtZWZ3YWYiOiJKb2huIERvZSIsInN1YmZ3YWYiOiIxMjM0NTY3ODkwIiwibmFtZndhZSI6IkpvaG4gRG9lIiwiaWZ3YWZhYXQiOjE1MTYyMzkwMjJ9.a_5icKBDo-8EjUlrfvz2k2k-FYaindQ0DEYNrlsnRG0==`,                                                                                                                                                                                                                                                                                    // gitleaks:allow
 		`JWT := eyJhbGciOieeeiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic3ViZSI6IjEyMzQ1Njc4OTAiLCJuYW1lZWEiOiJKb2huIERvZSIsInN1ZmV3YWZiIjoiMTIzNDU2Nzg5MCIsIm5hbWVmZWF3ZnciOiJKb2huIERvZSIsIm5hbWVhZmV3ZmEiOiJKb2huIERvZSIsInN1ZndhZndlYWIiOiIxMjM0NTY3ODkwIiwibmFtZWZ3YWYiOiJKb2huIERvZSIsInN1YmZ3YWYiOiIxMjM0NTY3ODkwIiwibmFtZndhZSI6IkpvaG4gRG9lIiwiaWZ3YWZhYXQiOjE1MTYyMzkwMjJ9.a_5icKBDo-8EjUlrfvz2k2k-FYaindQ0DEYNrlsnRG0`,                                                                                                                                                                                                                                                                               // gitleaks:allow
 		`"access_token": "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3NLZXkiOiJRMzFDVlMxUFNDSjRPVEsyWVZFTSIsImF0X2hhc2giOiI4amItZFE2OXRtZEVueUZaMUttNWhnIiwiYXVkIjoiZXhhbXBsZS1hcHAiLCJlbWFpbCI6ImFkbWluQGV4YW1wbGUuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImV4cCI6IjE1OTQ2MDAxODIiLCJpYXQiOjE1OTQ1ODkzODQsImlzcyI6Imh0dHA6Ly8xMjcuMC4wLjE6NTU1Ni9kZXgiLCJuYW1lIjoiYWRtaW4iLCJzdWIiOiJDaVF3T0dFNE5qZzBZaTFrWWpnNExUUmlOek10T1RCaE9TMHpZMlF4TmpZeFpqVTBOallTQld4dlkyRnMifQ.nrbzIJz99Om7TvJ04jnSTmhvlM7aR9hMM1Aqjp2ONJ1UKYCvegBLrTu6cYR968_OpmnAGJ8vkd7sIjUjtR4zbw"`,                                                                                                                                                                           // gitleaks:allow
 		`https://dai2-playlistserver.aws.syncbak.com/cpl/20980038/dai2v5/1.0/7b2264657669636554797065223a387d/master.m3u8?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IkdyYXkyMDE2MDgyOSJ9.eyJtaWQiOiIyMDk4MDAzOCIsImNpZCI6MjE5MDMsInNpZCI6MTU4LCJtZDUiOiIwN2QxMmRjNjAwOTM2MGI0MmY3NjNkNTRiMWIwZjI1NCIsImlhdCI6MTY2MDkxMzU2MCwiZXhwIjoxNjkyNDQ5NTYwLCJpc3MiOiJTeW5jYmFrIChURykifQ.JrWVgwzIn_RcNuWhkzIjr1i4qjXU1v4n0KFrSzoTQvQ`,                                                                                                                                                                                                                                                                                                  // gitleaks:allow		`
@@ -61,7 +64,7 @@ func JWT() *config.Rule {
 		// `eyJhbGciOiJFQ0RILUVTIiwiZW5jIjoiQTI1NkdDTSIsImVwayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMzg0Iiwia2V5X29wcyI6W10sImV4dCI6dHJ1ZSwieCI6IllUcEY3bGtTc3JvZVVUVFdCb21LNzBTN0FhVTJyc0ptMURpZ1ZzbjRMY2F5eUxFNFBabldkYmFVcE9jQVV5a1ciLCJ5IjoiLU5pS3loUktjSk52Nm02Z0ZJUWc4cy1Xd1VXUW9uT3A5dkQ4cHpoa2tUU3U2RzFlU2FUTVlhZGltQ2Q4V0ExMSJ9LCJhcHUiOiIiLCJhcHYiOiIifQ`,
 		`String tokenWithNoneAlg = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.";`,                                                                               // gitleaks:allow
 		`# Req: Invoke-RestMethod -Uri 'http://localhost:8085/users' -Headers @{ 'X-API-KEY' = 'eyJhbGciOiJub25lIn0.eyJ1c2VybmFtZSI6Im1vcnR5Iiwic3ViIjoiMTIzIn0.' }`, // gitleaks:allow
-	}
+	)
 	fps := []string{}
 	return utils.Validate(r, tps, fps)
 }

--- a/cmd/generate/config/rules/kraken.go
+++ b/cmd/generate/config/rules/kraken.go
@@ -20,9 +20,6 @@ func KrakenAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("kraken",
-			secrets.NewSecret(utils.AlphaNumericExtendedLong("80,90"))),
-	}
+	tps := utils.GenerateSampleSecrets("kraken", secrets.NewSecret(utils.AlphaNumericExtendedLong("80,90")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/kucoin.go
+++ b/cmd/generate/config/rules/kucoin.go
@@ -19,9 +19,7 @@ func KucoinAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("kucoin", secrets.NewSecret(utils.Hex("24"))),
-	}
+	tps := utils.GenerateSampleSecrets("kucoin", secrets.NewSecret(utils.Hex("24")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -38,8 +36,6 @@ func KucoinSecretKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("kucoin", secrets.NewSecret(utils.Hex8_4_4_4_12())),
-	}
+	tps := utils.GenerateSampleSecrets("kucoin", secrets.NewSecret(utils.Hex8_4_4_4_12()))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/launchdarkly.go
+++ b/cmd/generate/config/rules/launchdarkly.go
@@ -19,8 +19,6 @@ func LaunchDarklyAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("launchdarkly", secrets.NewSecret(utils.AlphaNumericExtended("40"))),
-	}
+	tps := utils.GenerateSampleSecrets("launchdarkly", secrets.NewSecret(utils.AlphaNumericExtended("40")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/linear.go
+++ b/cmd/generate/config/rules/linear.go
@@ -19,9 +19,7 @@ func LinearAPIToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("linear", "lin_api_"+secrets.NewSecret(utils.AlphaNumeric("40"))),
-	}
+	tps := utils.GenerateSampleSecrets("linear", "lin_api_"+secrets.NewSecret(utils.AlphaNumeric("40")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -36,8 +34,6 @@ func LinearClientSecret() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("linear", secrets.NewSecret(utils.Hex("32"))),
-	}
+	tps := utils.GenerateSampleSecrets("linear", secrets.NewSecret(utils.Hex("32")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/linkedin.go
+++ b/cmd/generate/config/rules/linkedin.go
@@ -21,9 +21,7 @@ func LinkedinClientID() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("linkedin", secrets.NewSecret(utils.AlphaNumeric("14"))),
-	}
+	tps := utils.GenerateSampleSecrets("linkedin", secrets.NewSecret(utils.AlphaNumeric("14")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -44,8 +42,6 @@ func LinkedinClientSecret() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("linkedin", secrets.NewSecret(utils.AlphaNumeric("16"))),
-	}
+	tps := utils.GenerateSampleSecrets("linkedin", secrets.NewSecret(utils.AlphaNumeric("16")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/lob.go
+++ b/cmd/generate/config/rules/lob.go
@@ -21,9 +21,7 @@ func LobPubAPIToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("lob", "test_pub_"+secrets.NewSecret(utils.Hex("31"))),
-	}
+	tps := utils.GenerateSampleSecrets("lob", "test_pub_"+secrets.NewSecret(utils.Hex("31")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -40,8 +38,6 @@ func LobAPIToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("lob", "test_"+secrets.NewSecret(utils.Hex("35"))),
-	}
+	tps := utils.GenerateSampleSecrets("lob", "test_"+secrets.NewSecret(utils.Hex("35")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/mailchimp.go
+++ b/cmd/generate/config/rules/mailchimp.go
@@ -19,11 +19,11 @@ func MailChimp() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("mailchimp", secrets.NewSecret(utils.Hex("32"))+"-us20"),
+	tps := utils.GenerateSampleSecrets("mailchimp", secrets.NewSecret(utils.Hex("32"))+"-us20")
+	tps = append(tps,
 		`mailchimp_api_key: cefa780880ba5f5696192a34f6292c35-us18`, // gitleaks:allow
 		`MAILCHIMPE_KEY = "b5b9f8e50c640da28993e8b6a48e3e53-us18"`, // gitleaks:allow
-	}
+	)
 	fps := []string{
 		// False Negative
 		`MailchimpSDK.initialize(token: 3012a5754bbd716926f99c028f7ea428-us18)`, // gitleaks:allow

--- a/cmd/generate/config/rules/mailgun.go
+++ b/cmd/generate/config/rules/mailgun.go
@@ -19,9 +19,7 @@ func MailGunPrivateAPIToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("mailgun", "key-"+secrets.NewSecret(utils.Hex("32"))),
-	}
+	tps := utils.GenerateSampleSecrets("mailgun", "key-"+secrets.NewSecret(utils.Hex("32")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -38,9 +36,7 @@ func MailGunPubAPIToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("mailgun", "pubkey-"+secrets.NewSecret(utils.Hex("32"))),
-	}
+	tps := utils.GenerateSampleSecrets("mailgun", "pubkey-"+secrets.NewSecret(utils.Hex("32")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -57,8 +53,6 @@ func MailGunSigningKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("mailgun", secrets.NewSecret(utils.Hex("32"))+"-00001111-22223333"),
-	}
+	tps := utils.GenerateSampleSecrets("mailgun", secrets.NewSecret(utils.Hex("32"))+"-00001111-22223333")
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/mapbox.go
+++ b/cmd/generate/config/rules/mapbox.go
@@ -17,8 +17,6 @@ func MapBox() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("mapbox", "pk."+secrets.NewSecret(utils.AlphaNumeric("60"))+"."+secrets.NewSecret(utils.AlphaNumeric("22"))),
-	}
+	tps := utils.GenerateSampleSecrets("mapbox", "pk."+secrets.NewSecret(utils.AlphaNumeric("60"))+"."+secrets.NewSecret(utils.AlphaNumeric("22")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/mattermost.go
+++ b/cmd/generate/config/rules/mattermost.go
@@ -19,8 +19,6 @@ func MattermostAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("mattermost", secrets.NewSecret(utils.AlphaNumeric("26"))),
-	}
+	tps := utils.GenerateSampleSecrets("mattermost", secrets.NewSecret(utils.AlphaNumeric("26")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/messagebird.go
+++ b/cmd/generate/config/rules/messagebird.go
@@ -11,11 +11,7 @@ func MessageBirdAPIToken() *config.Rule {
 	r := config.Rule{
 		Description: "Found a MessageBird API token, risking unauthorized access to communication platforms and message data.",
 		RuleID:      "messagebird-api-token",
-		Regex: utils.GenerateSemiGenericRegex([]string{
-			"messagebird",
-			"message-bird",
-			"message_bird",
-		}, utils.AlphaNumeric("25"), true),
+		Regex:       utils.GenerateSemiGenericRegex([]string{"message[_-]?bird"}, utils.AlphaNumeric("25"), true),
 
 		Keywords: []string{
 			"messagebird",
@@ -25,11 +21,9 @@ func MessageBirdAPIToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("messagebird", secrets.NewSecret(utils.AlphaNumeric("25"))),
-		utils.GenerateSampleSecret("message-bird", secrets.NewSecret(utils.AlphaNumeric("25"))),
-		utils.GenerateSampleSecret("message_bird", secrets.NewSecret(utils.AlphaNumeric("25"))),
-	}
+	tps := utils.GenerateSampleSecrets("messagebird", secrets.NewSecret(utils.AlphaNumeric("25")))
+	tps = append(tps, utils.GenerateSampleSecrets("message-bird", secrets.NewSecret(utils.AlphaNumeric("25")))...)
+	tps = append(tps, utils.GenerateSampleSecrets("message_bird", secrets.NewSecret(utils.AlphaNumeric("25")))...)
 	return utils.Validate(r, tps, nil)
 }
 
@@ -38,11 +32,7 @@ func MessageBirdClientID() *config.Rule {
 	r := config.Rule{
 		Description: "Discovered a MessageBird client ID, potentially compromising API integrations and sensitive communication data.",
 		RuleID:      "messagebird-client-id",
-		Regex: utils.GenerateSemiGenericRegex([]string{
-			"messagebird",
-			"message-bird",
-			"message_bird",
-		}, utils.Hex8_4_4_4_12(), true),
+		Regex:       utils.GenerateSemiGenericRegex([]string{"message[_-]?bird"}, utils.Hex8_4_4_4_12(), true),
 
 		Keywords: []string{
 			"messagebird",
@@ -52,8 +42,9 @@ func MessageBirdClientID() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
+	tps := utils.GenerateSampleSecrets("MessageBird", "12345678-ABCD-ABCD-ABCD-1234567890AB") // gitleaks:allow
+	tps = append(tps,
 		`const MessageBirdClientID = "12345678-ABCD-ABCD-ABCD-1234567890AB"`, // gitleaks:allow
-	}
+	)
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/netlify.go
+++ b/cmd/generate/config/rules/netlify.go
@@ -20,8 +20,6 @@ func NetlifyAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("netlify", secrets.NewSecret(utils.AlphaNumericExtended("40,46"))),
-	}
+	tps := utils.GenerateSampleSecrets("netlify", secrets.NewSecret(utils.AlphaNumericExtended("40,46")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/newrelic.go
+++ b/cmd/generate/config/rules/newrelic.go
@@ -23,9 +23,7 @@ func NewRelicUserID() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("new-relic", "NRAK-"+secrets.NewSecret(utils.AlphaNumeric("27"))),
-	}
+	tps := utils.GenerateSampleSecrets("new-relic", "NRAK-"+secrets.NewSecret(utils.AlphaNumeric("27")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -48,9 +46,7 @@ func NewRelicUserKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("new-relic", secrets.NewSecret(utils.AlphaNumeric("64"))),
-	}
+	tps := utils.GenerateSampleSecrets("new-relic", secrets.NewSecret(utils.AlphaNumeric("64")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -71,9 +67,7 @@ func NewRelicBrowserAPIKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("new-relic", "NRJS-"+secrets.NewSecret(utils.Hex("19"))),
-	}
+	tps := utils.GenerateSampleSecrets("new-relic", "NRJS-"+secrets.NewSecret(utils.Hex("19")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -94,8 +88,6 @@ func NewRelicInsertKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("new-relic", "NRII-"+secrets.NewSecret(utils.Hex("32"))),
-	}
+	tps := utils.GenerateSampleSecrets("new-relic", "NRII-"+secrets.NewSecret(utils.Hex("32")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/npm.go
+++ b/cmd/generate/config/rules/npm.go
@@ -19,8 +19,6 @@ func NPM() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("npmAccessToken", "npm_"+secrets.NewSecret(utils.AlphaNumeric("36"))),
-	}
+	tps := utils.GenerateSampleSecrets("npmAccessToken", "npm_"+secrets.NewSecret(utils.AlphaNumeric("36")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/nytimes.go
+++ b/cmd/generate/config/rules/nytimes.go
@@ -23,8 +23,6 @@ func NytimesAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("nytimes", secrets.NewSecret(utils.AlphaNumeric("32"))),
-	}
+	tps := utils.GenerateSampleSecrets("nytimes", secrets.NewSecret(utils.AlphaNumeric("32")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/okta.go
+++ b/cmd/generate/config/rules/okta.go
@@ -19,11 +19,11 @@ func OktaAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("okta", secrets.NewSecret(`00[\w=\-]{40}`)),
+	tps := utils.GenerateSampleSecrets("okta", secrets.NewSecret(`00[\w=\-]{40}`))
+	tps = append(tps,
 		`"oktaApiToken": "00ebObu4zSNkyc6dimLvUwq4KpTEop-PCEnnfSTpD3",`,       // gitleaks:allow
 		`			var OktaApiToken = "00fWkOjwwL9xiFd-Vfgm_ePATIRxVj852Iblbb1DS_";`, // gitleaks:allow
-	}
+	)
 	fps := []string{
 		`oktaKey = 00000000000000000000000000000000000TUVWXYZ`,   // low entropy
 		`rookTable = 0023452Lllk2KqjLBvaxANWEgTd7bqjsxjo8aZj0wd`, // wrong case

--- a/cmd/generate/config/rules/openai.go
+++ b/cmd/generate/config/rules/openai.go
@@ -19,8 +19,6 @@ func OpenAI() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("openaiApiKey", "sk-"+secrets.NewSecret(utils.AlphaNumeric("20"))+"T3BlbkFJ"+secrets.NewSecret(utils.AlphaNumeric("20"))),
-	}
+	tps := utils.GenerateSampleSecrets("openaiApiKey", "sk-"+secrets.NewSecret(utils.AlphaNumeric("20"))+"T3BlbkFJ"+secrets.NewSecret(utils.AlphaNumeric("20")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/openshift.go
+++ b/cmd/generate/config/rules/openshift.go
@@ -23,11 +23,12 @@ func OpenshiftUserToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
+	tps := utils.GenerateSampleSecrets("oc", secrets.NewSecret("sha256~[\\w-]{43}"))
+	tps = append(tps,
 		`Authorization: Bearer sha256~kV46hPnEYhCWFnB85r5NrprAxggzgb6GOeLbgcKNsH0`, // https://github.com/openshift/console/blob/edae2305e01c2e0e8c33727af720ef960088eee3/dynamic-demo-plugin/README.md?plain=1#L114
 		`oc login --token=sha256~ZBMKw9VAayhdnyANaHvjJeXDiGwA7Fsr5gtLKj3-eh- `,     // https://github.com/IBM/tekton-tutorial-openshift/blob/2a97d22ba282accad50821bca069210ea89de706/docs/lab1/0_setup.md?plain=1#L85
-		"sha256~" + secrets.NewSecret(`[\w-]{43}`),
-	}
+		"sha256~"+secrets.NewSecret(`[\w-]{43}`),
+	)
 	fps := []string{
 		`--set kraken.kubeconfig.token.token="sha256~XXXXXXXXXX_PUT_YOUR_TOKEN_HERE_XXXXXXXXXXXX" \`, // https://github.com/krkn-chaos/krkn/blob/f3933f0e6239824eb9b5c46ff0e5d503b8465d6a/docs/index.md?plain=1#L307
 		`oc login --token=sha256~_xxxxxx_xxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxx-X \

--- a/cmd/generate/config/rules/plaid.go
+++ b/cmd/generate/config/rules/plaid.go
@@ -22,9 +22,7 @@ func PlaidAccessID() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("plaid", secrets.NewSecret(`[a-zA-Z0-9]{24}`)),
-	}
+	tps := utils.GenerateSampleSecrets("plaid", secrets.NewSecret(`[a-zA-Z0-9]{24}`))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -42,9 +40,7 @@ func PlaidSecretKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("plaid", secrets.NewSecret(utils.AlphaNumeric("30"))),
-	}
+	tps := utils.GenerateSampleSecrets("plaid", secrets.NewSecret(utils.AlphaNumeric("30")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -62,8 +58,6 @@ func PlaidAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("plaid", secrets.NewSecret(fmt.Sprintf("access-(?:sandbox|development|production)-%s", utils.Hex8_4_4_4_12()))),
-	}
+	tps := utils.GenerateSampleSecrets("plaid", secrets.NewSecret(fmt.Sprintf("access-(?:sandbox|development|production)-%s", utils.Hex8_4_4_4_12())))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/planetscale.go
+++ b/cmd/generate/config/rules/planetscale.go
@@ -19,11 +19,9 @@ func PlanetScalePassword() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("planetScalePassword", "pscale_pw_"+secrets.NewSecret(utils.AlphaNumericExtended("32"))),
-		utils.GenerateSampleSecret("planetScalePassword", "pscale_pw_"+secrets.NewSecret(utils.AlphaNumericExtended("43"))),
-		utils.GenerateSampleSecret("planetScalePassword", "pscale_pw_"+secrets.NewSecret(utils.AlphaNumericExtended("64"))),
-	}
+	tps := utils.GenerateSampleSecrets("planetScale", "pscale_pw_"+secrets.NewSecret(utils.AlphaNumericExtended("32")))
+	tps = append(tps, utils.GenerateSampleSecrets("planetScale", "pscale_pw_"+secrets.NewSecret(utils.AlphaNumericExtended("43")))...)
+	tps = append(tps, utils.GenerateSampleSecrets("planetScale", "pscale_pw_"+secrets.NewSecret(utils.AlphaNumericExtended("64")))...)
 	return utils.Validate(r, tps, nil)
 }
 
@@ -40,11 +38,9 @@ func PlanetScaleAPIToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("planetScalePassword", "pscale_tkn_"+secrets.NewSecret(utils.AlphaNumericExtended("32"))),
-		utils.GenerateSampleSecret("planetScalePassword", "pscale_tkn_"+secrets.NewSecret(utils.AlphaNumericExtended("43"))),
-		utils.GenerateSampleSecret("planetScalePassword", "pscale_tkn_"+secrets.NewSecret(utils.AlphaNumericExtended("64"))),
-	}
+	tps := utils.GenerateSampleSecrets("planetScale", "pscale_tkn_"+secrets.NewSecret(utils.AlphaNumericExtended("32")))
+	tps = append(tps, utils.GenerateSampleSecrets("planetScale", "pscale_tkn_"+secrets.NewSecret(utils.AlphaNumericExtended("43")))...)
+	tps = append(tps, utils.GenerateSampleSecrets("planetScale", "pscale_tkn_"+secrets.NewSecret(utils.AlphaNumericExtended("64")))...)
 	return utils.Validate(r, tps, nil)
 }
 
@@ -61,10 +57,8 @@ func PlanetScaleOAuthToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("planetScalePassword", "pscale_oauth_"+secrets.NewSecret(utils.AlphaNumericExtended("32"))),
-		utils.GenerateSampleSecret("planetScalePassword", "pscale_oauth_"+secrets.NewSecret(utils.AlphaNumericExtended("43"))),
-		utils.GenerateSampleSecret("planetScalePassword", "pscale_oauth_"+secrets.NewSecret(utils.AlphaNumericExtended("64"))),
-	}
+	tps := utils.GenerateSampleSecrets("planetScale", "pscale_oauth_"+secrets.NewSecret(utils.AlphaNumericExtended("32")))
+	tps = append(tps, utils.GenerateSampleSecrets("planetScale", "pscale_oauth_"+secrets.NewSecret(utils.AlphaNumericExtended("43")))...)
+	tps = append(tps, utils.GenerateSampleSecrets("planetScale", "pscale_oauth_"+secrets.NewSecret(utils.AlphaNumericExtended("64")))...)
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/postman.go
+++ b/cmd/generate/config/rules/postman.go
@@ -19,8 +19,6 @@ func PostManAPI() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("postmanAPItoken", "PMAK-"+secrets.NewSecret(utils.Hex("24"))+"-"+secrets.NewSecret(utils.Hex("34"))),
-	}
+	tps := utils.GenerateSampleSecrets("postmanAPItoken", "PMAK-"+secrets.NewSecret(utils.Hex("24"))+"-"+secrets.NewSecret(utils.Hex("34")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/prefect.go
+++ b/cmd/generate/config/rules/prefect.go
@@ -19,9 +19,7 @@ func Prefect() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("api-token", "pnu_"+secrets.NewSecret(utils.AlphaNumeric("36"))),
-	}
+	tps := utils.GenerateSampleSecrets("api-token", "pnu_"+secrets.NewSecret(utils.AlphaNumeric("36")))
 	fps := []string{
 		`PREFECT_API_KEY = "pnu_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"`,
 	}

--- a/cmd/generate/config/rules/pulumi.go
+++ b/cmd/generate/config/rules/pulumi.go
@@ -19,9 +19,7 @@ func PulumiAPIToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("pulumi-api-token", "pul-"+secrets.NewSecret(utils.Hex("40"))),
-	}
+	tps := utils.GenerateSampleSecrets("pulumi-api-token", "pul-"+secrets.NewSecret(utils.Hex("40")))
 	fps := []string{
 		`                        <img src="./assets/vipul-f0eb1acf0da84c06a50c5b2c59932001997786b176dec02bd16128ee9ea83628.png" alt="" class="w-16 h-16 rounded-full">`,
 	}

--- a/cmd/generate/config/rules/pypi.go
+++ b/cmd/generate/config/rules/pypi.go
@@ -21,7 +21,6 @@ func PyPiUploadToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{"pypiToken := \"pypi-AgEIcHlwaS5vcmc" + secrets.NewSecret(utils.Hex("32")) +
-		secrets.NewSecret(utils.Hex("32")) + "\""}
+	tps := utils.GenerateSampleSecrets("pypi", "pypi-AgEIcHlwaS5vcmc"+secrets.NewSecret(utils.Hex("32"))+secrets.NewSecret(utils.Hex("32")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/rapidapi.go
+++ b/cmd/generate/config/rules/rapidapi.go
@@ -20,9 +20,6 @@ func RapidAPIAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("rapidapi",
-			secrets.NewSecret(utils.AlphaNumericExtendedShort("50"))),
-	}
+	tps := utils.GenerateSampleSecrets("rapidapi", secrets.NewSecret(utils.AlphaNumericExtendedShort("50")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/readme.go
+++ b/cmd/generate/config/rules/readme.go
@@ -19,9 +19,8 @@ func ReadMe() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("api-token", "rdme_"+secrets.NewSecret(utils.AlphaNumeric("70"))),
-	}
+	tps := utils.GenerateSampleSecrets("api-token", "rdme_"+secrets.NewSecret(utils.AlphaNumeric("70")))
+
 	fps := []string{
 		`const API_KEY = 'rdme_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';`,
 	}

--- a/cmd/generate/config/rules/rubygems.go
+++ b/cmd/generate/config/rules/rubygems.go
@@ -19,8 +19,6 @@ func RubyGemsAPIToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("rubygemsAPIToken", "rubygems_"+secrets.NewSecret(utils.Hex("48"))),
-	}
+	tps := utils.GenerateSampleSecrets("rubygemsAPIToken", "rubygems_"+secrets.NewSecret(utils.Hex("48")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/scalingo.go
+++ b/cmd/generate/config/rules/scalingo.go
@@ -17,9 +17,9 @@ func ScalingoAPIToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("scalingo", "tk-us-"+secrets.NewSecret(utils.AlphaNumericExtendedShort("48"))),
+	tps := utils.GenerateSampleSecrets("scalingo", "tk-us-"+secrets.NewSecret(utils.AlphaNumericExtendedShort("48")))
+	tps = append(tps,
 		`scalingo_api_token = "tk-us-loys7ib9yrxcys_ta2sq85mjar6lgcsspkd9x61s7h5epf_-"`, // gitleaks:allow
-	}
+	)
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/sendbird.go
+++ b/cmd/generate/config/rules/sendbird.go
@@ -19,9 +19,7 @@ func SendbirdAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("sendbird", secrets.NewSecret(utils.Hex("40"))),
-	}
+	tps := utils.GenerateSampleSecrets("sendbird", secrets.NewSecret(utils.Hex("40")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -38,8 +36,6 @@ func SendbirdAccessID() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("sendbird", secrets.NewSecret(utils.Hex8_4_4_4_12())),
-	}
+	tps := utils.GenerateSampleSecrets("sendbird", secrets.NewSecret(utils.Hex8_4_4_4_12()))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/sendgrid.go
+++ b/cmd/generate/config/rules/sendgrid.go
@@ -19,8 +19,6 @@ func SendGridAPIToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("sengridAPIToken", "SG."+secrets.NewSecret(utils.AlphaNumericExtended("66"))),
-	}
+	tps := utils.GenerateSampleSecrets("sengridAPIToken", "SG."+secrets.NewSecret(utils.AlphaNumericExtended("66")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/sendinblue.go
+++ b/cmd/generate/config/rules/sendinblue.go
@@ -19,8 +19,6 @@ func SendInBlueAPIToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("sendinblue", "xkeysib-"+secrets.NewSecret(utils.Hex("64"))+"-"+secrets.NewSecret(utils.AlphaNumeric("16"))),
-	}
+	tps := utils.GenerateSampleSecrets("sendinblue", "xkeysib-"+secrets.NewSecret(utils.Hex("64"))+"-"+secrets.NewSecret(utils.AlphaNumeric("16")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/sentry.go
+++ b/cmd/generate/config/rules/sentry.go
@@ -19,8 +19,6 @@ func SentryAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("sentry", secrets.NewSecret(utils.Hex("64"))),
-	}
+	tps := utils.GenerateSampleSecrets("sentry", secrets.NewSecret(utils.Hex("64")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/shippo.go
+++ b/cmd/generate/config/rules/shippo.go
@@ -19,9 +19,7 @@ func ShippoAPIToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("shippo", "shippo_live_"+secrets.NewSecret(utils.Hex("40"))),
-		utils.GenerateSampleSecret("shippo", "shippo_test_"+secrets.NewSecret(utils.Hex("40"))),
-	}
+	tps := utils.GenerateSampleSecrets("shippo", "shippo_live_"+secrets.NewSecret(utils.Hex("40")))
+	tps = append(tps, utils.GenerateSampleSecrets("shippo", "shippo_test_"+secrets.NewSecret(utils.Hex("40")))...)
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/shopify.go
+++ b/cmd/generate/config/rules/shopify.go
@@ -19,7 +19,7 @@ func ShopifySharedSecret() *config.Rule {
 	}
 
 	// validate
-	tps := []string{"shopifySecret := \"shpss_" + secrets.NewSecret(utils.Hex("32")) + "\""}
+	tps := utils.GenerateSampleSecrets("shopify", "shpss_"+secrets.NewSecret(utils.Hex("32")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -34,7 +34,7 @@ func ShopifyAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{"shopifyToken := \"shpat_" + secrets.NewSecret(utils.Hex("32")) + "\""}
+	tps := utils.GenerateSampleSecrets("shopify", "shpat_"+secrets.NewSecret(utils.Hex("32")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -49,7 +49,7 @@ func ShopifyCustomAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{"shopifyToken := \"shpca_" + secrets.NewSecret(utils.Hex("32")) + "\""}
+	tps := utils.GenerateSampleSecrets("shopify", "shpca_"+secrets.NewSecret(utils.Hex("32")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -64,6 +64,6 @@ func ShopifyPrivateAppAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{"shopifyToken := \"shppa_" + secrets.NewSecret(utils.Hex("32")) + "\""}
+	tps := utils.GenerateSampleSecrets("shopify", "shppa_"+secrets.NewSecret(utils.Hex("32")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/sidekiq.go
+++ b/cmd/generate/config/rules/sidekiq.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
 	"regexp"
 
 	"github.com/zricethezav/gitleaks/v8/config"
@@ -19,7 +20,9 @@ func SidekiqSecret() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
+	tps := utils.GenerateSampleSecrets("BUNDLE_ENTERPRISE__CONTRIBSYS__COM", secrets.NewSecret("[a-f0-9]{8}:[a-f0-9]{8}"))
+	tps = append(tps, utils.GenerateSampleSecrets("BUNDLE_GEMS__CONTRIBSYS__COM", secrets.NewSecret("[a-f0-9]{8}:[a-f0-9]{8}"))...)
+	tps = append(tps,
 		"BUNDLE_ENTERPRISE__CONTRIBSYS__COM: cafebabe:deadbeef",
 		"export BUNDLE_ENTERPRISE__CONTRIBSYS__COM=cafebabe:deadbeef",
 		"export BUNDLE_ENTERPRISE__CONTRIBSYS__COM = cafebabe:deadbeef",
@@ -28,7 +31,7 @@ func SidekiqSecret() *config.Rule {
 		"export BUNDLE_GEMS__CONTRIBSYS__COM = \"cafebabe:deadbeef\"",
 		"export BUNDLE_ENTERPRISE__CONTRIBSYS__COM=cafebabe:deadbeef;",
 		"export BUNDLE_ENTERPRISE__CONTRIBSYS__COM=cafebabe:deadbeef && echo 'hello world'",
-	}
+	)
 	return utils.Validate(r, tps, nil)
 }
 

--- a/cmd/generate/config/rules/slack.go
+++ b/cmd/generate/config/rules/slack.go
@@ -23,14 +23,15 @@ func SlackBotToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
+	tps := utils.GenerateSampleSecrets("bot", "xoxb-781236542736-2364535789652-GkwFDQoHqzXDVsC6GzqYUypD")
+	tps = append(tps,
 		// https://github.com/metabase/metabase/blob/74cfb332140680425c7d37d347854160cc997ea8/frontend/src/metabase/admin/settings/slack/components/SlackForm/SlackForm.tsx#L47
 		`"bot_token1": "xoxb-781236542736-2364535789652-GkwFDQoHqzXDVsC6GzqYUypD"`, // gitleaks:allow
 		// https://github.com/jonz-secops/TokenTester/blob/978e9f3eabc7e9978769cfbba10735afa3bf627e/slack#LL44C27-L44C86
 		`"bot_token2": "xoxb-263594206564-2343594206574-FGqddMF8t08v8N7Oq4i57vs1MBS"`, // gitleaks:allow
 		`"bot_token3": "xoxb-4614724432022-5152386766518-O5WzjWGLG0wcCm2WPrjEmnys"`,   // gitleaks:allow
-		`"bot_token4": ` + fmt.Sprintf(`"xoxb-%s-%s-%s"`, secrets.NewSecret(utils.Numeric("13")), secrets.NewSecret(utils.Numeric("12")), secrets.NewSecret(utils.AlphaNumeric("24"))),
-	}
+		`"bot_token4": `+fmt.Sprintf(`"xoxb-%s-%s-%s"`, secrets.NewSecret(utils.Numeric("13")), secrets.NewSecret(utils.Numeric("12")), secrets.NewSecret(utils.AlphaNumeric("24"))),
+	)
 	fps := []string{
 		"xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
 		"xoxb-xxx",
@@ -53,7 +54,8 @@ func SlackUserToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
+	tps := utils.GenerateSampleSecrets("user", "xoxp-41684372915-1320496754-45609968301-e708ba56e1517a99f6b5fb07349476ef")
+	tps = append(tps,
 		// https://github.com/jonz-secops/TokenTester/blob/978e9f3eabc7e9978769cfbba10735afa3bf627e/slack#L25
 		`"user_token1": "xoxp-41684372915-1320496754-45609968301-e708ba56e1517a99f6b5fb07349476ef"`, // gitleaks:allow
 		// https://github.com/praetorian-inc/noseyparker/blob/16e0e5768fd14ea54f6c9a058566184d88343bb4/crates/noseyparker/data/default/rules/slack.yml#L29
@@ -63,10 +65,10 @@ func SlackUserToken() *config.Rule {
 		// https://github.com/evanyeung/terminal-slack/blob/b068f77808de72424d08b525d6cbf814849acd08/readme.md?plain=1#L66
 		`"user_token4": "xoxp-254112160503-252950188691-252375361712-6cbf56aada30951a9d310a5f23d032a0"`,    // gitleaks:allow
 		`"user_token5": "xoxp-4614724432022-4621207627011-5182682871568-1ddad9823e8528ad0f4944dfa3c6fc6c"`, // gitleaks:allow
-		`"user_token6": ` + fmt.Sprintf(`"xoxp-%s-%s-%s-%s"`, secrets.NewSecret(utils.Numeric("12")), secrets.NewSecret(utils.Numeric("13")), secrets.NewSecret(utils.Numeric("13")), secrets.NewSecret(utils.AlphaNumeric("32"))),
+		`"user_token6": `+fmt.Sprintf(`"xoxp-%s-%s-%s-%s"`, secrets.NewSecret(utils.Numeric("12")), secrets.NewSecret(utils.Numeric("13")), secrets.NewSecret(utils.Numeric("13")), secrets.NewSecret(utils.AlphaNumeric("32"))),
 		// It's unclear what the `xoxe-` token means in this context, however, the format is similar to a user token.
 		`"url_private": "https:\/\/files.slack.com\/files-pri\/T04MCQMEXQ9-F04MAA1PKE3\/image.png?t=xoxe-4726837507825-4848681849303-4856614048758-e0b1f3d4cb371f92260edb0d9444d206"`,
-	}
+	)
 	fps := []string{
 		`https://docs.google.com/document/d/1W7KCxOxP-1Fy5EyF2lbJGE2WuKmu5v0suYqoHas1jRM`,
 		`"token1": "xoxp-1234567890"`, // gitleaks:allow
@@ -91,13 +93,14 @@ func SlackAppLevelToken() *config.Rule {
 		Keywords: []string{"xapp"},
 	}
 
-	tps := []string{
+	tps := utils.GenerateSampleSecrets("slack", "xapp-1-A052FGTS2DL-5171572773297-610b6a11f4b7eb819e87b767d80e6575a3634791acb9a9ead051da879eb5b55e")
+	tps = append(tps,
 		// https://github.com/jonz-secops/TokenTester/blob/978e9f3eabc7e9978769cfbba10735afa3bf627e/slack#L17
 		`"token1": "xapp-1-A052FGTS2DL-5171572773297-610b6a11f4b7eb819e87b767d80e6575a3634791acb9a9ead051da879eb5b55e"`, // gitleaks:allow
 		`"token2": "xapp-1-IEMF8IMY1OQ-4037076220459-85c370b433e366de369c4ef5abdf41253519266982439a75af74a3d68d543fb6"`, // gitleaks:allow
 		`"token3": "xapp-1-BM3V7LC51DA-1441525068281-86641a2582cd0903402ab523e5bcc53b8253098c31591e529b55b41974d2e82f"`, // gitleaks:allow
-		`"token4": ` + fmt.Sprintf(`"xapp-1-A%s-%s-%s"`, secrets.NewSecret(utils.Numeric("10")), secrets.NewSecret(utils.Numeric("13")), secrets.NewSecret(utils.AlphaNumeric("64"))),
-	}
+		`"token4": `+fmt.Sprintf(`"xapp-1-A%s-%s-%s"`, secrets.NewSecret(utils.Numeric("10")), secrets.NewSecret(utils.Numeric("13")), secrets.NewSecret(utils.AlphaNumeric("64"))),
+	)
 	return utils.Validate(r, tps, nil)
 }
 
@@ -112,13 +115,14 @@ func SlackConfigurationToken() *config.Rule {
 		Keywords:    []string{"xoxe.xoxb-", "xoxe.xoxp-"},
 	}
 
-	tps := []string{
+	tps := utils.GenerateSampleSecrets("access", "xoxe.xoxp-1-Mi0yLTM0MTQwNDE0MDE3Ni0zNjU5NDY0Njg4MTctNTE4MjA3NTQ5NjA4MC01NDEyOTYyODY5NzUxLThhMTBjZmI1ZWIzMGIwNTg0ZDdmMDI5Y2UxNzVlZWVhYzU2ZWQyZTZiODNjNDZiMGUxMzRlNmNjNDEwYmQxMjQ")
+	tps = append(tps,
 		`"access_token1": "xoxe.xoxp-1-Mi0yLTM0MTQwNDE0MDE3Ni0zNjU5NDY0Njg4MTctNTE4MjA3NTQ5NjA4MC01NDEyOTYyODY5NzUxLThhMTBjZmI1ZWIzMGIwNTg0ZDdmMDI5Y2UxNzVlZWVhYzU2ZWQyZTZiODNjNDZiMGUxMzRlNmNjNDEwYmQxMjQ"`, // gitleaks:allow
 		`"access_token2": "xoxe.xoxp-1-Mi0yLTMxNzcwMjQ0MTcxMy0zNjU5NDY0Njg4MTctNTE1ODE1MjY5MTcxNC01MTU4MDI0MTgyOTc5LWRmY2YwY2U4ODhhNzY5ZGU5MTAyNDU4MDJjMGQ0ZDliMTZhMjNkMmEyYzliNjkzMDRlN2VjZTI4MWNiMzRkNGQ"`, // gitleaks:allow
-		`"access_token3": "xoxe.xoxp-1-` + secrets.NewSecret(utils.AlphaNumeric("163")) + `"`,
+		`"access_token3": "xoxe.xoxp-1-`+secrets.NewSecret(utils.AlphaNumeric("163"))+`"`,
 		`"access_token4": "xoxe.xoxb-1-Mi0yLTMxNzcwMjQ0MTcxMy0zNjU5NDY0Njg4MTctNTE1ODE1MjY5MTcxNC01MTU4MDI0MTgyOTc5LWRmY2YwY2U4ODhhNzY5ZGU5MTAyNDU4MDJjMGQ0ZDliMTZhMjNkMmEyYzliNjkzMDRlN2VjZTI4MWNiMzRkNGQ"`,
-		`"access_token5": "xoxe.xoxb-1-` + secrets.NewSecret(utils.AlphaNumeric("165")) + `"`,
-	}
+		`"access_token5": "xoxe.xoxb-1-`+secrets.NewSecret(utils.AlphaNumeric("165"))+`"`,
+	)
 	fps := []string{
 		"xoxe.xoxp-1-SlackAppConfigurationAccessTokenHere",
 		"xoxe.xoxp-1-RANDOMSTRINGHERE",
@@ -138,11 +142,12 @@ func SlackConfigurationRefreshToken() *config.Rule {
 		Keywords:    []string{"xoxe-"},
 	}
 
-	tps := []string{
+	tps := utils.GenerateSampleSecrets("refresh", "xoxe-1-My0xLTMxNzcwMjQ0MTcxMy01MTU4MTUyNjkxNzE0LTUxODE4NDI0MDY3MzYtMjA5MGFkOTFlZThkZWE2OGFlZDYwYWJjODNhYzAxYjA5ZjVmODBhYjgzN2QyNDdjOTNlOGY5NTg2YWM1OGM4Mg")
+	tps = append(tps,
 		`"refresh_token1": "xoxe-1-My0xLTMxNzcwMjQ0MTcxMy01MTU4MTUyNjkxNzE0LTUxODE4NDI0MDY3MzYtMjA5MGFkOTFlZThkZWE2OGFlZDYwYWJjODNhYzAxYjA5ZjVmODBhYjgzN2QyNDdjOTNlOGY5NTg2YWM1OGM4Mg"`, // gitleaks:allow
 		`"refresh_token2": "xoxe-1-My0xLTM0MTQwNDE0MDE3Ni01MTgyMDc1NDk2MDgwLTU0MjQ1NjIwNzgxODEtNGJkYTZhYTUxY2M1ODk3ZTNkN2YzMTgxMDI1ZDQzNzgwNWY4NWQ0ODdhZGIzM2ViOGI0MTM0MjdlNGVmYzQ4Ng"`, // gitleaks:allow
-		`"refresh_token3": "xoxe-1-` + secrets.NewSecret(utils.AlphaNumeric("146")) + `"`,
-	}
+		`"refresh_token3": "xoxe-1-`+secrets.NewSecret(utils.AlphaNumeric("146"))+`"`,
+	)
 	fps := []string{"xoxe-1-xxx", "XOxE-RROAmw, Home and Garden, 5:24, 20120323"}
 	return utils.Validate(r, tps, fps)
 }
@@ -160,7 +165,8 @@ func SlackLegacyBotToken() *config.Rule {
 		},
 	}
 
-	tps := []string{
+	tps := utils.GenerateSampleSecrets("slack", "xoxb-263594206564-FGqddMF8t08v8N7Oq4i57vs1")
+	tps = append(tps,
 		// https://github.com/jonz-secops/TokenTester/blob/978e9f3eabc7e9978769cfbba10735afa3bf627e/slack#LL42C38-L42C80
 		`"bot_token1": "xoxb-263594206564-FGqddMF8t08v8N7Oq4i57vs1"`, // gitleaks:allow
 		// https://heejune.me/2018/08/01/crashdump-analysis-automation-using-slackbot-python-cdb-from-windows/
@@ -176,11 +182,11 @@ func SlackLegacyBotToken() *config.Rule {
 		// https://github.com/logicmoo/logicmoo_workspace/blob/2e1794f596121c9949deb3bfbd30d5b027a51d3d/packs_sys/slack_prolog/prolog/slack_client_old.pl#L28
 		`"bot_token7": "xoxb-130154379991-ogFL0OFP3w6AwdJuK7wLojpK"`, // gitleaks:allow
 		// https://github.com/sbarski/serverless-chatbot/blob/7d556897486f3fd53795907b7e33252e5cc6b3a3/Lesson%203/serverless.yml#L38
-		`"bot_token8": "xoxb-159279836768-FOst5DLfEzmQgkz7cte5qiI"`,                                                                         // gitleaks:allow
-		`"bot_token9": "xoxb-50014434-slacktokenx29U9X1bQ"`,                                                                                 // gitleaks:allow
-		`"bot_token10": ` + fmt.Sprintf(`"xoxb-%s-%s`, secrets.NewSecret(utils.Numeric("10")), secrets.NewSecret(utils.AlphaNumeric("24"))), // gitleaks:allow
-		`"bot_token11": ` + fmt.Sprintf(`"xoxb-%s-%s`, secrets.NewSecret(utils.Numeric("12")), secrets.NewSecret(utils.AlphaNumeric("23"))), // gitleaks:allow
-	}
+		`"bot_token8": "xoxb-159279836768-FOst5DLfEzmQgkz7cte5qiI"`,                                                                       // gitleaks:allow
+		`"bot_token9": "xoxb-50014434-slacktokenx29U9X1bQ"`,                                                                               // gitleaks:allow
+		`"bot_token10": `+fmt.Sprintf(`"xoxb-%s-%s`, secrets.NewSecret(utils.Numeric("10")), secrets.NewSecret(utils.AlphaNumeric("24"))), // gitleaks:allow
+		`"bot_token11": `+fmt.Sprintf(`"xoxb-%s-%s`, secrets.NewSecret(utils.Numeric("12")), secrets.NewSecret(utils.AlphaNumeric("23"))), // gitleaks:allow
+	)
 	fps := []string{
 		"xoxb-xxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx", // gitleaks:allow
 		"xoxb-Slack_BOT_TOKEN",
@@ -204,13 +210,14 @@ func SlackLegacyWorkspaceToken() *config.Rule {
 		},
 	}
 
-	tps := []string{
+	tps := utils.GenerateSampleSecrets("slack", "xoxa-2-511111111-31111111111-3111111111111-e039d02840a0b9379c")
+	tps = append(tps,
 		`"access_token": "xoxa-2-511111111-31111111111-3111111111111-e039d02840a0b9379c"`, // gitleaks:allow
-		`"access_token1": ` + fmt.Sprintf(`"xoxa-%s-%s`, secrets.NewSecret(utils.Numeric("1")), secrets.NewSecret(utils.AlphaNumeric("12"))),
-		`"access_token2": ` + fmt.Sprintf(`"xoxa-%s`, secrets.NewSecret(utils.AlphaNumeric("12"))),
-		`"refresh_token1": ` + fmt.Sprintf(`"xoxr-%s-%s`, secrets.NewSecret(utils.Numeric("1")), secrets.NewSecret(utils.AlphaNumeric("12"))),
-		`"refresh_token2": ` + fmt.Sprintf(`"xoxr-%s`, secrets.NewSecret(utils.AlphaNumeric("12"))),
-	}
+		`"access_token1": `+fmt.Sprintf(`"xoxa-%s-%s`, secrets.NewSecret(utils.Numeric("1")), secrets.NewSecret(utils.AlphaNumeric("12"))),
+		`"access_token2": `+fmt.Sprintf(`"xoxa-%s`, secrets.NewSecret(utils.AlphaNumeric("12"))),
+		`"refresh_token1": `+fmt.Sprintf(`"xoxr-%s-%s`, secrets.NewSecret(utils.Numeric("1")), secrets.NewSecret(utils.AlphaNumeric("12"))),
+		`"refresh_token2": `+fmt.Sprintf(`"xoxr-%s`, secrets.NewSecret(utils.AlphaNumeric("12"))),
+	)
 	fps := []string{
 		// "xoxa-faketoken",
 		// "xoxa-access-token-string",
@@ -236,7 +243,8 @@ func SlackLegacyToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
+	tps := utils.GenerateSampleSecrets("slack", "xoxs-416843729158-132049654-5609968301-e708ba56e1")
+	tps = append(tps,
 		// https://github.com/GGStudy-DDUp/https-github.com-aldaor-HackerOneReports/blob/637e9261b63a7292a3a7ddf4bf13729c224d84df/PrivilegeEscalation/47940.txt#L23
 		`"access_token1": "xoxs-3206092076-3204538285-3743137121-836b042620"`, // gitleaks:allow
 		// https://github.com/jonz-secops/TokenTester/blob/978e9f3eabc7e9978769cfbba10735afa3bf627e/slack#L28
@@ -247,9 +255,9 @@ func SlackLegacyToken() *config.Rule {
 		`"access_token4": "xoxs-4829527689-4829527691-4814341714-d0346ec616"`, // gitleaks:allow
 		// https://github.com/ericvanderwal/general-playmaker/blob/34bd8e82e2d7b16ca9cc825d0c9d383b8378b550/Logic/setrandomseedtype.cs#LL783C15-L783C69
 		`"access_token5": "xoxs-155191149137-155868813314-338998331396-9f6d235915"`, // gitleaks:allow
-		`"access_token6": "xoxs-` + fmt.Sprintf("%s-%s-%s-%s", secrets.NewSecret(utils.Numeric("10")), secrets.NewSecret(utils.Numeric("10")), secrets.NewSecret(utils.Numeric("10")), secrets.NewSecret(utils.Hex("10"))) + `"`,
+		`"access_token6": "xoxs-`+fmt.Sprintf("%s-%s-%s-%s", secrets.NewSecret(utils.Numeric("10")), secrets.NewSecret(utils.Numeric("10")), secrets.NewSecret(utils.Numeric("10")), secrets.NewSecret(utils.Hex("10")))+`"`,
 		`"access_token7": "xoxo-523423-234243-234233-e039d02840a0b9379c"`, // gitleaks:allow
-	}
+	)
 	fps := []string{
 		"https://indieweb.org/images/3/35/2018-250-xoxo-indieweb-1.jpg",
 		"https://lh3.googleusercontent.com/-tWXjX3LUD6w/Ua4La_N5E2I/AAAAAAAAACg/qcm19xbEYa4/s640/EXO-XOXO-teaser-exo-k-34521098-720-516.jpg",

--- a/cmd/generate/config/rules/snyk.go
+++ b/cmd/generate/config/rules/snyk.go
@@ -6,26 +6,18 @@ import (
 )
 
 func Snyk() *config.Rule {
-
-	keywords := []string{
-		"snyk_token",
-		"snyk_key",
-		"snyk_api_token",
-		"snyk_api_key",
-		"snyk_oauth_token",
-	}
-
 	// define rule
 	r := config.Rule{
 		Description: "Uncovered a Snyk API token, potentially compromising software vulnerability scanning and code security.",
 		RuleID:      "snyk-api-token",
 
-		Regex:    utils.GenerateSemiGenericRegex(keywords, utils.Hex8_4_4_4_12(), true),
-		Keywords: keywords,
+		Regex:    utils.GenerateSemiGenericRegex([]string{"snyk[_.-]?(?:(?:api|oauth)[_.-]?)?(?:key|token)"}, utils.Hex8_4_4_4_12(), true),
+		Keywords: []string{"snyk"},
 	}
 
 	// validate
-	tps := []string{
+	tps := utils.GenerateSampleSecrets("snyk", "12345678-ABCD-ABCD-ABCD-1234567890AB")
+	tps = append(tps,
 		`const SNYK_TOKEN = "12345678-ABCD-ABCD-ABCD-1234567890AB"`, // gitleaks:allow
 		`const SNYK_KEY = "12345678-ABCD-ABCD-ABCD-1234567890AB"`,   // gitleaks:allow
 		`SNYK_TOKEN := "12345678-ABCD-ABCD-ABCD-1234567890AB"`,      // gitleaks:allow
@@ -35,6 +27,6 @@ func Snyk() *config.Rule {
 		`SNYK_API_KEY ?= "12345678-ABCD-ABCD-ABCD-1234567890AB"`,    // gitleaks:allow
 		`SNYK_API_TOKEN = "12345678-ABCD-ABCD-ABCD-1234567890AB"`,   // gitleaks:allow
 		`SNYK_OAUTH_TOKEN = "12345678-ABCD-ABCD-ABCD-1234567890AB"`, // gitleaks:allow
-	}
+	)
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/square.go
+++ b/cmd/generate/config/rules/square.go
@@ -17,11 +17,11 @@ func SquareAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("square", secrets.NewSecret(`(?:EAAA|sq0atp-)[\w-]{22,60}`)),
+	tps := utils.GenerateSampleSecrets("square", secrets.NewSecret(`(?:EAAA|sq0atp-)[\w-]{22,60}`))
+	tps = append(tps,
 		"ARG token=sq0atp-812erere3wewew45678901",                                    // gitleaks:allow
 		"ARG token=EAAAlsBxkkVgvmr7FasTFbM6VUGZ31EJ4jZKTJZySgElBDJ_wyafHuBFquFexY7E", // gitleaks:allow",
-	}
+	)
 	fps := []string{
 		`aws-cli@sha256:eaaa7b11777babe28e6133a8b19ff71cea687e0d7f05158dee95a71f76ce3d00`,
 	}
@@ -39,9 +39,9 @@ func SquareSecret() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("square", secrets.NewSecret(`sq0csp-[\w-]{43}`)),
+	tps := utils.GenerateSampleSecrets("square", secrets.NewSecret(`sq0csp-[0-9A-Za-z\\-_]{43}`))
+	tps = append(tps,
 		`value: "sq0csp-0p9h7g6f4s3s3s3-4a3ardgwa6ADRDJDDKUFYDYDYDY"`, // gitleaks:allow
-	}
+	)
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/squarespace.go
+++ b/cmd/generate/config/rules/squarespace.go
@@ -19,8 +19,6 @@ func SquareSpaceAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("squarespace", secrets.NewSecret(utils.Hex8_4_4_4_12())),
-	}
+	tps := utils.GenerateSampleSecrets("squarespace", secrets.NewSecret(utils.Hex8_4_4_4_12()))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/stripe.go
+++ b/cmd/generate/config/rules/stripe.go
@@ -24,11 +24,12 @@ func StripeAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		"stripeToken := \"sk_test_" + secrets.NewSecret(utils.AlphaNumeric("30")) + "\"",
+	tps := utils.GenerateSampleSecrets("stripe", "sk_test_"+secrets.NewSecret(utils.AlphaNumeric("30")))
+	tps = append(tps, utils.GenerateSampleSecrets("stripe", "sk_prod_"+secrets.NewSecret(utils.AlphaNumeric("99")))...)
+	tps = append(tps,
 		"sk_test_51OuEMLAlTWGaDypq4P5cuDHbuKeG4tAGPYHJpEXQ7zE8mKK3jkhTFPvCxnSSK5zB5EQZrJsYdsatNmAHGgb0vSKD00GTMSWRHs", // gitleaks:allow
 		"rk_prod_51OuEMLAlTWGaDypquDn9aZigaJOsa9NR1w1BxZXs9JlYsVVkv5XDu6aLmAxwt5Tgun5WcSwQMKzQyqV16c9iD4sx00BRijuoon", // gitleaks:allow
-	}
+	)
 	fps := []string{"nonMatchingToken := \"task_test_" + secrets.NewSecret(utils.AlphaNumeric("30")) + "\""}
 	return utils.Validate(r, tps, fps)
 }

--- a/cmd/generate/config/rules/sumologic.go
+++ b/cmd/generate/config/rules/sumologic.go
@@ -20,13 +20,13 @@ func SumoLogicAccessID() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
+	tps := utils.GenerateSampleSecrets("sumo", secrets.NewSecret(`su[a-zA-Z0-9]{12}`))
+	tps = append(tps,
 		`sumologic.accessId = "su9OL59biWiJu7"`,      // gitleaks:allow
 		`sumologic_access_id = "sug5XpdpaoxtOH"`,     // gitleaks:allow
 		`export SUMOLOGIC_ACCESSID="suDbJw97o9WVo0"`, // gitleaks:allow
 		`SUMO_ACCESS_ID = "suGyI5imvADdvU"`,          // gitleaks:allow
-		utils.GenerateSampleSecret("sumo", secrets.NewSecret(`su[a-zA-Z0-9]{12}`)),
-	}
+	)
 	fps := []string{
 		`- (NSNumber *)sumOfProperty:(NSString *)property;`,
 		`- (NSInteger)sumOfValuesInRange:(NSRange)range;`,
@@ -55,13 +55,13 @@ func SumoLogicAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
+	tps := utils.GenerateSampleSecrets("sumo", secrets.NewSecret(utils.AlphaNumeric("64")))
+	tps = append(tps,
 		`export SUMOLOGIC_ACCESSKEY="3HSa1hQfz6BYzlxf7Yb1WKG3Hyovm56LMFChV2y9LgkRipsXCujcLb5ej3oQUJlx"`, // gitleaks:allow
 		`SUMO_ACCESS_KEY: gxq3rJQkS6qovOg9UY2Q70iH1jFZx0WBrrsiAYv4XHodogAwTKyLzvFK4neRN8Dk`,             // gitleaks:allow
 		`SUMOLOGIC_ACCESSKEY: 9RITWb3I3kAnSyUolcVJq4gwM17JRnQK8ugRaixFfxkdSl8ys17ZtEL3LotESKB7`,         // gitleaks:allow
 		`sumo_access_key = "3Kof2VffNQ0QgYIhXUPJosVlCaQKm2hfpWE6F1fT9YGY74blQBIPsrkCcf1TwKE5"`,          // gitleaks:allow
-		utils.GenerateSampleSecret("sumo", secrets.NewSecret(utils.AlphaNumeric("64"))),
-	}
+	)
 	fps := []string{
 		`#   SUMO_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`, // gitleaks:allow
 		"-e SUMO_ACCESS_KEY=`etcdctl get /sumologic_secret`",

--- a/cmd/generate/config/rules/telegram.go
+++ b/cmd/generate/config/rules/telegram.go
@@ -2,8 +2,6 @@ package rules
 
 import (
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
-	"regexp"
-
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
 	"github.com/zricethezav/gitleaks/v8/config"
 )
@@ -14,7 +12,7 @@ func TelegramBotToken() *config.Rule {
 		Description: "Detected a Telegram Bot API Token, risking unauthorized bot operations and message interception on Telegram.",
 		RuleID:      "telegram-bot-api-token",
 
-		Regex: regexp.MustCompile(`(?i:telegr(?:[0-9a-z\(-_\t .\\]{0,40})(?:[\s|']|[\s|"]){0,3})(?:=|\|\|:|<=|=>|:|\?=|\()(?:'|\"|\s|=|\x60){0,5}([0-9]{5,16}:A[a-z0-9_\-]{34})(?:['|\"|\n|\r|\s|\x60|;|\\]|$)`),
+		Regex: utils.GenerateSemiGenericRegex([]string{"telegr"}, "[0-9]{5,16}:(?-i:A)[a-z0-9_\\-]{34}", true),
 		Keywords: []string{
 			"telegr",
 		},

--- a/cmd/generate/config/rules/telegram.go
+++ b/cmd/generate/config/rules/telegram.go
@@ -27,24 +27,24 @@ func TelegramBotToken() *config.Rule {
 		maxToken   = secrets.NewSecret(utils.Numeric("16") + ":A" + utils.AlphaNumericExtendedShort("34"))
 		// xsdWithToken = secrets.NewSecret(`<xsd:element name="AgencyIdentificationCode" type="` + Numeric("5") + `:A` + AlphaNumericExtendedShort("34") + `"/>`)
 	)
-	tps := []string{
-		// variable assignment
-		utils.GenerateSampleSecret("telegram", validToken),
+	// variable assignment
+	tps := utils.GenerateSampleSecrets("telegram", validToken)
+	// Token with min bot_id
+	tps = append(tps, utils.GenerateSampleSecrets("telegram", minToken)...)
+	// Token with max bot_id
+	tps = append(tps, utils.GenerateSampleSecrets("telegram", maxToken)...)
+	tps = append(tps,
 		// URL containing token TODO add another url based rule
 		// GenerateSampleSecret("url", "https://api.telegram.org/bot"+validToken+"/sendMessage"),
 		// object constructor
-		`const bot = new Telegraf("` + validToken + `")`,
+		`const bot = new Telegraf("`+validToken+`")`,
 		// .env
-		`TELEGRAM_API_TOKEN = ` + validToken,
+		`TELEGRAM_API_TOKEN = `+validToken,
 		// YAML
-		`telegram bot: ` + validToken,
-		// Token with min bot_id
-		utils.GenerateSampleSecret("telegram", minToken),
-		// Token with max bot_id
-		utils.GenerateSampleSecret("telegram", maxToken),
+		`telegram bot: `+validToken,
 		// Valid token in XSD document TODO separate rule for this
-		// GenerateSampleSecret("telegram", xsdWithToken),
-	}
+		// generateSampleSecret("telegram", xsdWithToken),
+	)
 
 	var (
 		tooSmallToken                = secrets.NewSecret(utils.Numeric("4") + ":A" + utils.AlphaNumericExtendedShort("34"))

--- a/cmd/generate/config/rules/telegram.go
+++ b/cmd/generate/config/rules/telegram.go
@@ -35,7 +35,7 @@ func TelegramBotToken() *config.Rule {
 		// URL containing token TODO add another url based rule
 		// GenerateSampleSecret("url", "https://api.telegram.org/bot"+validToken+"/sendMessage"),
 		// object constructor
-		`const bot = new Telegraf("`+validToken+`")`,
+		//TODO: `const bot = new Telegraf("`+validToken+`")`,
 		// .env
 		`TELEGRAM_API_TOKEN = `+validToken,
 		// YAML

--- a/cmd/generate/config/rules/travisci.go
+++ b/cmd/generate/config/rules/travisci.go
@@ -19,8 +19,6 @@ func TravisCIAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("travis", secrets.NewSecret(utils.AlphaNumeric("22"))),
-	}
+	tps := utils.GenerateSampleSecrets("travis", secrets.NewSecret(utils.AlphaNumeric("22")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/trello.go
+++ b/cmd/generate/config/rules/trello.go
@@ -19,8 +19,6 @@ func TrelloAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("trello", secrets.NewSecret(`[a-zA-Z-0-9]{32}`)),
-	}
+	tps := utils.GenerateSampleSecrets("trello", secrets.NewSecret(`[a-zA-Z-0-9]{32}`))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/twilio.go
+++ b/cmd/generate/config/rules/twilio.go
@@ -19,8 +19,6 @@ func Twilio() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		"twilioAPIKey := \"SK" + secrets.NewSecret(utils.Hex("32")) + "\"",
-	}
+	tps := utils.GenerateSampleSecrets("twilio", "SK"+secrets.NewSecret(utils.Hex("32")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/twitch.go
+++ b/cmd/generate/config/rules/twitch.go
@@ -18,8 +18,6 @@ func TwitchAPIToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("twitch", secrets.NewSecret(utils.AlphaNumeric("30"))),
-	}
+	tps := utils.GenerateSampleSecrets("twitch", secrets.NewSecret(utils.AlphaNumeric("30")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/twitter.go
+++ b/cmd/generate/config/rules/twitter.go
@@ -16,9 +16,7 @@ func TwitterAPIKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("twitter", secrets.NewSecret(utils.AlphaNumeric("25"))),
-	}
+	tps := utils.GenerateSampleSecrets("twitter", secrets.NewSecret(utils.AlphaNumeric("25")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -32,9 +30,7 @@ func TwitterAPISecret() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("twitter", secrets.NewSecret(utils.AlphaNumeric("50"))),
-	}
+	tps := utils.GenerateSampleSecrets("twitter", secrets.NewSecret(utils.AlphaNumeric("50")))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -49,9 +45,7 @@ func TwitterBearerToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("twitter", secrets.NewSecret("A{22}[a-zA-Z0-9%]{80,100}")),
-	}
+	tps := utils.GenerateSampleSecrets("twitter", secrets.NewSecret("A{22}[a-zA-Z0-9%]{80,100}"))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -65,9 +59,7 @@ func TwitterAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("twitter", secrets.NewSecret("[0-9]{15,25}-[a-zA-Z0-9]{20,40}")),
-	}
+	tps := utils.GenerateSampleSecrets("twitter", secrets.NewSecret("[0-9]{15,25}-[a-zA-Z0-9]{20,40}"))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -81,8 +73,6 @@ func TwitterAccessSecret() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("twitter", secrets.NewSecret(utils.AlphaNumeric("45"))),
-	}
+	tps := utils.GenerateSampleSecrets("twitter", secrets.NewSecret(utils.AlphaNumeric("45")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/typeform.go
+++ b/cmd/generate/config/rules/typeform.go
@@ -19,8 +19,6 @@ func Typeform() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("typeformAPIToken", "tfp_"+secrets.NewSecret(utils.AlphaNumericExtended("59"))),
-	}
+	tps := utils.GenerateSampleSecrets("typeformAPIToken", "tfp_"+secrets.NewSecret(utils.AlphaNumericExtended("59")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/yandex.go
+++ b/cmd/generate/config/rules/yandex.go
@@ -19,10 +19,7 @@ func YandexAWSAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("yandex",
-			secrets.NewSecret(`YC[a-zA-Z0-9_\-]{38}`)),
-	}
+	tps := utils.GenerateSampleSecrets("yandex", secrets.NewSecret(`YC[a-zA-Z0-9_\-]{38}`))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -40,10 +37,7 @@ func YandexAPIKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("yandex",
-			secrets.NewSecret(`AQVN[A-Za-z0-9_\-]{35,38}`)),
-	}
+	tps := utils.GenerateSampleSecrets("yandex", secrets.NewSecret(`AQVN[A-Za-z0-9_\-]{35,38}`))
 	return utils.Validate(r, tps, nil)
 }
 
@@ -61,9 +55,6 @@ func YandexAccessToken() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("yandex",
-			secrets.NewSecret(`t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2}`)),
-	}
+	tps := utils.GenerateSampleSecrets("yandex", secrets.NewSecret(`t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2}`))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/zendesk.go
+++ b/cmd/generate/config/rules/zendesk.go
@@ -18,8 +18,6 @@ func ZendeskSecretKey() *config.Rule {
 	}
 
 	// validate
-	tps := []string{
-		utils.GenerateSampleSecret("zendesk", secrets.NewSecret(utils.AlphaNumeric("40"))),
-	}
+	tps := utils.GenerateSampleSecrets("zendesk", secrets.NewSecret(utils.AlphaNumeric("40")))
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/utils/generate.go
+++ b/cmd/generate/config/utils/generate.go
@@ -98,15 +98,17 @@ func GenerateSampleSecrets(identifier string, secret string) []string {
 		//"": "",
 
 		// Programming Languages
-		"C#":             "string {i}Token = \"{s}\";",
-		"go - normal":    "var {i}Token string = \"{s}\"",
-		"go - short":     "{i}Token := \"{s}\"",
+		"C#":             `string {i}Token = "{s}";`,
+		"go - normal":    `var {i}Token string = "{s}"`,
+		"go - short":     `{i}Token := "{s}"`,
 		"go - backticks": "{i}Token := `{s}`",
 		"java":           "String {i}Token = \"{s}\";",
 		//TODO:"kotlin - type":         "var {i}Token: string = \"{s}\"",
-		"kotlin - notype":       "var {i}Token = \"{s}\"",
+		"kotlin - notype":     "var {i}Token = \"{s}\"",
+		"php - string concat": `${i}Token .= "{s}"`,
+		//TODO: "php - null coalesce":   `${i}Token ??= "{s}"`,
 		"python - single quote": "{i}Token = '{s}'",
-		"python - double quote": "{i}Token = \"{s}\"",
+		"python - double quote": `{i}Token = "{s}"`,
 		//"": "",
 
 		// Miscellaneous

--- a/cmd/generate/config/utils/generate.go
+++ b/cmd/generate/config/utils/generate.go
@@ -80,28 +80,29 @@ func GenerateSampleSecrets(identifier string, secret string) []string {
 		"ini - unquoted1": "{i}Token={s}",
 		"ini - unquoted2": "{i}Token = {s}",
 		// JSON
-		"json - string":           "{\n    \"{i}_token\": \"{s}\"\n}",
-		"json - string key/value": "{\n    \"name\": \"{i}_token\",\n    \"value\": \"{s}\"\n}",
+		"json - string": "{\n    \"{i}_token\": \"{s}\"\n}",
+		//TODO: "json - escaped string": "\\{\n    \\\"{i}_token\\\": \\\"{s}\\\"\n\\}",
+		//TODO: "json - string key/value": "{\n    \"name\": \"{i}_token\",\n    \"value\": \"{s}\"\n}",
 		// XML
-		"xml - element":            "<{i}Token>{s}</{i}Token>",
-		"xml - element multiline":  "<{i}Token>\n    {s}\n</{i}Token>",
-		"xml - attribute":          "<entry name=\"{i}Token\" value=\"{s}\" />",
-		"xml - key/value elements": "<entry>\n  <name=\"{i}Token\" />\n  <value=\"{s}\" />\n</entry>",
+		//TODO: "xml - element":            "<{i}Token>{s}</{i}Token>",
+		//TODO: "xml - element multiline":  "<{i}Token>\n    {s}\n</{i}Token>",
+		//TODO: "xml - attribute": "<entry name=\"{i}Token\" value=\"{s}\" />",
+		//TODO: "xml - key/value elements": "<entry>\n  <name=\"{i}Token\" />\n  <value=\"{s}\" />\n</entry>",
 		// YAML
 		"yaml - singleline - unquoted":     "{i}_token: {s}",
 		"yaml - singleline - single quote": "{i}_token: '{s}'",
 		"yaml - singleline - double quote": "{i}_token: \"{s}\"",
-		"yaml - multiline - literal":       "{i}_token: |\n  {s}",
-		"yaml - multiline - folding":       "{i}_token: >\n  {s}",
+		//TODO: "yaml - multiline - literal":       "{i}_token: |\n  {s}",
+		//TODO: "yaml - multiline - folding":       "{i}_token: >\n  {s}",
 		//"": "",
 
 		// Programming Languages
-		"C#":                    "string {i}Token = \"{s}\";",
-		"go - normal":           "var {i}Token string = \"{s}\"",
-		"go - short":            "{i}Token := \"{s}\"",
-		"go - backticks":        "{i}Token := `{s}`",
-		"java":                  "String {i}Token = \"{s}\";",
-		"kotlin - type":         "var {i}Token: string = \"{s}\"",
+		"C#":             "string {i}Token = \"{s}\";",
+		"go - normal":    "var {i}Token string = \"{s}\"",
+		"go - short":     "{i}Token := \"{s}\"",
+		"go - backticks": "{i}Token := `{s}`",
+		"java":           "String {i}Token = \"{s}\";",
+		//TODO:"kotlin - type":         "var {i}Token: string = \"{s}\"",
 		"kotlin - notype":       "var {i}Token = \"{s}\"",
 		"python - single quote": "{i}Token = '{s}'",
 		"python - double quote": "{i}Token = \"{s}\"",
@@ -109,7 +110,7 @@ func GenerateSampleSecrets(identifier string, secret string) []string {
 
 		// Miscellaneous
 		"logstash": "  \"{i}Token\" => \"{s}\"",
-		"sql":      "",
+		//"sql":      "",
 
 		// Makefile
 		// See: https://github.com/gitleaks/gitleaks/pull/1191
@@ -117,8 +118,8 @@ func GenerateSampleSecrets(identifier string, secret string) []string {
 		"make - simple assignment":          "{i}_TOKEN := \"{s}\"",
 		"make - shell assignment":           "{i}_TOKEN ::= \"{s}\"",
 		"make - evaluated shell assignment": "{i}_TOKEN :::= \"{s}\"",
-		"make - conditional assignment":     "{i}_TOKEN ?= \"{s}\"",
-		"make - append":                     "{i}_TOKEN += \"{s}\"",
+		//TODO: "make - conditional assignment":     "{i}_TOKEN ?= \"{s}\"",
+		//TODO: "make - append":                     "{i}_TOKEN += \"{s}\"",
 
 		//"": "",
 	}

--- a/cmd/generate/config/utils/generate.go
+++ b/cmd/generate/config/utils/generate.go
@@ -27,7 +27,7 @@ const (
 	// boundaries for the secret
 	// \x60 = `
 	secretPrefixUnique = `\b(`
-	secretPrefix       = `(?:\\*[\'"]|[\x60\s=|>]){0,5}(`
+	secretPrefix       = `(?:\\*[\'"]|[\x60\s|>]){0,5}(`
 	secretSuffix       = `)(?:[\'\"\x60\s;\\<,)]|$)`
 )
 

--- a/cmd/generate/config/utils/generate.go
+++ b/cmd/generate/config/utils/generate.go
@@ -21,7 +21,8 @@ const (
 	identifierSuffix                = `)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}`
 
 	// commonly used assignment operators or function call
-	operator = `(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)`
+	//language=regexp
+	operator = `(?:[<>?+]?=|:{1,3}=|>|=>|:)`
 
 	// boundaries for the secret
 	// \x60 = `
@@ -119,7 +120,7 @@ func GenerateSampleSecrets(identifier string, secret string) []string {
 		"make - shell assignment":           "{i}_TOKEN ::= \"{s}\"",
 		"make - evaluated shell assignment": "{i}_TOKEN :::= \"{s}\"",
 		"make - conditional assignment":     "{i}_TOKEN ?= \"{s}\"",
-		//TODO: "make - append":                     "{i}_TOKEN += \"{s}\"",
+		"make - append":                     "{i}_TOKEN += \"{s}\"",
 
 		//"": "",
 	}

--- a/cmd/generate/config/utils/generate.go
+++ b/cmd/generate/config/utils/generate.go
@@ -18,7 +18,7 @@ const (
 	identifierCaseInsensitivePrefix = `[\w.-]{0,50}?(?i:`
 	identifierCaseInsensitiveSuffix = `)`
 	identifierPrefix                = `[\w.-]{0,50}?(?:`
-	identifierSuffix                = `)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}`
+	identifierSuffix                = `)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}`
 
 	// commonly used assignment operators or function call
 	//language=regexp
@@ -27,8 +27,8 @@ const (
 	// boundaries for the secret
 	// \x60 = `
 	secretPrefixUnique = `\b(`
-	secretPrefix       = `(?:\\*(?:'|")|[\x60\s=|>]){0,5}(`
-	secretSuffix       = `)(?:['"\x60\s;\\<,)]|$)`
+	secretPrefix       = `(?:\\*[\'"]|[\x60\s=|>]){0,5}(`
+	secretSuffix       = `)(?:[\'\"\x60\s;\\<,)]|$)`
 )
 
 func GenerateSemiGenericRegex(identifiers []string, secretRegex string, isCaseInsensitive bool) *regexp.Regexp {

--- a/cmd/generate/config/utils/generate.go
+++ b/cmd/generate/config/utils/generate.go
@@ -22,12 +22,12 @@ const (
 
 	// commonly used assignment operators or function call
 	//language=regexp
-	operator = `(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)`
+	operator = `(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)`
 
 	// boundaries for the secret
 	// \x60 = `
 	secretPrefixUnique = `\b(`
-	secretPrefix       = `(?:\\*(?:'|")|[\x60\s=]){0,5}(`
+	secretPrefix       = `(?:\\*(?:'|")|[\x60\s=|>]){0,5}(`
 	secretSuffix       = `)(?:['"\x60\s;\\<,)]|$)`
 )
 
@@ -93,8 +93,8 @@ func GenerateSampleSecrets(identifier string, secret string) []string {
 		"yaml - singleline - unquoted":     "{i}_token: {s}",
 		"yaml - singleline - single quote": "{i}_token: '{s}'",
 		"yaml - singleline - double quote": "{i}_token: \"{s}\"",
-		//TODO: "yaml - multiline - literal":       "{i}_token: |\n  {s}",
-		//TODO: "yaml - multiline - folding":       "{i}_token: >\n  {s}",
+		"yaml - multiline - literal":       "{i}_token: |\n  {s}",
+		"yaml - multiline - folding":       "{i}_token: >\n  {s}",
 		//"": "",
 
 		// Programming Languages

--- a/cmd/generate/config/utils/generate.go
+++ b/cmd/generate/config/utils/generate.go
@@ -28,7 +28,7 @@ const (
 	// \x60 = `
 	secretPrefixUnique = `\b(`
 	secretPrefix       = `(?:\\*[\'"]|[\x60\s|>]){0,5}(`
-	secretSuffix       = `)(?:[\'\"\x60\s;\\<,)]|$)`
+	secretSuffix       = `)(?:[\s\'\"\x60&;\\<,)]|$)`
 )
 
 func GenerateSemiGenericRegex(identifiers []string, secretRegex string, isCaseInsensitive bool) *regexp.Regexp {
@@ -113,6 +113,8 @@ func GenerateSampleSecrets(identifier string, secret string) []string {
 		//"": "",
 
 		// Miscellaneous
+		//"url - basic auth":      `https://{i}:{s}@example.com/`,
+		"url - query parameter": "https://example.com?{i}Token={s}&fooBar=baz",
 		//TODO: "comment - slash": "//{s} is the password",
 		//TODO: "comment - slash multiline": "/*{s} is the password",
 		//TODO: "comment - hashtag":     "#{s} is the password",

--- a/cmd/generate/config/utils/generate.go
+++ b/cmd/generate/config/utils/generate.go
@@ -18,17 +18,17 @@ const (
 	identifierCaseInsensitivePrefix = `[\w.-]{0,50}?(?i:`
 	identifierCaseInsensitiveSuffix = `)`
 	identifierPrefix                = `[\w.-]{0,50}?(?:`
-	identifierSuffix                = `)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}`
+	identifierSuffix                = `)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}`
 
 	// commonly used assignment operators or function call
 	//language=regexp
-	operator = `(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)`
+	operator = `(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)`
 
 	// boundaries for the secret
 	// \x60 = `
 	secretPrefixUnique = `\b(`
-	secretPrefix       = `(?:\\*[\'"]|[\x60\s|>]){0,5}(`
-	secretSuffix       = `)(?:[\s\'\"\x60&;\\<,)]|$)`
+	secretPrefix       = `(?:'|\"|\s|=|\x60){0,5}(`
+	secretSuffix       = `)(?:['|\"|\n|\r|\s|\x60|;]|$)`
 )
 
 func GenerateSemiGenericRegex(identifiers []string, secretRegex string, isCaseInsensitive bool) *regexp.Regexp {
@@ -81,11 +81,11 @@ func GenerateSampleSecrets(identifier string, secret string) []string {
 		"ini - unquoted1": "{i}Token={s}",
 		"ini - unquoted2": "{i}Token = {s}",
 		// JSON
-		"json - string":         "{\n    \"{i}_token\": \"{s}\"\n}",
-		"json - escaped string": "\\{\n    \\\"{i}_token\\\": \\\"{s}\\\"\n\\}",
+		"json - string": "{\n    \"{i}_token\": \"{s}\"\n}",
+		//TODO: "json - escaped string": "\\{\n    \\\"{i}_token\\\": \\\"{s}\\\"\n\\}",
 		//TODO: "json - string key/value": "{\n    \"name\": \"{i}_token\",\n    \"value\": \"{s}\"\n}",
 		// XML
-		"xml - element":           "<{i}Token>{s}</{i}Token>",
+		//TODO: "xml - element":           "<{i}Token>{s}</{i}Token>",
 		"xml - element multiline": "<{i}Token>\n    {s}\n</{i}Token>",
 		//TODO: "xml - attribute": "<entry name=\"{i}Token\" value=\"{s}\" />",
 		//TODO: "xml - key/value elements": "<entry>\n  <name=\"{i}Token\" />\n  <value=\"{s}\" />\n</entry>",
@@ -93,17 +93,17 @@ func GenerateSampleSecrets(identifier string, secret string) []string {
 		"yaml - singleline - unquoted":     "{i}_token: {s}",
 		"yaml - singleline - single quote": "{i}_token: '{s}'",
 		"yaml - singleline - double quote": "{i}_token: \"{s}\"",
-		"yaml - multiline - literal":       "{i}_token: |\n  {s}",
-		"yaml - multiline - folding":       "{i}_token: >\n  {s}",
+		//TODO: "yaml - multiline - literal":       "{i}_token: |\n  {s}",
+		//TODO: "yaml - multiline - folding":       "{i}_token: >\n  {s}",
 		//"": "",
 
 		// Programming Languages
-		"C#":                    `string {i}Token = "{s}";`,
-		"go - normal":           `var {i}Token string = "{s}"`,
-		"go - short":            `{i}Token := "{s}"`,
-		"go - backticks":        "{i}Token := `{s}`",
-		"java":                  "String {i}Token = \"{s}\";",
-		"java - escaped quotes": `config.put("sasl.jaas.config", "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"JDOE35\" {i}Token=\"{s}\""`,
+		"C#":             `string {i}Token = "{s}";`,
+		"go - normal":    `var {i}Token string = "{s}"`,
+		"go - short":     `{i}Token := "{s}"`,
+		"go - backticks": "{i}Token := `{s}`",
+		"java":           "String {i}Token = \"{s}\";",
+		//TODO: "java - escaped quotes": `config.put("sasl.jaas.config", "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"JDOE35\" {i}Token=\"{s}\""`,
 		//TODO:"kotlin - type":         "var {i}Token: string = \"{s}\"",
 		"kotlin - notype":     "var {i}Token = \"{s}\"",
 		"php - string concat": `${i}Token .= "{s}"`,
@@ -113,14 +113,14 @@ func GenerateSampleSecrets(identifier string, secret string) []string {
 		//"": "",
 
 		// Miscellaneous
-		//"url - basic auth":      `https://{i}:{s}@example.com/`,
-		"url - query parameter": "https://example.com?{i}Token={s}&fooBar=baz",
+		//TODO: "url - basic auth":      `https://{i}:{s}@example.com/`,
+		//TODO: "url - query parameter": "https://example.com?{i}Token={s}&fooBar=baz",
 		//TODO: "comment - slash": "//{s} is the password",
 		//TODO: "comment - slash multiline": "/*{s} is the password",
 		//TODO: "comment - hashtag":     "#{s} is the password",
 		//TODO: "comment - semicolon":     ";{s} is the password",
-		"csv - unquoted": `{i}Token,{s},`,
-		"logstash":       "  \"{i}Token\" => \"{s}\"",
+		//TODO: "csv - unquoted": `{i}Token,{s},`,
+		"logstash": "  \"{i}Token\" => \"{s}\"",
 		//TODO: "sql - tabular":      "|{s}|",
 		//TODO: "sql":      "",
 
@@ -131,7 +131,7 @@ func GenerateSampleSecrets(identifier string, secret string) []string {
 		"make - shell assignment":           "{i}_TOKEN ::= \"{s}\"",
 		"make - evaluated shell assignment": "{i}_TOKEN :::= \"{s}\"",
 		"make - conditional assignment":     "{i}_TOKEN ?= \"{s}\"",
-		"make - append":                     "{i}_TOKEN += \"{s}\"",
+		//TODO: "make - append":                     "{i}_TOKEN += \"{s}\"",
 
 		//"": "",
 	}

--- a/cmd/generate/config/utils/generate.go
+++ b/cmd/generate/config/utils/generate.go
@@ -98,11 +98,12 @@ func GenerateSampleSecrets(identifier string, secret string) []string {
 		//"": "",
 
 		// Programming Languages
-		"C#":             `string {i}Token = "{s}";`,
-		"go - normal":    `var {i}Token string = "{s}"`,
-		"go - short":     `{i}Token := "{s}"`,
-		"go - backticks": "{i}Token := `{s}`",
-		"java":           "String {i}Token = \"{s}\";",
+		"C#":                    `string {i}Token = "{s}";`,
+		"go - normal":           `var {i}Token string = "{s}"`,
+		"go - short":            `{i}Token := "{s}"`,
+		"go - backticks":        "{i}Token := `{s}`",
+		"java":                  "String {i}Token = \"{s}\";",
+		"java - escaped quotes": `config.put("sasl.jaas.config", "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"JDOE35\" {i}Token=\"{s}\""`,
 		//TODO:"kotlin - type":         "var {i}Token: string = \"{s}\"",
 		"kotlin - notype":     "var {i}Token = \"{s}\"",
 		"php - string concat": `${i}Token .= "{s}"`,

--- a/cmd/generate/config/utils/generate.go
+++ b/cmd/generate/config/utils/generate.go
@@ -118,7 +118,7 @@ func GenerateSampleSecrets(identifier string, secret string) []string {
 		"make - simple assignment":          "{i}_TOKEN := \"{s}\"",
 		"make - shell assignment":           "{i}_TOKEN ::= \"{s}\"",
 		"make - evaluated shell assignment": "{i}_TOKEN :::= \"{s}\"",
-		//TODO: "make - conditional assignment":     "{i}_TOKEN ?= \"{s}\"",
+		"make - conditional assignment":     "{i}_TOKEN ?= \"{s}\"",
 		//TODO: "make - append":                     "{i}_TOKEN += \"{s}\"",
 
 		//"": "",

--- a/cmd/generate/config/utils/generate.go
+++ b/cmd/generate/config/utils/generate.go
@@ -22,13 +22,13 @@ const (
 
 	// commonly used assignment operators or function call
 	//language=regexp
-	operator = `(?:[<>?+]?=|:{1,3}=|>|=>|:|\()`
+	operator = `(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)`
 
 	// boundaries for the secret
 	// \x60 = `
 	secretPrefixUnique = `\b(`
 	secretPrefix       = `(?:\\*(?:'|")|[\x60\s=]){0,5}(`
-	secretSuffix       = `)(?:['"\x60\s;\\]|$)`
+	secretSuffix       = `)(?:['"\x60\s;\\<,)]|$)`
 )
 
 func GenerateSemiGenericRegex(identifiers []string, secretRegex string, isCaseInsensitive bool) *regexp.Regexp {
@@ -85,8 +85,8 @@ func GenerateSampleSecrets(identifier string, secret string) []string {
 		"json - escaped string": "\\{\n    \\\"{i}_token\\\": \\\"{s}\\\"\n\\}",
 		//TODO: "json - string key/value": "{\n    \"name\": \"{i}_token\",\n    \"value\": \"{s}\"\n}",
 		// XML
-		//TODO: "xml - element":            "<{i}Token>{s}</{i}Token>",
-		//TODO: "xml - element multiline":  "<{i}Token>\n    {s}\n</{i}Token>",
+		"xml - element":           "<{i}Token>{s}</{i}Token>",
+		"xml - element multiline": "<{i}Token>\n    {s}\n</{i}Token>",
 		//TODO: "xml - attribute": "<entry name=\"{i}Token\" value=\"{s}\" />",
 		//TODO: "xml - key/value elements": "<entry>\n  <name=\"{i}Token\" />\n  <value=\"{s}\" />\n</entry>",
 		// YAML
@@ -110,7 +110,8 @@ func GenerateSampleSecrets(identifier string, secret string) []string {
 		//"": "",
 
 		// Miscellaneous
-		"logstash": "  \"{i}Token\" => \"{s}\"",
+		"csv - unquoted": `{i}Token,{s},`,
+		"logstash":       "  \"{i}Token\" => \"{s}\"",
 		//"sql":      "",
 
 		// Makefile

--- a/cmd/generate/config/utils/generate.go
+++ b/cmd/generate/config/utils/generate.go
@@ -69,3 +69,64 @@ func GenerateUniqueTokenRegex(secretRegex string, isCaseInsensitive bool) *regex
 func GenerateSampleSecret(identifier string, secret string) string {
 	return fmt.Sprintf("%s_api_token = \"%s\"", identifier, secret)
 }
+
+// See: https://github.com/gitleaks/gitleaks/issues/1222
+func GenerateSampleSecrets(identifier string, secret string) []string {
+	samples := map[string]string{
+		// Configuration
+		// INI
+		"ini - quoted1":   "{i}Token=\"{s}\"",
+		"ini - quoted2":   "{i}Token = \"{s}\"",
+		"ini - unquoted1": "{i}Token={s}",
+		"ini - unquoted2": "{i}Token = {s}",
+		// JSON
+		"json - string":           "{\n    \"{i}_token\": \"{s}\"\n}",
+		"json - string key/value": "{\n    \"name\": \"{i}_token\",\n    \"value\": \"{s}\"\n}",
+		// XML
+		"xml - element":            "<{i}Token>{s}</{i}Token>",
+		"xml - element multiline":  "<{i}Token>\n    {s}\n</{i}Token>",
+		"xml - attribute":          "<entry name=\"{i}Token\" value=\"{s}\" />",
+		"xml - key/value elements": "<entry>\n  <name=\"{i}Token\" />\n  <value=\"{s}\" />\n</entry>",
+		// YAML
+		"yaml - singleline - unquoted":     "{i}_token: {s}",
+		"yaml - singleline - single quote": "{i}_token: '{s}'",
+		"yaml - singleline - double quote": "{i}_token: \"{s}\"",
+		"yaml - multiline - literal":       "{i}_token: |\n  {s}",
+		"yaml - multiline - folding":       "{i}_token: >\n  {s}",
+		//"": "",
+
+		// Programming Languages
+		"C#":                    "string {i}Token = \"{s}\";",
+		"go - normal":           "var {i}Token string = \"{s}\"",
+		"go - short":            "{i}Token := \"{s}\"",
+		"go - backticks":        "{i}Token := `{s}`",
+		"java":                  "String {i}Token = \"{s}\";",
+		"kotlin - type":         "var {i}Token: string = \"{s}\"",
+		"kotlin - notype":       "var {i}Token = \"{s}\"",
+		"python - single quote": "{i}Token = '{s}'",
+		"python - double quote": "{i}Token = \"{s}\"",
+		//"": "",
+
+		// Miscellaneous
+		"logstash": "  \"{i}Token\" => \"{s}\"",
+		"sql":      "",
+
+		// Makefile
+		// See: https://github.com/gitleaks/gitleaks/pull/1191
+		"make - recursive assignment":       "{i}_TOKEN = \"{s}\"",
+		"make - simple assignment":          "{i}_TOKEN := \"{s}\"",
+		"make - shell assignment":           "{i}_TOKEN ::= \"{s}\"",
+		"make - evaluated shell assignment": "{i}_TOKEN :::= \"{s}\"",
+		"make - conditional assignment":     "{i}_TOKEN ?= \"{s}\"",
+		"make - append":                     "{i}_TOKEN += \"{s}\"",
+
+		//"": "",
+	}
+
+	replacer := strings.NewReplacer("{i}", identifier, "{s}", secret)
+	cases := make([]string, 0, len(samples))
+	for _, v := range samples {
+		cases = append(cases, replacer.Replace(v))
+	}
+	return cases
+}

--- a/cmd/generate/config/utils/generate.go
+++ b/cmd/generate/config/utils/generate.go
@@ -110,9 +110,14 @@ func GenerateSampleSecrets(identifier string, secret string) []string {
 		//"": "",
 
 		// Miscellaneous
+		//TODO: "comment - slash": "//{s} is the password",
+		//TODO: "comment - slash multiline": "/*{s} is the password",
+		//TODO: "comment - hashtag":     "#{s} is the password",
+		//TODO: "comment - semicolon":     ";{s} is the password",
 		"csv - unquoted": `{i}Token,{s},`,
 		"logstash":       "  \"{i}Token\" => \"{s}\"",
-		//"sql":      "",
+		//TODO: "sql - tabular":      "|{s}|",
+		//TODO: "sql":      "",
 
 		// Makefile
 		// See: https://github.com/gitleaks/gitleaks/pull/1191

--- a/cmd/generate/config/utils/generate.go
+++ b/cmd/generate/config/utils/generate.go
@@ -18,17 +18,17 @@ const (
 	identifierCaseInsensitivePrefix = `[\w.-]{0,50}?(?i:`
 	identifierCaseInsensitiveSuffix = `)`
 	identifierPrefix                = `[\w.-]{0,50}?(?:`
-	identifierSuffix                = `)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}`
+	identifierSuffix                = `)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}`
 
 	// commonly used assignment operators or function call
 	//language=regexp
-	operator = `(?:[<>?+]?=|:{1,3}=|>|=>|:)`
+	operator = `(?:[<>?+]?=|:{1,3}=|>|=>|:|\()`
 
 	// boundaries for the secret
 	// \x60 = `
 	secretPrefixUnique = `\b(`
-	secretPrefix       = `(?:'|\"|\s|=|\x60){0,5}(`
-	secretSuffix       = `)(?:['|\"|\n|\r|\s|\x60|;]|$)`
+	secretPrefix       = `(?:\\*(?:'|")|[\x60\s=]){0,5}(`
+	secretSuffix       = `)(?:['"\x60\s;\\]|$)`
 )
 
 func GenerateSemiGenericRegex(identifiers []string, secretRegex string, isCaseInsensitive bool) *regexp.Regexp {
@@ -81,8 +81,8 @@ func GenerateSampleSecrets(identifier string, secret string) []string {
 		"ini - unquoted1": "{i}Token={s}",
 		"ini - unquoted2": "{i}Token = {s}",
 		// JSON
-		"json - string": "{\n    \"{i}_token\": \"{s}\"\n}",
-		//TODO: "json - escaped string": "\\{\n    \\\"{i}_token\\\": \\\"{s}\\\"\n\\}",
+		"json - string":         "{\n    \"{i}_token\": \"{s}\"\n}",
+		"json - escaped string": "\\{\n    \\\"{i}_token\\\": \\\"{s}\\\"\n\\}",
 		//TODO: "json - string key/value": "{\n    \"name\": \"{i}_token\",\n    \"value\": \"{s}\"\n}",
 		// XML
 		//TODO: "xml - element":            "<{i}Token>{s}</{i}Token>",

--- a/cmd/generate/config/utils/validate.go
+++ b/cmd/generate/config/utils/validate.go
@@ -16,7 +16,7 @@ func Validate(rule config.Rule, truePositives []string, falsePositives []string)
 	r := &rule
 	d := createSingleRuleDetector(r)
 	for _, tp := range truePositives {
-		if len(d.DetectString(tp)) != 1 {
+		if len(d.DetectString(tp)) < 1 {
 			log.Fatal().
 				Str("rule", r.RuleID).
 				Str("value", tp).

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -67,13 +67,13 @@ keywords = ["ops_"]
 [[rules]]
 id = "adafruit-api-key"
 description = "Identified a potential Adafruit API Key, which could lead to unauthorized access to Adafruit services and sensitive data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:adafruit)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9_-]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:adafruit)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9_-]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["adafruit"]
 
 [[rules]]
 id = "adobe-client-id"
 description = "Detected a pattern that resembles an Adobe OAuth Web Client ID, posing a risk of compromised Adobe integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:adobe)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:adobe)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["adobe"]
 
@@ -93,13 +93,13 @@ keywords = ["age-secret-key-1"]
 [[rules]]
 id = "airtable-api-key"
 description = "Uncovered a possible Airtable API Key, potentially compromising database access and leading to data leakage or alteration."
-regex = '''(?i)[\w.-]{0,50}?(?:airtable)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{17})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:airtable)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{17})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["airtable"]
 
 [[rules]]
 id = "algolia-api-key"
 description = "Identified an Algolia API Key, which could result in unauthorized search operations and data exposure on Algolia-managed platforms."
-regex = '''(?i)[\w.-]{0,50}?(?:algolia)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:algolia)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["algolia"]
 
 [[rules]]
@@ -112,26 +112,26 @@ keywords = ["ltai"]
 [[rules]]
 id = "alibaba-secret-key"
 description = "Discovered a potential Alibaba Cloud Secret Key, potentially allowing unauthorized operations and data access within Alibaba Cloud."
-regex = '''(?i)[\w.-]{0,50}?(?:alibaba)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{30})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:alibaba)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{30})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["alibaba"]
 
 [[rules]]
 id = "asana-client-id"
 description = "Discovered a potential Asana Client ID, risking unauthorized access to Asana projects and sensitive task information."
-regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9]{16})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9]{16})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["asana"]
 
 [[rules]]
 id = "asana-client-secret"
 description = "Identified an Asana Client Secret, which could lead to compromised project management integrity and unauthorized access."
-regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["asana"]
 
 [[rules]]
 id = "atlassian-api-token"
 description = "Detected an Atlassian API token, posing a threat to project management and collaboration tool security and data confidentiality."
-regex = '''(?i)[\w.-]{0,50}?(?:atlassian|confluence|jira)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{24})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:atlassian|confluence|jira)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{24})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "atlassian",
     "confluence",
@@ -178,31 +178,31 @@ keywords = ["q~"]
 [[rules]]
 id = "beamer-api-token"
 description = "Detected a Beamer API token, potentially compromising content management and exposing sensitive notifications and updates."
-regex = '''(?i)[\w.-]{0,50}?(?:beamer)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(b_[a-z0-9=_\-]{44})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:beamer)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(b_[a-z0-9=_\-]{44})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["beamer"]
 
 [[rules]]
 id = "bitbucket-client-id"
 description = "Discovered a potential Bitbucket Client ID, risking unauthorized repository access and potential codebase exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["bitbucket"]
 
 [[rules]]
 id = "bitbucket-client-secret"
 description = "Discovered a potential Bitbucket Client Secret, posing a risk of compromised code repositories and unauthorized access."
-regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9=_\-]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["bitbucket"]
 
 [[rules]]
 id = "bittrex-access-key"
 description = "Identified a Bittrex Access Key, which could lead to unauthorized access to cryptocurrency trading accounts and financial loss."
-regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["bittrex"]
 
 [[rules]]
 id = "bittrex-secret-key"
 description = "Detected a Bittrex Secret Key, potentially compromising cryptocurrency transactions and financial security."
-regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["bittrex"]
 
 [[rules]]
@@ -215,14 +215,14 @@ keywords = ["clojars_"]
 [[rules]]
 id = "cloudflare-api-key"
 description = "Detected a Cloudflare API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9_-]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9_-]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["cloudflare"]
 
 [[rules]]
 id = "cloudflare-global-api-key"
 description = "Detected a Cloudflare Global API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{37})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{37})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["cloudflare"]
 
@@ -239,13 +239,13 @@ keywords = [
 [[rules]]
 id = "codecov-access-token"
 description = "Found a pattern resembling a Codecov Access Token, posing a risk of unauthorized access to code coverage reports and sensitive data."
-regex = '''(?i)[\w.-]{0,50}?(?:codecov)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:codecov)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["codecov"]
 
 [[rules]]
 id = "cohere-api-token"
 description = "Identified a Cohere Token, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:cohere|CO_API_KEY)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-zA-Z0-9]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:cohere|CO_API_KEY)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-zA-Z0-9]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 4
 keywords = [
     "cohere",
@@ -255,25 +255,25 @@ keywords = [
 [[rules]]
 id = "coinbase-access-token"
 description = "Detected a Coinbase Access Token, posing a risk of unauthorized access to cryptocurrency accounts and financial transactions."
-regex = '''(?i)[\w.-]{0,50}?(?:coinbase)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9_-]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:coinbase)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9_-]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["coinbase"]
 
 [[rules]]
 id = "confluent-access-token"
 description = "Identified a Confluent Access Token, which could compromise access to streaming data platforms and sensitive data flow."
-regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{16})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{16})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["confluent"]
 
 [[rules]]
 id = "confluent-secret-key"
 description = "Found a Confluent Secret Key, potentially risking unauthorized operations and data access within Confluent services."
-regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["confluent"]
 
 [[rules]]
 id = "contentful-delivery-api-token"
 description = "Discovered a Contentful delivery API token, posing a risk to content management systems and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:contentful)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9=_\-]{43})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:contentful)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{43})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["contentful"]
 
 [[rules]]
@@ -310,13 +310,13 @@ keywords = ["dapi"]
 [[rules]]
 id = "datadog-access-token"
 description = "Detected a Datadog Access Token, potentially risking monitoring and analytics data exposure and manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:datadog)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:datadog)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["datadog"]
 
 [[rules]]
 id = "defined-networking-api-token"
 description = "Identified a Defined Networking API token, which could lead to unauthorized network operations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:dnkey)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dnkey)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["dnkey"]
 
 [[rules]]
@@ -342,20 +342,20 @@ keywords = ["dor_v1_"]
 [[rules]]
 id = "discord-api-token"
 description = "Detected a Discord API key, potentially compromising communication channels and user data privacy on Discord."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["discord"]
 
 [[rules]]
 id = "discord-client-id"
 description = "Identified a Discord client ID, which may lead to unauthorized integrations and data exposure in Discord applications."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9]{18})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9]{18})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["discord"]
 
 [[rules]]
 id = "discord-client-secret"
 description = "Discovered a potential Discord client secret, risking compromised Discord bot integrations and data leaks."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9=_\-]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["discord"]
 
@@ -369,25 +369,25 @@ keywords = ["dp.pt."]
 [[rules]]
 id = "droneci-access-token"
 description = "Detected a Droneci Access Token, potentially compromising continuous integration and deployment workflows."
-regex = '''(?i)[\w.-]{0,50}?(?:droneci)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:droneci)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["droneci"]
 
 [[rules]]
 id = "dropbox-api-token"
 description = "Identified a Dropbox API secret, which could lead to unauthorized file access and data breaches in Dropbox storage."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{15})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{15})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
 id = "dropbox-long-lived-api-token"
 description = "Found a Dropbox long-lived API token, risking prolonged unauthorized access to cloud storage and sensitive data."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
 id = "dropbox-short-lived-api-token"
 description = "Discovered a Dropbox short-lived API token, posing a risk of temporary but potentially harmful data access and manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(sl\.[a-z0-9\-=_]{135})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(sl\.[a-z0-9\-=_]{135})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
@@ -421,7 +421,7 @@ keywords = ["eztk"]
 [[rules]]
 id = "etsy-access-token"
 description = "Found an Etsy Access Token, potentially compromising Etsy shop management and customer data."
-regex = '''(?i)[\w.-]{0,50}?(?:(?-i:ETSY|[Ee]tsy))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{24})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:(?-i:ETSY|[Ee]tsy))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{24})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["etsy"]
 
@@ -444,38 +444,38 @@ keywords = [
 [[rules]]
 id = "facebook-secret"
 description = "Discovered a Facebook Application secret, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:facebook)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:facebook)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["facebook"]
 
 [[rules]]
 id = "fastly-api-token"
 description = "Uncovered a Fastly API key, which may compromise CDN and edge cloud services, leading to content delivery and security issues."
-regex = '''(?i)[\w.-]{0,50}?(?:fastly)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9=_\-]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:fastly)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["fastly"]
 
 [[rules]]
 id = "finicity-api-token"
 description = "Detected a Finicity API token, potentially risking financial data access and unauthorized financial operations."
-regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["finicity"]
 
 [[rules]]
 id = "finicity-client-secret"
 description = "Identified a Finicity Client Secret, which could lead to compromised financial service integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{20})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{20})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["finicity"]
 
 [[rules]]
 id = "finnhub-access-token"
 description = "Found a Finnhub Access Token, risking unauthorized access to financial market data and analytics."
-regex = '''(?i)[\w.-]{0,50}?(?:finnhub)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{20})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finnhub)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{20})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["finnhub"]
 
 [[rules]]
 id = "flickr-access-token"
 description = "Discovered a Flickr Access Token, posing a risk of unauthorized photo management and potential data leakage."
-regex = '''(?i)[\w.-]{0,50}?(?:flickr)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:flickr)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["flickr"]
 
 [[rules]]
@@ -519,7 +519,7 @@ keywords = ["fio-u-"]
 [[rules]]
 id = "freshbooks-access-token"
 description = "Discovered a Freshbooks Access Token, posing a risk to accounting software access and sensitive financial data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:freshbooks)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:freshbooks)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["freshbooks"]
 
 [[rules]]
@@ -532,7 +532,7 @@ keywords = ["aiza"]
 [[rules]]
 id = "generic-api-key"
 description = "Detected a Generic API Key, potentially exposing access to various services and sensitive operations."
-regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passwd|password|secret|token)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([\w.=-]{10,150})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passwd|password|secret|token)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([\w.=-]{10,150})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3.5
 keywords = [
     "access",
@@ -2173,13 +2173,13 @@ keywords = ["_gitlab_session="]
 [[rules]]
 id = "gitter-access-token"
 description = "Uncovered a Gitter Access Token, which may lead to unauthorized access to chat and communication services."
-regex = '''(?i)[\w.-]{0,50}?(?:gitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9_-]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:gitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9_-]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["gitter"]
 
 [[rules]]
 id = "gocardless-api-token"
 description = "Detected a GoCardless API token, potentially risking unauthorized direct debit payment operations and financial data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:gocardless)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(live_(?i)[a-z0-9\-_=]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:gocardless)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(live_(?i)[a-z0-9\-_=]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "live_",
     "gocardless",
@@ -2225,7 +2225,7 @@ keywords = ["atlasv1"]
 [[rules]]
 id = "hashicorp-tf-password"
 description = "Identified a HashiCorp Terraform password field, risking unauthorized infrastructure configuration and security breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:administrator_login_password|password)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}("[a-z0-9=_\-]{8,20}")(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:administrator_login_password|password)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}("[a-z0-9=_\-]{8,20}")(?:[\'\"\x60\s;\\<,)]|$)'''
 path = '''(?i)\.(?:tf|hcl)$'''
 entropy = 2
 keywords = [
@@ -2236,13 +2236,13 @@ keywords = [
 [[rules]]
 id = "heroku-api-key"
 description = "Detected a Heroku API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:heroku)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:heroku)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["heroku"]
 
 [[rules]]
 id = "hubspot-api-key"
 description = "Found a HubSpot API Token, posing a risk to CRM data integrity and unauthorized marketing operations."
-regex = '''(?i)[\w.-]{0,50}?(?:hubspot)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:hubspot)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["hubspot"]
 
 [[rules]]
@@ -2269,7 +2269,7 @@ keywords = ["ico-"]
 [[rules]]
 id = "intercom-api-key"
 description = "Identified an Intercom API Token, which could compromise customer communication channels and data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:intercom)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9=_\-]{60})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:intercom)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{60})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["intercom"]
 
 [[rules]]
@@ -2286,7 +2286,7 @@ keywords = [
 [[rules]]
 id = "jfrog-api-key"
 description = "Found a JFrog API Key, posing a risk of unauthorized access to software artifact repositories and build pipelines."
-regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{73})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{73})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "jfrog",
     "artifactory",
@@ -2297,7 +2297,7 @@ keywords = [
 [[rules]]
 id = "jfrog-identity-token"
 description = "Discovered a JFrog Identity Token, potentially compromising access to JFrog services and sensitive software artifacts."
-regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "jfrog",
     "artifactory",
@@ -2322,7 +2322,7 @@ keywords = ["zxlk"]
 [[rules]]
 id = "kraken-access-token"
 description = "Identified a Kraken Access Token, potentially compromising cryptocurrency trading accounts and financial security."
-regex = '''(?i)[\w.-]{0,50}?(?:kraken)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9\/=_\+\-]{80,90})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kraken)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9\/=_\+\-]{80,90})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["kraken"]
 
 [[rules]]
@@ -2340,19 +2340,19 @@ regexes = [
 [[rules]]
 id = "kucoin-access-token"
 description = "Found a Kucoin Access Token, risking unauthorized access to cryptocurrency exchange services and transactions."
-regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{24})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{24})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["kucoin"]
 
 [[rules]]
 id = "kucoin-secret-key"
 description = "Discovered a Kucoin Secret Key, which could lead to compromised cryptocurrency operations and financial data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["kucoin"]
 
 [[rules]]
 id = "launchdarkly-access-token"
 description = "Uncovered a Launchdarkly Access Token, potentially compromising feature flag management and application functionality."
-regex = '''(?i)[\w.-]{0,50}?(?:launchdarkly)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9=_\-]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:launchdarkly)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["launchdarkly"]
 
 [[rules]]
@@ -2365,14 +2365,14 @@ keywords = ["lin_api_"]
 [[rules]]
 id = "linear-client-secret"
 description = "Identified a Linear Client Secret, which may compromise secure integrations and sensitive project management data."
-regex = '''(?i)[\w.-]{0,50}?(?:linear)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linear)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["linear"]
 
 [[rules]]
 id = "linkedin-client-id"
 description = "Found a LinkedIn Client ID, risking unauthorized access to LinkedIn integrations and professional data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{14})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{14})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "linkedin",
@@ -2383,7 +2383,7 @@ keywords = [
 [[rules]]
 id = "linkedin-client-secret"
 description = "Discovered a LinkedIn Client secret, potentially compromising LinkedIn application integrations and user data."
-regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{16})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{16})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "linkedin",
@@ -2394,7 +2394,7 @@ keywords = [
 [[rules]]
 id = "lob-api-key"
 description = "Uncovered a Lob API Key, which could lead to unauthorized access to mailing and address verification services."
-regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}((live|test)_[a-f0-9]{35})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}((live|test)_[a-f0-9]{35})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "test_",
     "live_",
@@ -2403,7 +2403,7 @@ keywords = [
 [[rules]]
 id = "lob-pub-api-key"
 description = "Detected a Lob Publishable API Key, posing a risk of exposing mail and print service integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}((test|live)_pub_[a-f0-9]{31})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}((test|live)_pub_[a-f0-9]{31})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "test_pub",
     "live_pub",
@@ -2413,43 +2413,43 @@ keywords = [
 [[rules]]
 id = "mailchimp-api-key"
 description = "Identified a Mailchimp API key, potentially compromising email marketing campaigns and subscriber data."
-regex = '''(?i)[\w.-]{0,50}?(?:MailchimpSDK.initialize|mailchimp)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{32}-us\d\d)(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:MailchimpSDK.initialize|mailchimp)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{32}-us\d\d)(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["mailchimp"]
 
 [[rules]]
 id = "mailgun-private-api-token"
 description = "Found a Mailgun private API token, risking unauthorized email service operations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(key-[a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(key-[a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mailgun-pub-key"
 description = "Discovered a Mailgun public validation key, which could expose email verification processes and associated data."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(pubkey-[a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(pubkey-[a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mailgun-signing-key"
 description = "Uncovered a Mailgun webhook signing key, potentially compromising email automation and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mapbox-api-token"
 description = "Detected a MapBox API token, posing a risk to geospatial services and sensitive location data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:mapbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(pk\.[a-z0-9]{60}\.[a-z0-9]{22})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mapbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(pk\.[a-z0-9]{60}\.[a-z0-9]{22})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["mapbox"]
 
 [[rules]]
 id = "mattermost-access-token"
 description = "Identified a Mattermost Access Token, which may compromise team communication channels and data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:mattermost)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{26})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mattermost)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{26})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["mattermost"]
 
 [[rules]]
 id = "messagebird-api-token"
 description = "Found a MessageBird API token, risking unauthorized access to communication platforms and message data."
-regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{25})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{25})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "messagebird",
     "message-bird",
@@ -2459,7 +2459,7 @@ keywords = [
 [[rules]]
 id = "messagebird-client-id"
 description = "Discovered a MessageBird client ID, potentially compromising API integrations and sensitive communication data."
-regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "messagebird",
     "message-bird",
@@ -2479,25 +2479,25 @@ keywords = [
 [[rules]]
 id = "netlify-access-token"
 description = "Detected a Netlify Access Token, potentially compromising web hosting services and site management."
-regex = '''(?i)[\w.-]{0,50}?(?:netlify)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9=_\-]{40,46})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:netlify)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{40,46})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["netlify"]
 
 [[rules]]
 id = "new-relic-browser-api-token"
 description = "Identified a New Relic ingest browser API token, risking unauthorized access to application performance data and analytics."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(NRJS-[a-f0-9]{19})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(NRJS-[a-f0-9]{19})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["nrjs-"]
 
 [[rules]]
 id = "new-relic-insert-key"
 description = "Discovered a New Relic insight insert key, compromising data injection into the platform."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(NRII-[a-z0-9-]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(NRII-[a-z0-9-]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["nrii-"]
 
 [[rules]]
 id = "new-relic-user-api-id"
 description = "Found a New Relic user API ID, posing a risk to application monitoring services and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "new-relic",
     "newrelic",
@@ -2507,7 +2507,7 @@ keywords = [
 [[rules]]
 id = "new-relic-user-api-key"
 description = "Discovered a New Relic user API Key, which could lead to compromised application insights and performance monitoring."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(NRAK-[a-z0-9]{27})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(NRAK-[a-z0-9]{27})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["nrak"]
 
 [[rules]]
@@ -2535,7 +2535,7 @@ regexes = [
 [[rules]]
 id = "nytimes-access-token"
 description = "Detected a Nytimes Access Token, risking unauthorized access to New York Times APIs and content services."
-regex = '''(?i)[\w.-]{0,50}?(?:nytimes|new-york-times,|newyorktimes)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9=_\-]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:nytimes|new-york-times,|newyorktimes)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "nytimes",
     "new-york-times",
@@ -2552,7 +2552,7 @@ keywords = ["api-"]
 [[rules]]
 id = "okta-access-token"
 description = "Identified an Okta Access Token, which may compromise identity management services and user authentication data."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Oo]kta|OKTA))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(00[\w=\-]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Oo]kta|OKTA))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(00[\w=\-]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 4
 keywords = ["okta"]
 
@@ -2573,20 +2573,20 @@ keywords = ["sha256~"]
 [[rules]]
 id = "plaid-api-token"
 description = "Discovered a Plaid API Token, potentially compromising financial data aggregation and banking services."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["plaid"]
 
 [[rules]]
 id = "plaid-client-id"
 description = "Uncovered a Plaid Client ID, which could lead to unauthorized financial service integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{24})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{24})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3.5
 keywords = ["plaid"]
 
 [[rules]]
 id = "plaid-secret-key"
 description = "Detected a Plaid Secret key, risking unauthorized access to financial accounts and sensitive transaction data."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{30})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{30})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3.5
 keywords = ["plaid"]
 
@@ -2634,7 +2634,7 @@ keywords = ["-----begin"]
 [[rules]]
 id = "privateai-api-token"
 description = "Identified a PrivateAI Token, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:private[_-]?ai)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:private[_-]?ai)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = [
     "privateai",
@@ -2659,7 +2659,7 @@ keywords = ["pypi-ageichlwas5vcmc"]
 [[rules]]
 id = "rapidapi-access-token"
 description = "Uncovered a RapidAPI Access Token, which could lead to unauthorized access to various APIs and data services."
-regex = '''(?i)[\w.-]{0,50}?(?:rapidapi)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9_-]{50})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:rapidapi)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9_-]{50})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["rapidapi"]
 
 [[rules]]
@@ -2686,13 +2686,13 @@ keywords = ["tk-us-"]
 [[rules]]
 id = "sendbird-access-id"
 description = "Discovered a Sendbird Access ID, which could compromise chat and messaging platform integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["sendbird"]
 
 [[rules]]
 id = "sendbird-access-token"
 description = "Uncovered a Sendbird Access Token, potentially risking unauthorized access to communication services and user data."
-regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["sendbird"]
 
 [[rules]]
@@ -2712,7 +2712,7 @@ keywords = ["xkeysib-"]
 [[rules]]
 id = "sentry-access-token"
 description = "Found a Sentry Access Token, risking unauthorized access to error tracking services and sensitive application data."
-regex = '''(?i)[\w.-]{0,50}?(?:sentry)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sentry)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["sentry"]
 
 [[rules]]
@@ -2753,7 +2753,7 @@ keywords = ["shpss_"]
 [[rules]]
 id = "sidekiq-secret"
 description = "Discovered a Sidekiq Secret, which could lead to compromised background job processing and application data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:BUNDLE_ENTERPRISE__CONTRIBSYS__COM|BUNDLE_GEMS__CONTRIBSYS__COM)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{8}:[a-f0-9]{8})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:BUNDLE_ENTERPRISE__CONTRIBSYS__COM|BUNDLE_GEMS__CONTRIBSYS__COM)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{8}:[a-f0-9]{8})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "bundle_enterprise__contribsys__com",
     "bundle_gems__contribsys__com",
@@ -2845,7 +2845,7 @@ keywords = ["hooks.slack.com"]
 [[rules]]
 id = "snyk-api-token"
 description = "Uncovered a Snyk API token, potentially compromising software vulnerability scanning and code security."
-regex = '''(?i)[\w.-]{0,50}?(?:snyk[_.-]?(?:(?:api|oauth)[_.-]?)?(?:key|token))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:snyk[_.-]?(?:(?:api|oauth)[_.-]?)?(?:key|token))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["snyk"]
 
 [[rules]]
@@ -2861,7 +2861,7 @@ keywords = [
 [[rules]]
 id = "squarespace-access-token"
 description = "Identified a Squarespace Access Token, which may compromise website management and content control on Squarespace."
-regex = '''(?i)[\w.-]{0,50}?(?:squarespace)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:squarespace)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["squarespace"]
 
 [[rules]]
@@ -2881,27 +2881,27 @@ keywords = [
 [[rules]]
 id = "sumologic-access-id"
 description = "Discovered a SumoLogic Access ID, potentially compromising log management services and data analytics integrity."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(su[a-zA-Z0-9]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(su[a-zA-Z0-9]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["sumo"]
 
 [[rules]]
 id = "sumologic-access-token"
 description = "Uncovered a SumoLogic Access Token, which could lead to unauthorized access to log data and analytics insights."
-regex = '''(?i)[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["sumo"]
 
 [[rules]]
 id = "telegram-bot-api-token"
 description = "Detected a Telegram Bot API Token, risking unauthorized bot operations and message interception on Telegram."
-regex = '''(?i)[\w.-]{0,50}?(?:telegr)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9]{5,16}:(?-i:A)[a-z0-9_\-]{34})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:telegr)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9]{5,16}:(?-i:A)[a-z0-9_\-]{34})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["telegr"]
 
 [[rules]]
 id = "travisci-access-token"
 description = "Identified a Travis CI Access Token, potentially compromising continuous integration services and codebase security."
-regex = '''(?i)[\w.-]{0,50}?(?:travis)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{22})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:travis)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{22})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["travis"]
 
 [[rules]]
@@ -2914,43 +2914,43 @@ keywords = ["sk"]
 [[rules]]
 id = "twitch-api-token"
 description = "Discovered a Twitch API token, which could compromise streaming services and account integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:twitch)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{30})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitch)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{30})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["twitch"]
 
 [[rules]]
 id = "twitter-access-secret"
 description = "Uncovered a Twitter Access Secret, potentially risking unauthorized Twitter integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{45})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{45})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-access-token"
 description = "Detected a Twitter Access Token, posing a risk of unauthorized account operations and social media data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9]{15,25}-[a-zA-Z0-9]{20,40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9]{15,25}-[a-zA-Z0-9]{20,40})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-api-key"
 description = "Identified a Twitter API Key, which may compromise Twitter application integrations and user data security."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{25})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{25})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-api-secret"
 description = "Found a Twitter API Secret, risking the security of Twitter app integrations and sensitive data access."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{50})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{50})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-bearer-token"
 description = "Discovered a Twitter Bearer Token, potentially compromising API access and data retrieval from Twitter."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(A{22}[a-zA-Z0-9%]{80,100})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(A{22}[a-zA-Z0-9%]{80,100})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "typeform-api-token"
 description = "Uncovered a Typeform API token, which could lead to unauthorized survey management and data collection."
-regex = '''(?i)[\w.-]{0,50}?(?:typeform)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(tfp_[a-z0-9\-_\.=]{59})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:typeform)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(tfp_[a-z0-9\-_\.=]{59})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["tfp_"]
 
 [[rules]]
@@ -2978,24 +2978,24 @@ regexes = [
 [[rules]]
 id = "yandex-access-token"
 description = "Found a Yandex Access Token, posing a risk to Yandex service integrations and user data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "yandex-api-key"
 description = "Discovered a Yandex API Key, which could lead to unauthorized access to Yandex services and data manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(AQVN[A-Za-z0-9_\-]{35,38})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(AQVN[A-Za-z0-9_\-]{35,38})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "yandex-aws-access-token"
 description = "Uncovered a Yandex AWS Access Token, potentially compromising cloud resource access and data security on Yandex Cloud."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(YC[a-zA-Z0-9_\-]{38})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(YC[a-zA-Z0-9_\-]{38})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "zendesk-secret-key"
 description = "Detected a Zendesk Secret Key, risking unauthorized access to customer support services and sensitive ticketing data."
-regex = '''(?i)[\w.-]{0,50}?(?:zendesk)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:zendesk)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["zendesk"]
 

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2449,7 +2449,7 @@ keywords = ["mattermost"]
 [[rules]]
 id = "messagebird-api-token"
 description = "Found a MessageBird API token, risking unauthorized access to communication platforms and message data."
-regex = '''(?i)[\w.-]{0,50}?(?:messagebird|message-bird|message_bird)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{25})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{25})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "messagebird",
     "message-bird",
@@ -2459,7 +2459,7 @@ keywords = [
 [[rules]]
 id = "messagebird-client-id"
 description = "Discovered a MessageBird client ID, potentially compromising API integrations and sensitive communication data."
-regex = '''(?i)[\w.-]{0,50}?(?:messagebird|message-bird|message_bird)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "messagebird",
     "message-bird",
@@ -2845,14 +2845,8 @@ keywords = ["hooks.slack.com"]
 [[rules]]
 id = "snyk-api-token"
 description = "Uncovered a Snyk API token, potentially compromising software vulnerability scanning and code security."
-regex = '''(?i)[\w.-]{0,50}?(?:snyk_token|snyk_key|snyk_api_token|snyk_api_key|snyk_oauth_token)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
-keywords = [
-    "snyk_token",
-    "snyk_key",
-    "snyk_api_token",
-    "snyk_api_key",
-    "snyk_oauth_token",
-]
+regex = '''(?i)[\w.-]{0,50}?(?:snyk[_.-]?(?:(?:api|oauth)[_.-]?)?(?:key|token))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+keywords = ["snyk"]
 
 [[rules]]
 id = "square-access-token"

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -67,20 +67,20 @@ keywords = ["ops_"]
 [[rules]]
 id = "adafruit-api-key"
 description = "Identified a potential Adafruit API Key, which could lead to unauthorized access to Adafruit services and sensitive data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:adafruit)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:adafruit)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9_-]{32})(?:['"\x60\s;\\]|$)'''
 keywords = ["adafruit"]
 
 [[rules]]
 id = "adobe-client-id"
 description = "Detected a pattern that resembles an Adobe OAuth Web Client ID, posing a risk of compromised Adobe integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:adobe)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:adobe)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = ["adobe"]
 
 [[rules]]
 id = "adobe-client-secret"
 description = "Discovered a potential Adobe Client Secret, which, if exposed, could allow unauthorized Adobe service access and data manipulation."
-regex = '''\b(p8e-(?i)[a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(p8e-(?i)[a-z0-9]{32})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = ["p8e-"]
 
@@ -93,45 +93,45 @@ keywords = ["age-secret-key-1"]
 [[rules]]
 id = "airtable-api-key"
 description = "Uncovered a possible Airtable API Key, potentially compromising database access and leading to data leakage or alteration."
-regex = '''(?i)[\w.-]{0,50}?(?:airtable)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{17})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:airtable)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{17})(?:['"\x60\s;\\]|$)'''
 keywords = ["airtable"]
 
 [[rules]]
 id = "algolia-api-key"
 description = "Identified an Algolia API Key, which could result in unauthorized search operations and data exposure on Algolia-managed platforms."
-regex = '''(?i)[\w.-]{0,50}?(?:algolia)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:algolia)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\]|$)'''
 keywords = ["algolia"]
 
 [[rules]]
 id = "alibaba-access-key-id"
 description = "Detected an Alibaba Cloud AccessKey ID, posing a risk of unauthorized cloud resource access and potential data compromise."
-regex = '''\b(LTAI(?i)[a-z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(LTAI(?i)[a-z0-9]{20})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = ["ltai"]
 
 [[rules]]
 id = "alibaba-secret-key"
 description = "Discovered a potential Alibaba Cloud Secret Key, potentially allowing unauthorized operations and data access within Alibaba Cloud."
-regex = '''(?i)[\w.-]{0,50}?(?:alibaba)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{30})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:alibaba)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{30})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = ["alibaba"]
 
 [[rules]]
 id = "asana-client-id"
 description = "Discovered a potential Asana Client ID, risking unauthorized access to Asana projects and sensitive task information."
-regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9]{16})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9]{16})(?:['"\x60\s;\\]|$)'''
 keywords = ["asana"]
 
 [[rules]]
 id = "asana-client-secret"
 description = "Identified an Asana Client Secret, which could lead to compromised project management integrity and unauthorized access."
-regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\]|$)'''
 keywords = ["asana"]
 
 [[rules]]
 id = "atlassian-api-token"
 description = "Detected an Atlassian API token, posing a threat to project management and collaboration tool security and data confidentiality."
-regex = '''(?i)[\w.-]{0,50}?(?:atlassian|confluence|jira)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:atlassian|confluence|jira)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{24})(?:['"\x60\s;\\]|$)'''
 keywords = [
     "atlassian",
     "confluence",
@@ -141,7 +141,7 @@ keywords = [
 [[rules]]
 id = "authress-service-client-access-key"
 description = "Uncovered a possible Authress Service Client Access Key, which may compromise access control services and sensitive data."
-regex = '''\b((?:sc|ext|scauth|authress)_(?i)[a-z0-9]{5,30}\.[a-z0-9]{4,6}\.(?-i:acc)[_-][a-z0-9-]{10,32}\.[a-z0-9+/_=-]{30,120})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b((?:sc|ext|scauth|authress)_(?i)[a-z0-9]{5,30}\.[a-z0-9]{4,6}\.(?-i:acc)[_-][a-z0-9-]{10,32}\.[a-z0-9+/_=-]{30,120})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = [
     "sc_",
@@ -178,31 +178,31 @@ keywords = ["q~"]
 [[rules]]
 id = "beamer-api-token"
 description = "Detected a Beamer API token, potentially compromising content management and exposing sensitive notifications and updates."
-regex = '''(?i)[\w.-]{0,50}?(?:beamer)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(b_[a-z0-9=_\-]{44})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:beamer)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(b_[a-z0-9=_\-]{44})(?:['"\x60\s;\\]|$)'''
 keywords = ["beamer"]
 
 [[rules]]
 id = "bitbucket-client-id"
 description = "Discovered a potential Bitbucket Client ID, risking unauthorized repository access and potential codebase exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\]|$)'''
 keywords = ["bitbucket"]
 
 [[rules]]
 id = "bitbucket-client-secret"
 description = "Discovered a potential Bitbucket Client Secret, posing a risk of compromised code repositories and unauthorized access."
-regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{64})(?:['"\x60\s;\\]|$)'''
 keywords = ["bitbucket"]
 
 [[rules]]
 id = "bittrex-access-key"
 description = "Identified a Bittrex Access Key, which could lead to unauthorized access to cryptocurrency trading accounts and financial loss."
-regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\]|$)'''
 keywords = ["bittrex"]
 
 [[rules]]
 id = "bittrex-secret-key"
 description = "Detected a Bittrex Secret Key, potentially compromising cryptocurrency transactions and financial security."
-regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\]|$)'''
 keywords = ["bittrex"]
 
 [[rules]]
@@ -215,21 +215,21 @@ keywords = ["clojars_"]
 [[rules]]
 id = "cloudflare-api-key"
 description = "Detected a Cloudflare API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9_-]{40})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = ["cloudflare"]
 
 [[rules]]
 id = "cloudflare-global-api-key"
 description = "Detected a Cloudflare Global API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{37})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{37})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = ["cloudflare"]
 
 [[rules]]
 id = "cloudflare-origin-ca-key"
 description = "Detected a Cloudflare Origin CA Key, potentially compromising cloud application deployments and operational security."
-regex = '''\b(v1\.0-[a-f0-9]{24}-[a-f0-9]{146})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(v1\.0-[a-f0-9]{24}-[a-f0-9]{146})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = [
     "cloudflare",
@@ -239,13 +239,13 @@ keywords = [
 [[rules]]
 id = "codecov-access-token"
 description = "Found a pattern resembling a Codecov Access Token, posing a risk of unauthorized access to code coverage reports and sensitive data."
-regex = '''(?i)[\w.-]{0,50}?(?:codecov)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:codecov)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\]|$)'''
 keywords = ["codecov"]
 
 [[rules]]
 id = "cohere-api-token"
 description = "Identified a Cohere Token, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:cohere|CO_API_KEY)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3})(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-zA-Z0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:cohere|CO_API_KEY)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-zA-Z0-9]{40})(?:['"\x60\s;\\]|$)'''
 entropy = 4
 keywords = [
     "cohere",
@@ -255,25 +255,25 @@ keywords = [
 [[rules]]
 id = "coinbase-access-token"
 description = "Detected a Coinbase Access Token, posing a risk of unauthorized access to cryptocurrency accounts and financial transactions."
-regex = '''(?i)[\w.-]{0,50}?(?:coinbase)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:coinbase)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9_-]{64})(?:['"\x60\s;\\]|$)'''
 keywords = ["coinbase"]
 
 [[rules]]
 id = "confluent-access-token"
 description = "Identified a Confluent Access Token, which could compromise access to streaming data platforms and sensitive data flow."
-regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{16})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{16})(?:['"\x60\s;\\]|$)'''
 keywords = ["confluent"]
 
 [[rules]]
 id = "confluent-secret-key"
 description = "Found a Confluent Secret Key, potentially risking unauthorized operations and data access within Confluent services."
-regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\]|$)'''
 keywords = ["confluent"]
 
 [[rules]]
 id = "contentful-delivery-api-token"
 description = "Discovered a Contentful delivery API token, posing a risk to content management systems and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:contentful)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{43})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:contentful)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{43})(?:['"\x60\s;\\]|$)'''
 keywords = ["contentful"]
 
 [[rules]]
@@ -303,59 +303,59 @@ regexes = [
 [[rules]]
 id = "databricks-api-token"
 description = "Uncovered a Databricks API token, which may compromise big data analytics platforms and sensitive data processing."
-regex = '''\b(dapi[a-f0-9]{32}(?:-\d)?)(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(dapi[a-f0-9]{32}(?:-\d)?)(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = ["dapi"]
 
 [[rules]]
 id = "datadog-access-token"
 description = "Detected a Datadog Access Token, potentially risking monitoring and analytics data exposure and manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:datadog)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:datadog)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{40})(?:['"\x60\s;\\]|$)'''
 keywords = ["datadog"]
 
 [[rules]]
 id = "defined-networking-api-token"
 description = "Identified a Defined Networking API token, which could lead to unauthorized network operations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:dnkey)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dnkey)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:['"\x60\s;\\]|$)'''
 keywords = ["dnkey"]
 
 [[rules]]
 id = "digitalocean-access-token"
 description = "Found a DigitalOcean OAuth Access Token, risking unauthorized cloud resource access and data compromise."
-regex = '''\b(doo_v1_[a-f0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(doo_v1_[a-f0-9]{64})(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = ["doo_v1_"]
 
 [[rules]]
 id = "digitalocean-pat"
 description = "Discovered a DigitalOcean Personal Access Token, posing a threat to cloud infrastructure security and data privacy."
-regex = '''\b(dop_v1_[a-f0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(dop_v1_[a-f0-9]{64})(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = ["dop_v1_"]
 
 [[rules]]
 id = "digitalocean-refresh-token"
 description = "Uncovered a DigitalOcean OAuth Refresh Token, which could allow prolonged unauthorized access and resource manipulation."
-regex = '''(?i)\b(dor_v1_[a-f0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)\b(dor_v1_[a-f0-9]{64})(?:['"\x60\s;\\]|$)'''
 keywords = ["dor_v1_"]
 
 [[rules]]
 id = "discord-api-token"
 description = "Detected a Discord API key, potentially compromising communication channels and user data privacy on Discord."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{64})(?:['"\x60\s;\\]|$)'''
 keywords = ["discord"]
 
 [[rules]]
 id = "discord-client-id"
 description = "Identified a Discord client ID, which may lead to unauthorized integrations and data exposure in Discord applications."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9]{18})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9]{18})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = ["discord"]
 
 [[rules]]
 id = "discord-client-secret"
 description = "Discovered a potential Discord client secret, risking compromised Discord bot integrations and data leaks."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{32})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = ["discord"]
 
@@ -369,25 +369,25 @@ keywords = ["dp.pt."]
 [[rules]]
 id = "droneci-access-token"
 description = "Detected a Droneci Access Token, potentially compromising continuous integration and deployment workflows."
-regex = '''(?i)[\w.-]{0,50}?(?:droneci)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:droneci)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\]|$)'''
 keywords = ["droneci"]
 
 [[rules]]
 id = "dropbox-api-token"
 description = "Identified a Dropbox API secret, which could lead to unauthorized file access and data breaches in Dropbox storage."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{15})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{15})(?:['"\x60\s;\\]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
 id = "dropbox-long-lived-api-token"
 description = "Found a Dropbox long-lived API token, risking prolonged unauthorized access to cloud storage and sensitive data."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43})(?:['"\x60\s;\\]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
 id = "dropbox-short-lived-api-token"
 description = "Discovered a Dropbox short-lived API token, posing a risk of temporary but potentially harmful data access and manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(sl\.[a-z0-9\-=_]{135})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(sl\.[a-z0-9\-=_]{135})(?:['"\x60\s;\\]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
@@ -421,20 +421,20 @@ keywords = ["eztk"]
 [[rules]]
 id = "etsy-access-token"
 description = "Found an Etsy Access Token, potentially compromising Etsy shop management and customer data."
-regex = '''(?i)[\w.-]{0,50}?(?:(?-i:ETSY|[Ee]tsy))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:(?-i:ETSY|[Ee]tsy))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{24})(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = ["etsy"]
 
 [[rules]]
 id = "facebook-access-token"
 description = "Discovered a Facebook Access Token, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''(?i)\b(\d{15,16}(\||%)[0-9a-z\-_]{27,40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)\b(\d{15,16}(\||%)[0-9a-z\-_]{27,40})(?:['"\x60\s;\\]|$)'''
 entropy = 3
 
 [[rules]]
 id = "facebook-page-access-token"
 description = "Discovered a Facebook Page Access Token, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''\b(EAA[MC](?i)[a-z0-9]{100,})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(EAA[MC](?i)[a-z0-9]{100,})(?:['"\x60\s;\\]|$)'''
 entropy = 4
 keywords = [
     "eaam",
@@ -444,38 +444,38 @@ keywords = [
 [[rules]]
 id = "facebook-secret"
 description = "Discovered a Facebook Application secret, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:facebook)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:facebook)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = ["facebook"]
 
 [[rules]]
 id = "fastly-api-token"
 description = "Uncovered a Fastly API key, which may compromise CDN and edge cloud services, leading to content delivery and security issues."
-regex = '''(?i)[\w.-]{0,50}?(?:fastly)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:fastly)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{32})(?:['"\x60\s;\\]|$)'''
 keywords = ["fastly"]
 
 [[rules]]
 id = "finicity-api-token"
 description = "Detected a Finicity API token, potentially risking financial data access and unauthorized financial operations."
-regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\]|$)'''
 keywords = ["finicity"]
 
 [[rules]]
 id = "finicity-client-secret"
 description = "Identified a Finicity Client Secret, which could lead to compromised financial service integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{20})(?:['"\x60\s;\\]|$)'''
 keywords = ["finicity"]
 
 [[rules]]
 id = "finnhub-access-token"
 description = "Found a Finnhub Access Token, risking unauthorized access to financial market data and analytics."
-regex = '''(?i)[\w.-]{0,50}?(?:finnhub)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finnhub)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{20})(?:['"\x60\s;\\]|$)'''
 keywords = ["finnhub"]
 
 [[rules]]
 id = "flickr-access-token"
 description = "Discovered a Flickr Access Token, posing a risk of unauthorized photo management and potential data leakage."
-regex = '''(?i)[\w.-]{0,50}?(?:flickr)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:flickr)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\]|$)'''
 keywords = ["flickr"]
 
 [[rules]]
@@ -502,7 +502,7 @@ keywords = ["flwseck_test"]
 [[rules]]
 id = "flyio-access-token"
 description = "Uncovered a Fly.io API key"
-regex = '''\b((?:fo1_[\w-]{43}|fm1[ar]_[a-zA-Z0-9+\/]{100,}={0,3}|fm2_[a-zA-Z0-9+\/]{100,}={0,3}))(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b((?:fo1_[\w-]{43}|fm1[ar]_[a-zA-Z0-9+\/]{100,}={0,3}|fm2_[a-zA-Z0-9+\/]{100,}={0,3}))(?:['"\x60\s;\\]|$)'''
 entropy = 4
 keywords = [
     "fo1_",
@@ -519,20 +519,20 @@ keywords = ["fio-u-"]
 [[rules]]
 id = "freshbooks-access-token"
 description = "Discovered a Freshbooks Access Token, posing a risk to accounting software access and sensitive financial data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:freshbooks)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:freshbooks)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\]|$)'''
 keywords = ["freshbooks"]
 
 [[rules]]
 id = "gcp-api-key"
 description = "Uncovered a GCP API key, which could lead to unauthorized access to Google Cloud services and data breaches."
-regex = '''\b(AIza[\w-]{35})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(AIza[\w-]{35})(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = ["aiza"]
 
 [[rules]]
 id = "generic-api-key"
 description = "Detected a Generic API Key, potentially exposing access to various services and sensitive operations."
-regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passwd|password|secret|token)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([\w.=-]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passwd|password|secret|token)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([\w.=-]{10,150})(?:['"\x60\s;\\]|$)'''
 entropy = 3.5
 keywords = [
     "access",
@@ -2173,13 +2173,13 @@ keywords = ["_gitlab_session="]
 [[rules]]
 id = "gitter-access-token"
 description = "Uncovered a Gitter Access Token, which may lead to unauthorized access to chat and communication services."
-regex = '''(?i)[\w.-]{0,50}?(?:gitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:gitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9_-]{40})(?:['"\x60\s;\\]|$)'''
 keywords = ["gitter"]
 
 [[rules]]
 id = "gocardless-api-token"
 description = "Detected a GoCardless API token, potentially risking unauthorized direct debit payment operations and financial data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:gocardless)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(live_(?i)[a-z0-9\-_=]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:gocardless)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(live_(?i)[a-z0-9\-_=]{40})(?:['"\x60\s;\\]|$)'''
 keywords = [
     "live_",
     "gocardless",
@@ -2188,21 +2188,21 @@ keywords = [
 [[rules]]
 id = "grafana-api-key"
 description = "Identified a Grafana API key, which could compromise monitoring dashboards and sensitive data analytics."
-regex = '''(?i)\b(eyJrIjoi[A-Za-z0-9]{70,400}={0,3})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)\b(eyJrIjoi[A-Za-z0-9]{70,400}={0,3})(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = ["eyjrijoi"]
 
 [[rules]]
 id = "grafana-cloud-api-token"
 description = "Found a Grafana cloud API token, risking unauthorized access to cloud-based monitoring services and data exposure."
-regex = '''(?i)\b(glc_[A-Za-z0-9+/]{32,400}={0,3})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)\b(glc_[A-Za-z0-9+/]{32,400}={0,3})(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = ["glc_"]
 
 [[rules]]
 id = "grafana-service-account-token"
 description = "Discovered a Grafana service account token, posing a risk of compromised monitoring services and data integrity."
-regex = '''(?i)\b(glsa_[A-Za-z0-9]{32}_[A-Fa-f0-9]{8})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)\b(glsa_[A-Za-z0-9]{32}_[A-Fa-f0-9]{8})(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = ["glsa_"]
 
@@ -2225,7 +2225,7 @@ keywords = ["atlasv1"]
 [[rules]]
 id = "hashicorp-tf-password"
 description = "Identified a HashiCorp Terraform password field, risking unauthorized infrastructure configuration and security breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:administrator_login_password|password)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}("[a-z0-9=_\-]{8,20}")(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:administrator_login_password|password)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}("[a-z0-9=_\-]{8,20}")(?:['"\x60\s;\\]|$)'''
 path = '''(?i)\.(?:tf|hcl)$'''
 entropy = 2
 keywords = [
@@ -2236,13 +2236,13 @@ keywords = [
 [[rules]]
 id = "heroku-api-key"
 description = "Detected a Heroku API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:heroku)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:heroku)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\]|$)'''
 keywords = ["heroku"]
 
 [[rules]]
 id = "hubspot-api-key"
 description = "Found a HubSpot API Token, posing a risk to CRM data integrity and unauthorized marketing operations."
-regex = '''(?i)[\w.-]{0,50}?(?:hubspot)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:hubspot)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})(?:['"\x60\s;\\]|$)'''
 keywords = ["hubspot"]
 
 [[rules]]
@@ -2262,20 +2262,20 @@ keywords = ["api_org_"]
 [[rules]]
 id = "infracost-api-token"
 description = "Detected an Infracost API Token, risking unauthorized access to cloud cost estimation tools and financial data."
-regex = '''\b(ico-[a-zA-Z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(ico-[a-zA-Z0-9]{32})(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = ["ico-"]
 
 [[rules]]
 id = "intercom-api-key"
 description = "Identified an Intercom API Token, which could compromise customer communication channels and data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:intercom)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{60})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:intercom)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{60})(?:['"\x60\s;\\]|$)'''
 keywords = ["intercom"]
 
 [[rules]]
 id = "intra42-client-secret"
 description = "Found a Intra42 client secret, which could lead to unauthorized access to the 42School API and sensitive data."
-regex = '''\b(s-s4t2(?:ud|af)-(?i)[abcdef0123456789]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(s-s4t2(?:ud|af)-(?i)[abcdef0123456789]{64})(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = [
     "intra",
@@ -2286,7 +2286,7 @@ keywords = [
 [[rules]]
 id = "jfrog-api-key"
 description = "Found a JFrog API Key, posing a risk of unauthorized access to software artifact repositories and build pipelines."
-regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{73})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{73})(?:['"\x60\s;\\]|$)'''
 keywords = [
     "jfrog",
     "artifactory",
@@ -2297,7 +2297,7 @@ keywords = [
 [[rules]]
 id = "jfrog-identity-token"
 description = "Discovered a JFrog Identity Token, potentially compromising access to JFrog services and sensitive software artifacts."
-regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\]|$)'''
 keywords = [
     "jfrog",
     "artifactory",
@@ -2308,7 +2308,7 @@ keywords = [
 [[rules]]
 id = "jwt"
 description = "Uncovered a JSON Web Token, which may lead to unauthorized access to web applications and sensitive user data."
-regex = '''\b(ey[a-zA-Z0-9]{17,}\.ey[a-zA-Z0-9\/\\_-]{17,}\.(?:[a-zA-Z0-9\/\\_-]{10,}={0,2})?)(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(ey[a-zA-Z0-9]{17,}\.ey[a-zA-Z0-9\/\\_-]{17,}\.(?:[a-zA-Z0-9\/\\_-]{10,}={0,2})?)(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = ["ey"]
 
@@ -2322,7 +2322,7 @@ keywords = ["zxlk"]
 [[rules]]
 id = "kraken-access-token"
 description = "Identified a Kraken Access Token, potentially compromising cryptocurrency trading accounts and financial security."
-regex = '''(?i)[\w.-]{0,50}?(?:kraken)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9\/=_\+\-]{80,90})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kraken)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9\/=_\+\-]{80,90})(?:['"\x60\s;\\]|$)'''
 keywords = ["kraken"]
 
 [[rules]]
@@ -2340,19 +2340,19 @@ regexes = [
 [[rules]]
 id = "kucoin-access-token"
 description = "Found a Kucoin Access Token, risking unauthorized access to cryptocurrency exchange services and transactions."
-regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{24})(?:['"\x60\s;\\]|$)'''
 keywords = ["kucoin"]
 
 [[rules]]
 id = "kucoin-secret-key"
 description = "Discovered a Kucoin Secret Key, which could lead to compromised cryptocurrency operations and financial data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\]|$)'''
 keywords = ["kucoin"]
 
 [[rules]]
 id = "launchdarkly-access-token"
 description = "Uncovered a Launchdarkly Access Token, potentially compromising feature flag management and application functionality."
-regex = '''(?i)[\w.-]{0,50}?(?:launchdarkly)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:launchdarkly)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{40})(?:['"\x60\s;\\]|$)'''
 keywords = ["launchdarkly"]
 
 [[rules]]
@@ -2365,14 +2365,14 @@ keywords = ["lin_api_"]
 [[rules]]
 id = "linear-client-secret"
 description = "Identified a Linear Client Secret, which may compromise secure integrations and sensitive project management data."
-regex = '''(?i)[\w.-]{0,50}?(?:linear)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linear)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = ["linear"]
 
 [[rules]]
 id = "linkedin-client-id"
 description = "Found a LinkedIn Client ID, risking unauthorized access to LinkedIn integrations and professional data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{14})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{14})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = [
     "linkedin",
@@ -2383,7 +2383,7 @@ keywords = [
 [[rules]]
 id = "linkedin-client-secret"
 description = "Discovered a LinkedIn Client secret, potentially compromising LinkedIn application integrations and user data."
-regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{16})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{16})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = [
     "linkedin",
@@ -2394,7 +2394,7 @@ keywords = [
 [[rules]]
 id = "lob-api-key"
 description = "Uncovered a Lob API Key, which could lead to unauthorized access to mailing and address verification services."
-regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}((live|test)_[a-f0-9]{35})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}((live|test)_[a-f0-9]{35})(?:['"\x60\s;\\]|$)'''
 keywords = [
     "test_",
     "live_",
@@ -2403,7 +2403,7 @@ keywords = [
 [[rules]]
 id = "lob-pub-api-key"
 description = "Detected a Lob Publishable API Key, posing a risk of exposing mail and print service integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}((test|live)_pub_[a-f0-9]{31})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}((test|live)_pub_[a-f0-9]{31})(?:['"\x60\s;\\]|$)'''
 keywords = [
     "test_pub",
     "live_pub",
@@ -2413,43 +2413,43 @@ keywords = [
 [[rules]]
 id = "mailchimp-api-key"
 description = "Identified a Mailchimp API key, potentially compromising email marketing campaigns and subscriber data."
-regex = '''(?i)[\w.-]{0,50}?(?:MailchimpSDK.initialize|mailchimp)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32}-us\d\d)(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:MailchimpSDK.initialize|mailchimp)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{32}-us\d\d)(?:['"\x60\s;\\]|$)'''
 keywords = ["mailchimp"]
 
 [[rules]]
 id = "mailgun-private-api-token"
 description = "Found a Mailgun private API token, risking unauthorized email service operations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(key-[a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(key-[a-f0-9]{32})(?:['"\x60\s;\\]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mailgun-pub-key"
 description = "Discovered a Mailgun public validation key, which could expose email verification processes and associated data."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(pubkey-[a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(pubkey-[a-f0-9]{32})(?:['"\x60\s;\\]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mailgun-signing-key"
 description = "Uncovered a Mailgun webhook signing key, potentially compromising email automation and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})(?:['"\x60\s;\\]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mapbox-api-token"
 description = "Detected a MapBox API token, posing a risk to geospatial services and sensitive location data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:mapbox)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(pk\.[a-z0-9]{60}\.[a-z0-9]{22})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mapbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(pk\.[a-z0-9]{60}\.[a-z0-9]{22})(?:['"\x60\s;\\]|$)'''
 keywords = ["mapbox"]
 
 [[rules]]
 id = "mattermost-access-token"
 description = "Identified a Mattermost Access Token, which may compromise team communication channels and data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:mattermost)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{26})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mattermost)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{26})(?:['"\x60\s;\\]|$)'''
 keywords = ["mattermost"]
 
 [[rules]]
 id = "messagebird-api-token"
 description = "Found a MessageBird API token, risking unauthorized access to communication platforms and message data."
-regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{25})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{25})(?:['"\x60\s;\\]|$)'''
 keywords = [
     "messagebird",
     "message-bird",
@@ -2459,7 +2459,7 @@ keywords = [
 [[rules]]
 id = "messagebird-client-id"
 description = "Discovered a MessageBird client ID, potentially compromising API integrations and sensitive communication data."
-regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\]|$)'''
 keywords = [
     "messagebird",
     "message-bird",
@@ -2479,25 +2479,25 @@ keywords = [
 [[rules]]
 id = "netlify-access-token"
 description = "Detected a Netlify Access Token, potentially compromising web hosting services and site management."
-regex = '''(?i)[\w.-]{0,50}?(?:netlify)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{40,46})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:netlify)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{40,46})(?:['"\x60\s;\\]|$)'''
 keywords = ["netlify"]
 
 [[rules]]
 id = "new-relic-browser-api-token"
 description = "Identified a New Relic ingest browser API token, risking unauthorized access to application performance data and analytics."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(NRJS-[a-f0-9]{19})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(NRJS-[a-f0-9]{19})(?:['"\x60\s;\\]|$)'''
 keywords = ["nrjs-"]
 
 [[rules]]
 id = "new-relic-insert-key"
 description = "Discovered a New Relic insight insert key, compromising data injection into the platform."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(NRII-[a-z0-9-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(NRII-[a-z0-9-]{32})(?:['"\x60\s;\\]|$)'''
 keywords = ["nrii-"]
 
 [[rules]]
 id = "new-relic-user-api-id"
 description = "Found a New Relic user API ID, posing a risk to application monitoring services and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\]|$)'''
 keywords = [
     "new-relic",
     "newrelic",
@@ -2507,13 +2507,13 @@ keywords = [
 [[rules]]
 id = "new-relic-user-api-key"
 description = "Discovered a New Relic user API Key, which could lead to compromised application insights and performance monitoring."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(NRAK-[a-z0-9]{27})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(NRAK-[a-z0-9]{27})(?:['"\x60\s;\\]|$)'''
 keywords = ["nrak"]
 
 [[rules]]
 id = "npm-access-token"
 description = "Uncovered an npm access token, potentially compromising package management and code repository access."
-regex = '''(?i)\b(npm_[a-z0-9]{36})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)\b(npm_[a-z0-9]{36})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = ["npm_"]
 
@@ -2535,7 +2535,7 @@ regexes = [
 [[rules]]
 id = "nytimes-access-token"
 description = "Detected a Nytimes Access Token, risking unauthorized access to New York Times APIs and content services."
-regex = '''(?i)[\w.-]{0,50}?(?:nytimes|new-york-times,|newyorktimes)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:nytimes|new-york-times,|newyorktimes)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{32})(?:['"\x60\s;\\]|$)'''
 keywords = [
     "nytimes",
     "new-york-times",
@@ -2545,21 +2545,21 @@ keywords = [
 [[rules]]
 id = "octopus-deploy-api-key"
 description = "Discovered a potential Octopus Deploy API key, risking application deployments and operational security."
-regex = '''\b(API-[A-Z0-9]{26})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(API-[A-Z0-9]{26})(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = ["api-"]
 
 [[rules]]
 id = "okta-access-token"
 description = "Identified an Okta Access Token, which may compromise identity management services and user authentication data."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Oo]kta|OKTA))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3})(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(00[\w=\-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Oo]kta|OKTA))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(00[\w=\-]{40})(?:['"\x60\s;\\]|$)'''
 entropy = 4
 keywords = ["okta"]
 
 [[rules]]
 id = "openai-api-key"
 description = "Found an OpenAI API Key, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''\b(sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = ["t3blbkfj"]
 
@@ -2573,55 +2573,55 @@ keywords = ["sha256~"]
 [[rules]]
 id = "plaid-api-token"
 description = "Discovered a Plaid API Token, potentially compromising financial data aggregation and banking services."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\]|$)'''
 keywords = ["plaid"]
 
 [[rules]]
 id = "plaid-client-id"
 description = "Uncovered a Plaid Client ID, which could lead to unauthorized financial service integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{24})(?:['"\x60\s;\\]|$)'''
 entropy = 3.5
 keywords = ["plaid"]
 
 [[rules]]
 id = "plaid-secret-key"
 description = "Detected a Plaid Secret key, risking unauthorized access to financial accounts and sensitive transaction data."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{30})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{30})(?:['"\x60\s;\\]|$)'''
 entropy = 3.5
 keywords = ["plaid"]
 
 [[rules]]
 id = "planetscale-api-token"
 description = "Identified a PlanetScale API token, potentially compromising database management and operations."
-regex = '''\b(pscale_tkn_(?i)[\w=\.-]{32,64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(pscale_tkn_(?i)[\w=\.-]{32,64})(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = ["pscale_tkn_"]
 
 [[rules]]
 id = "planetscale-oauth-token"
 description = "Found a PlanetScale OAuth token, posing a risk to database access control and sensitive data integrity."
-regex = '''\b(pscale_oauth_[\w=\.-]{32,64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(pscale_oauth_[\w=\.-]{32,64})(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = ["pscale_oauth_"]
 
 [[rules]]
 id = "planetscale-password"
 description = "Discovered a PlanetScale password, which could lead to unauthorized database operations and data breaches."
-regex = '''(?i)\b(pscale_pw_(?i)[\w=\.-]{32,64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)\b(pscale_pw_(?i)[\w=\.-]{32,64})(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = ["pscale_pw_"]
 
 [[rules]]
 id = "postman-api-token"
 description = "Uncovered a Postman API token, potentially compromising API testing and development workflows."
-regex = '''\b(PMAK-(?i)[a-f0-9]{24}\-[a-f0-9]{34})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(PMAK-(?i)[a-f0-9]{24}\-[a-f0-9]{34})(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = ["pmak-"]
 
 [[rules]]
 id = "prefect-api-token"
 description = "Detected a Prefect API token, risking unauthorized access to workflow management and automation services."
-regex = '''\b(pnu_[a-zA-Z0-9]{36})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(pnu_[a-zA-Z0-9]{36})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = ["pnu_"]
 
@@ -2634,7 +2634,7 @@ keywords = ["-----begin"]
 [[rules]]
 id = "privateai-api-token"
 description = "Identified a PrivateAI Token, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:private[_-]?ai)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3})(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:private[_-]?ai)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = [
     "privateai",
@@ -2645,7 +2645,7 @@ keywords = [
 [[rules]]
 id = "pulumi-api-token"
 description = "Found a Pulumi API token, posing a risk to infrastructure as code services and cloud resource management."
-regex = '''\b(pul-[a-f0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(pul-[a-f0-9]{40})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = ["pul-"]
 
@@ -2659,66 +2659,66 @@ keywords = ["pypi-ageichlwas5vcmc"]
 [[rules]]
 id = "rapidapi-access-token"
 description = "Uncovered a RapidAPI Access Token, which could lead to unauthorized access to various APIs and data services."
-regex = '''(?i)[\w.-]{0,50}?(?:rapidapi)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{50})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:rapidapi)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9_-]{50})(?:['"\x60\s;\\]|$)'''
 keywords = ["rapidapi"]
 
 [[rules]]
 id = "readme-api-token"
 description = "Detected a Readme API token, risking unauthorized documentation management and content exposure."
-regex = '''\b(rdme_[a-z0-9]{70})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(rdme_[a-z0-9]{70})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = ["rdme_"]
 
 [[rules]]
 id = "rubygems-api-token"
 description = "Identified a Rubygem API token, potentially compromising Ruby library distribution and package management."
-regex = '''\b(rubygems_[a-f0-9]{48})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(rubygems_[a-f0-9]{48})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = ["rubygems_"]
 
 [[rules]]
 id = "scalingo-api-token"
 description = "Found a Scalingo API token, posing a risk to cloud platform services and application deployment security."
-regex = '''\b(tk-us-[\w-]{48})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(tk-us-[\w-]{48})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = ["tk-us-"]
 
 [[rules]]
 id = "sendbird-access-id"
 description = "Discovered a Sendbird Access ID, which could compromise chat and messaging platform integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\]|$)'''
 keywords = ["sendbird"]
 
 [[rules]]
 id = "sendbird-access-token"
 description = "Uncovered a Sendbird Access Token, potentially risking unauthorized access to communication services and user data."
-regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{40})(?:['"\x60\s;\\]|$)'''
 keywords = ["sendbird"]
 
 [[rules]]
 id = "sendgrid-api-token"
 description = "Detected a SendGrid API token, posing a risk of unauthorized email service operations and data exposure."
-regex = '''\b(SG\.(?i)[a-z0-9=_\-\.]{66})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(SG\.(?i)[a-z0-9=_\-\.]{66})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = ["sg."]
 
 [[rules]]
 id = "sendinblue-api-token"
 description = "Identified a Sendinblue API token, which may compromise email marketing services and subscriber data privacy."
-regex = '''\b(xkeysib-[a-f0-9]{64}\-(?i)[a-z0-9]{16})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(xkeysib-[a-f0-9]{64}\-(?i)[a-z0-9]{16})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = ["xkeysib-"]
 
 [[rules]]
 id = "sentry-access-token"
 description = "Found a Sentry Access Token, risking unauthorized access to error tracking services and sensitive application data."
-regex = '''(?i)[\w.-]{0,50}?(?:sentry)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sentry)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{64})(?:['"\x60\s;\\]|$)'''
 keywords = ["sentry"]
 
 [[rules]]
 id = "shippo-api-token"
 description = "Discovered a Shippo API token, potentially compromising shipping services and customer order data."
-regex = '''\b(shippo_(?:live|test)_[a-fA-F0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(shippo_(?:live|test)_[a-fA-F0-9]{40})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = ["shippo_"]
 
@@ -2753,7 +2753,7 @@ keywords = ["shpss_"]
 [[rules]]
 id = "sidekiq-secret"
 description = "Discovered a Sidekiq Secret, which could lead to compromised background job processing and application data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:BUNDLE_ENTERPRISE__CONTRIBSYS__COM|BUNDLE_GEMS__CONTRIBSYS__COM)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{8}:[a-f0-9]{8})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:BUNDLE_ENTERPRISE__CONTRIBSYS__COM|BUNDLE_GEMS__CONTRIBSYS__COM)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{8}:[a-f0-9]{8})(?:['"\x60\s;\\]|$)'''
 keywords = [
     "bundle_enterprise__contribsys__com",
     "bundle_gems__contribsys__com",
@@ -2845,13 +2845,13 @@ keywords = ["hooks.slack.com"]
 [[rules]]
 id = "snyk-api-token"
 description = "Uncovered a Snyk API token, potentially compromising software vulnerability scanning and code security."
-regex = '''(?i)[\w.-]{0,50}?(?:snyk[_.-]?(?:(?:api|oauth)[_.-]?)?(?:key|token))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:snyk[_.-]?(?:(?:api|oauth)[_.-]?)?(?:key|token))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\]|$)'''
 keywords = ["snyk"]
 
 [[rules]]
 id = "square-access-token"
 description = "Detected a Square Access Token, risking unauthorized payment processing and financial transaction exposure."
-regex = '''\b((?:EAAA|sq0atp-)[\w-]{22,60})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b((?:EAAA|sq0atp-)[\w-]{22,60})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = [
     "sq0atp-",
@@ -2861,13 +2861,13 @@ keywords = [
 [[rules]]
 id = "squarespace-access-token"
 description = "Identified a Squarespace Access Token, which may compromise website management and content control on Squarespace."
-regex = '''(?i)[\w.-]{0,50}?(?:squarespace)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:squarespace)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\]|$)'''
 keywords = ["squarespace"]
 
 [[rules]]
 id = "stripe-access-token"
 description = "Found a Stripe Access Token, posing a risk to payment processing services and sensitive financial data."
-regex = '''\b((?:sk|rk)_(?:test|live|prod)_[a-zA-Z0-9]{10,99})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b((?:sk|rk)_(?:test|live|prod)_[a-zA-Z0-9]{10,99})(?:['"\x60\s;\\]|$)'''
 entropy = 2
 keywords = [
     "sk_test",
@@ -2881,27 +2881,27 @@ keywords = [
 [[rules]]
 id = "sumologic-access-id"
 description = "Discovered a SumoLogic Access ID, potentially compromising log management services and data analytics integrity."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3})(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(su[a-zA-Z0-9]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(su[a-zA-Z0-9]{12})(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = ["sumo"]
 
 [[rules]]
 id = "sumologic-access-token"
 description = "Uncovered a SumoLogic Access Token, which could lead to unauthorized access to log data and analytics insights."
-regex = '''(?i)[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\]|$)'''
 entropy = 3
 keywords = ["sumo"]
 
 [[rules]]
 id = "telegram-bot-api-token"
 description = "Detected a Telegram Bot API Token, risking unauthorized bot operations and message interception on Telegram."
-regex = '''(?i:telegr(?:[0-9a-z\(-_\t .\\]{0,40})(?:[\s|']|[\s|"]){0,3})(?:=|\|\|:|<=|=>|:|\?=|\()(?:'|\"|\s|=|\x60){0,5}([0-9]{5,16}:A[a-z0-9_\-]{34})(?:['|\"|\n|\r|\s|\x60|;|\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:telegr)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9]{5,16}:(?-i:A)[a-z0-9_\-]{34})(?:['"\x60\s;\\]|$)'''
 keywords = ["telegr"]
 
 [[rules]]
 id = "travisci-access-token"
 description = "Identified a Travis CI Access Token, potentially compromising continuous integration services and codebase security."
-regex = '''(?i)[\w.-]{0,50}?(?:travis)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{22})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:travis)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{22})(?:['"\x60\s;\\]|$)'''
 keywords = ["travis"]
 
 [[rules]]
@@ -2914,56 +2914,56 @@ keywords = ["sk"]
 [[rules]]
 id = "twitch-api-token"
 description = "Discovered a Twitch API token, which could compromise streaming services and account integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:twitch)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{30})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitch)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{30})(?:['"\x60\s;\\]|$)'''
 keywords = ["twitch"]
 
 [[rules]]
 id = "twitter-access-secret"
 description = "Uncovered a Twitter Access Secret, potentially risking unauthorized Twitter integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{45})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{45})(?:['"\x60\s;\\]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-access-token"
 description = "Detected a Twitter Access Token, posing a risk of unauthorized account operations and social media data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9]{15,25}-[a-zA-Z0-9]{20,40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9]{15,25}-[a-zA-Z0-9]{20,40})(?:['"\x60\s;\\]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-api-key"
 description = "Identified a Twitter API Key, which may compromise Twitter application integrations and user data security."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{25})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{25})(?:['"\x60\s;\\]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-api-secret"
 description = "Found a Twitter API Secret, risking the security of Twitter app integrations and sensitive data access."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{50})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{50})(?:['"\x60\s;\\]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-bearer-token"
 description = "Discovered a Twitter Bearer Token, potentially compromising API access and data retrieval from Twitter."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(A{22}[a-zA-Z0-9%]{80,100})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(A{22}[a-zA-Z0-9%]{80,100})(?:['"\x60\s;\\]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "typeform-api-token"
 description = "Uncovered a Typeform API token, which could lead to unauthorized survey management and data collection."
-regex = '''(?i)[\w.-]{0,50}?(?:typeform)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(tfp_[a-z0-9\-_\.=]{59})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:typeform)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(tfp_[a-z0-9\-_\.=]{59})(?:['"\x60\s;\\]|$)'''
 keywords = ["tfp_"]
 
 [[rules]]
 id = "vault-batch-token"
 description = "Detected a Vault Batch Token, risking unauthorized access to secret management services and sensitive data."
-regex = '''\b(hvb\.[\w-]{138,300})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b(hvb\.[\w-]{138,300})(?:['"\x60\s;\\]|$)'''
 entropy = 4
 keywords = ["hvb."]
 
 [[rules]]
 id = "vault-service-token"
 description = "Identified a Vault Service Token, potentially compromising infrastructure security and access to sensitive credentials."
-regex = '''\b((?:hvs\.[\w-]{90,120}|s\.(?i:[a-z0-9]{24})))(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b((?:hvs\.[\w-]{90,120}|s\.(?i:[a-z0-9]{24})))(?:['"\x60\s;\\]|$)'''
 entropy = 3.5
 keywords = [
     "hvs.",
@@ -2978,24 +2978,24 @@ regexes = [
 [[rules]]
 id = "yandex-access-token"
 description = "Found a Yandex Access Token, posing a risk to Yandex service integrations and user data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})(?:['"\x60\s;\\]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "yandex-api-key"
 description = "Discovered a Yandex API Key, which could lead to unauthorized access to Yandex services and data manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(AQVN[A-Za-z0-9_\-]{35,38})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(AQVN[A-Za-z0-9_\-]{35,38})(?:['"\x60\s;\\]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "yandex-aws-access-token"
 description = "Uncovered a Yandex AWS Access Token, potentially compromising cloud resource access and data security on Yandex Cloud."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(YC[a-zA-Z0-9_\-]{38})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(YC[a-zA-Z0-9_\-]{38})(?:['"\x60\s;\\]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "zendesk-secret-key"
 description = "Detected a Zendesk Secret Key, risking unauthorized access to customer support services and sensitive ticketing data."
-regex = '''(?i)[\w.-]{0,50}?(?:zendesk)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:zendesk)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{40})(?:['"\x60\s;\\]|$)'''
 keywords = ["zendesk"]
 

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -67,20 +67,20 @@ keywords = ["ops_"]
 [[rules]]
 id = "adafruit-api-key"
 description = "Identified a potential Adafruit API Key, which could lead to unauthorized access to Adafruit services and sensitive data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:adafruit)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9_-]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:adafruit)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9_-]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["adafruit"]
 
 [[rules]]
 id = "adobe-client-id"
 description = "Detected a pattern that resembles an Adobe OAuth Web Client ID, posing a risk of compromised Adobe integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:adobe)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:adobe)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = ["adobe"]
 
 [[rules]]
 id = "adobe-client-secret"
 description = "Discovered a potential Adobe Client Secret, which, if exposed, could allow unauthorized Adobe service access and data manipulation."
-regex = '''\b(p8e-(?i)[a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(p8e-(?i)[a-z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = ["p8e-"]
 
@@ -93,45 +93,45 @@ keywords = ["age-secret-key-1"]
 [[rules]]
 id = "airtable-api-key"
 description = "Uncovered a possible Airtable API Key, potentially compromising database access and leading to data leakage or alteration."
-regex = '''(?i)[\w.-]{0,50}?(?:airtable)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{17})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:airtable)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{17})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["airtable"]
 
 [[rules]]
 id = "algolia-api-key"
 description = "Identified an Algolia API Key, which could result in unauthorized search operations and data exposure on Algolia-managed platforms."
-regex = '''(?i)[\w.-]{0,50}?(?:algolia)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:algolia)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["algolia"]
 
 [[rules]]
 id = "alibaba-access-key-id"
 description = "Detected an Alibaba Cloud AccessKey ID, posing a risk of unauthorized cloud resource access and potential data compromise."
-regex = '''\b(LTAI(?i)[a-z0-9]{20})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(LTAI(?i)[a-z0-9]{20})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = ["ltai"]
 
 [[rules]]
 id = "alibaba-secret-key"
 description = "Discovered a potential Alibaba Cloud Secret Key, potentially allowing unauthorized operations and data access within Alibaba Cloud."
-regex = '''(?i)[\w.-]{0,50}?(?:alibaba)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{30})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:alibaba)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{30})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = ["alibaba"]
 
 [[rules]]
 id = "asana-client-id"
 description = "Discovered a potential Asana Client ID, risking unauthorized access to Asana projects and sensitive task information."
-regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9]{16})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9]{16})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["asana"]
 
 [[rules]]
 id = "asana-client-secret"
 description = "Identified an Asana Client Secret, which could lead to compromised project management integrity and unauthorized access."
-regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["asana"]
 
 [[rules]]
 id = "atlassian-api-token"
 description = "Detected an Atlassian API token, posing a threat to project management and collaboration tool security and data confidentiality."
-regex = '''(?i)[\w.-]{0,50}?(?:atlassian|confluence|jira)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{24})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:atlassian|confluence|jira)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{24})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = [
     "atlassian",
     "confluence",
@@ -141,7 +141,7 @@ keywords = [
 [[rules]]
 id = "authress-service-client-access-key"
 description = "Uncovered a possible Authress Service Client Access Key, which may compromise access control services and sensitive data."
-regex = '''\b((?:sc|ext|scauth|authress)_(?i)[a-z0-9]{5,30}\.[a-z0-9]{4,6}\.(?-i:acc)[_-][a-z0-9-]{10,32}\.[a-z0-9+/_=-]{30,120})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b((?:sc|ext|scauth|authress)_(?i)[a-z0-9]{5,30}\.[a-z0-9]{4,6}\.(?-i:acc)[_-][a-z0-9-]{10,32}\.[a-z0-9+/_=-]{30,120})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "sc_",
@@ -178,31 +178,31 @@ keywords = ["q~"]
 [[rules]]
 id = "beamer-api-token"
 description = "Detected a Beamer API token, potentially compromising content management and exposing sensitive notifications and updates."
-regex = '''(?i)[\w.-]{0,50}?(?:beamer)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(b_[a-z0-9=_\-]{44})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:beamer)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(b_[a-z0-9=_\-]{44})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["beamer"]
 
 [[rules]]
 id = "bitbucket-client-id"
 description = "Discovered a potential Bitbucket Client ID, risking unauthorized repository access and potential codebase exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["bitbucket"]
 
 [[rules]]
 id = "bitbucket-client-secret"
 description = "Discovered a potential Bitbucket Client Secret, posing a risk of compromised code repositories and unauthorized access."
-regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["bitbucket"]
 
 [[rules]]
 id = "bittrex-access-key"
 description = "Identified a Bittrex Access Key, which could lead to unauthorized access to cryptocurrency trading accounts and financial loss."
-regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["bittrex"]
 
 [[rules]]
 id = "bittrex-secret-key"
 description = "Detected a Bittrex Secret Key, potentially compromising cryptocurrency transactions and financial security."
-regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["bittrex"]
 
 [[rules]]
@@ -215,21 +215,21 @@ keywords = ["clojars_"]
 [[rules]]
 id = "cloudflare-api-key"
 description = "Detected a Cloudflare API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9_-]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9_-]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = ["cloudflare"]
 
 [[rules]]
 id = "cloudflare-global-api-key"
 description = "Detected a Cloudflare Global API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{37})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{37})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = ["cloudflare"]
 
 [[rules]]
 id = "cloudflare-origin-ca-key"
 description = "Detected a Cloudflare Origin CA Key, potentially compromising cloud application deployments and operational security."
-regex = '''\b(v1\.0-[a-f0-9]{24}-[a-f0-9]{146})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(v1\.0-[a-f0-9]{24}-[a-f0-9]{146})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "cloudflare",
@@ -239,13 +239,13 @@ keywords = [
 [[rules]]
 id = "codecov-access-token"
 description = "Found a pattern resembling a Codecov Access Token, posing a risk of unauthorized access to code coverage reports and sensitive data."
-regex = '''(?i)[\w.-]{0,50}?(?:codecov)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:codecov)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["codecov"]
 
 [[rules]]
 id = "cohere-api-token"
 description = "Identified a Cohere Token, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:cohere|CO_API_KEY)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-zA-Z0-9]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:cohere|CO_API_KEY)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-zA-Z0-9]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 4
 keywords = [
     "cohere",
@@ -255,25 +255,25 @@ keywords = [
 [[rules]]
 id = "coinbase-access-token"
 description = "Detected a Coinbase Access Token, posing a risk of unauthorized access to cryptocurrency accounts and financial transactions."
-regex = '''(?i)[\w.-]{0,50}?(?:coinbase)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9_-]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:coinbase)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9_-]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["coinbase"]
 
 [[rules]]
 id = "confluent-access-token"
 description = "Identified a Confluent Access Token, which could compromise access to streaming data platforms and sensitive data flow."
-regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{16})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{16})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["confluent"]
 
 [[rules]]
 id = "confluent-secret-key"
 description = "Found a Confluent Secret Key, potentially risking unauthorized operations and data access within Confluent services."
-regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["confluent"]
 
 [[rules]]
 id = "contentful-delivery-api-token"
 description = "Discovered a Contentful delivery API token, posing a risk to content management systems and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:contentful)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{43})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:contentful)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{43})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["contentful"]
 
 [[rules]]
@@ -303,59 +303,59 @@ regexes = [
 [[rules]]
 id = "databricks-api-token"
 description = "Uncovered a Databricks API token, which may compromise big data analytics platforms and sensitive data processing."
-regex = '''\b(dapi[a-f0-9]{32}(?:-\d)?)(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(dapi[a-f0-9]{32}(?:-\d)?)(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = ["dapi"]
 
 [[rules]]
 id = "datadog-access-token"
 description = "Detected a Datadog Access Token, potentially risking monitoring and analytics data exposure and manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:datadog)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:datadog)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["datadog"]
 
 [[rules]]
 id = "defined-networking-api-token"
 description = "Identified a Defined Networking API token, which could lead to unauthorized network operations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:dnkey)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dnkey)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["dnkey"]
 
 [[rules]]
 id = "digitalocean-access-token"
 description = "Found a DigitalOcean OAuth Access Token, risking unauthorized cloud resource access and data compromise."
-regex = '''\b(doo_v1_[a-f0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(doo_v1_[a-f0-9]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = ["doo_v1_"]
 
 [[rules]]
 id = "digitalocean-pat"
 description = "Discovered a DigitalOcean Personal Access Token, posing a threat to cloud infrastructure security and data privacy."
-regex = '''\b(dop_v1_[a-f0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(dop_v1_[a-f0-9]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = ["dop_v1_"]
 
 [[rules]]
 id = "digitalocean-refresh-token"
 description = "Uncovered a DigitalOcean OAuth Refresh Token, which could allow prolonged unauthorized access and resource manipulation."
-regex = '''(?i)\b(dor_v1_[a-f0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)\b(dor_v1_[a-f0-9]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["dor_v1_"]
 
 [[rules]]
 id = "discord-api-token"
 description = "Detected a Discord API key, potentially compromising communication channels and user data privacy on Discord."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["discord"]
 
 [[rules]]
 id = "discord-client-id"
 description = "Identified a Discord client ID, which may lead to unauthorized integrations and data exposure in Discord applications."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9]{18})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9]{18})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = ["discord"]
 
 [[rules]]
 id = "discord-client-secret"
 description = "Discovered a potential Discord client secret, risking compromised Discord bot integrations and data leaks."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = ["discord"]
 
@@ -369,25 +369,25 @@ keywords = ["dp.pt."]
 [[rules]]
 id = "droneci-access-token"
 description = "Detected a Droneci Access Token, potentially compromising continuous integration and deployment workflows."
-regex = '''(?i)[\w.-]{0,50}?(?:droneci)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:droneci)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["droneci"]
 
 [[rules]]
 id = "dropbox-api-token"
 description = "Identified a Dropbox API secret, which could lead to unauthorized file access and data breaches in Dropbox storage."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{15})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{15})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
 id = "dropbox-long-lived-api-token"
 description = "Found a Dropbox long-lived API token, risking prolonged unauthorized access to cloud storage and sensitive data."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
 id = "dropbox-short-lived-api-token"
 description = "Discovered a Dropbox short-lived API token, posing a risk of temporary but potentially harmful data access and manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(sl\.[a-z0-9\-=_]{135})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(sl\.[a-z0-9\-=_]{135})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
@@ -421,20 +421,20 @@ keywords = ["eztk"]
 [[rules]]
 id = "etsy-access-token"
 description = "Found an Etsy Access Token, potentially compromising Etsy shop management and customer data."
-regex = '''(?i)[\w.-]{0,50}?(?:(?-i:ETSY|[Ee]tsy))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{24})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:(?-i:ETSY|[Ee]tsy))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{24})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = ["etsy"]
 
 [[rules]]
 id = "facebook-access-token"
 description = "Discovered a Facebook Access Token, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''(?i)\b(\d{15,16}(\||%)[0-9a-z\-_]{27,40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)\b(\d{15,16}(\||%)[0-9a-z\-_]{27,40})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 
 [[rules]]
 id = "facebook-page-access-token"
 description = "Discovered a Facebook Page Access Token, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''\b(EAA[MC](?i)[a-z0-9]{100,})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(EAA[MC](?i)[a-z0-9]{100,})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 4
 keywords = [
     "eaam",
@@ -444,38 +444,38 @@ keywords = [
 [[rules]]
 id = "facebook-secret"
 description = "Discovered a Facebook Application secret, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:facebook)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:facebook)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = ["facebook"]
 
 [[rules]]
 id = "fastly-api-token"
 description = "Uncovered a Fastly API key, which may compromise CDN and edge cloud services, leading to content delivery and security issues."
-regex = '''(?i)[\w.-]{0,50}?(?:fastly)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:fastly)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["fastly"]
 
 [[rules]]
 id = "finicity-api-token"
 description = "Detected a Finicity API token, potentially risking financial data access and unauthorized financial operations."
-regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["finicity"]
 
 [[rules]]
 id = "finicity-client-secret"
 description = "Identified a Finicity Client Secret, which could lead to compromised financial service integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{20})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{20})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["finicity"]
 
 [[rules]]
 id = "finnhub-access-token"
 description = "Found a Finnhub Access Token, risking unauthorized access to financial market data and analytics."
-regex = '''(?i)[\w.-]{0,50}?(?:finnhub)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{20})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finnhub)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{20})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["finnhub"]
 
 [[rules]]
 id = "flickr-access-token"
 description = "Discovered a Flickr Access Token, posing a risk of unauthorized photo management and potential data leakage."
-regex = '''(?i)[\w.-]{0,50}?(?:flickr)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:flickr)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["flickr"]
 
 [[rules]]
@@ -502,7 +502,7 @@ keywords = ["flwseck_test"]
 [[rules]]
 id = "flyio-access-token"
 description = "Uncovered a Fly.io API key"
-regex = '''\b((?:fo1_[\w-]{43}|fm1[ar]_[a-zA-Z0-9+\/]{100,}={0,3}|fm2_[a-zA-Z0-9+\/]{100,}={0,3}))(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b((?:fo1_[\w-]{43}|fm1[ar]_[a-zA-Z0-9+\/]{100,}={0,3}|fm2_[a-zA-Z0-9+\/]{100,}={0,3}))(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 4
 keywords = [
     "fo1_",
@@ -519,20 +519,20 @@ keywords = ["fio-u-"]
 [[rules]]
 id = "freshbooks-access-token"
 description = "Discovered a Freshbooks Access Token, posing a risk to accounting software access and sensitive financial data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:freshbooks)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:freshbooks)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["freshbooks"]
 
 [[rules]]
 id = "gcp-api-key"
 description = "Uncovered a GCP API key, which could lead to unauthorized access to Google Cloud services and data breaches."
-regex = '''\b(AIza[\w-]{35})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(AIza[\w-]{35})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = ["aiza"]
 
 [[rules]]
 id = "generic-api-key"
 description = "Detected a Generic API Key, potentially exposing access to various services and sensitive operations."
-regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passwd|password|secret|token)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([\w.=-]{10,150})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passwd|password|secret|token)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([\w.=-]{10,150})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3.5
 keywords = [
     "access",
@@ -2173,13 +2173,13 @@ keywords = ["_gitlab_session="]
 [[rules]]
 id = "gitter-access-token"
 description = "Uncovered a Gitter Access Token, which may lead to unauthorized access to chat and communication services."
-regex = '''(?i)[\w.-]{0,50}?(?:gitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9_-]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:gitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9_-]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["gitter"]
 
 [[rules]]
 id = "gocardless-api-token"
 description = "Detected a GoCardless API token, potentially risking unauthorized direct debit payment operations and financial data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:gocardless)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(live_(?i)[a-z0-9\-_=]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:gocardless)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(live_(?i)[a-z0-9\-_=]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = [
     "live_",
     "gocardless",
@@ -2188,21 +2188,21 @@ keywords = [
 [[rules]]
 id = "grafana-api-key"
 description = "Identified a Grafana API key, which could compromise monitoring dashboards and sensitive data analytics."
-regex = '''(?i)\b(eyJrIjoi[A-Za-z0-9]{70,400}={0,3})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)\b(eyJrIjoi[A-Za-z0-9]{70,400}={0,3})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = ["eyjrijoi"]
 
 [[rules]]
 id = "grafana-cloud-api-token"
 description = "Found a Grafana cloud API token, risking unauthorized access to cloud-based monitoring services and data exposure."
-regex = '''(?i)\b(glc_[A-Za-z0-9+/]{32,400}={0,3})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)\b(glc_[A-Za-z0-9+/]{32,400}={0,3})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = ["glc_"]
 
 [[rules]]
 id = "grafana-service-account-token"
 description = "Discovered a Grafana service account token, posing a risk of compromised monitoring services and data integrity."
-regex = '''(?i)\b(glsa_[A-Za-z0-9]{32}_[A-Fa-f0-9]{8})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)\b(glsa_[A-Za-z0-9]{32}_[A-Fa-f0-9]{8})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = ["glsa_"]
 
@@ -2225,7 +2225,7 @@ keywords = ["atlasv1"]
 [[rules]]
 id = "hashicorp-tf-password"
 description = "Identified a HashiCorp Terraform password field, risking unauthorized infrastructure configuration and security breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:administrator_login_password|password)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}("[a-z0-9=_\-]{8,20}")(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:administrator_login_password|password)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}("[a-z0-9=_\-]{8,20}")(?:[\s\'\"\x60&;\\<,)]|$)'''
 path = '''(?i)\.(?:tf|hcl)$'''
 entropy = 2
 keywords = [
@@ -2236,46 +2236,46 @@ keywords = [
 [[rules]]
 id = "heroku-api-key"
 description = "Detected a Heroku API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:heroku)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:heroku)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["heroku"]
 
 [[rules]]
 id = "hubspot-api-key"
 description = "Found a HubSpot API Token, posing a risk to CRM data integrity and unauthorized marketing operations."
-regex = '''(?i)[\w.-]{0,50}?(?:hubspot)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:hubspot)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["hubspot"]
 
 [[rules]]
 id = "huggingface-access-token"
 description = "Discovered a Hugging Face Access token, which could lead to unauthorized access to AI models and sensitive data."
-regex = '''\b(hf_(?i:[a-z]{34}))(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(hf_(?i:[a-z]{34}))(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = ["hf_"]
 
 [[rules]]
 id = "huggingface-organization-api-token"
 description = "Uncovered a Hugging Face Organization API token, potentially compromising AI organization accounts and associated data."
-regex = '''\b(api_org_(?i:[a-z]{34}))(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(api_org_(?i:[a-z]{34}))(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = ["api_org_"]
 
 [[rules]]
 id = "infracost-api-token"
 description = "Detected an Infracost API Token, risking unauthorized access to cloud cost estimation tools and financial data."
-regex = '''\b(ico-[a-zA-Z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(ico-[a-zA-Z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = ["ico-"]
 
 [[rules]]
 id = "intercom-api-key"
 description = "Identified an Intercom API Token, which could compromise customer communication channels and data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:intercom)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{60})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:intercom)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{60})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["intercom"]
 
 [[rules]]
 id = "intra42-client-secret"
 description = "Found a Intra42 client secret, which could lead to unauthorized access to the 42School API and sensitive data."
-regex = '''\b(s-s4t2(?:ud|af)-(?i)[abcdef0123456789]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(s-s4t2(?:ud|af)-(?i)[abcdef0123456789]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = [
     "intra",
@@ -2286,7 +2286,7 @@ keywords = [
 [[rules]]
 id = "jfrog-api-key"
 description = "Found a JFrog API Key, posing a risk of unauthorized access to software artifact repositories and build pipelines."
-regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{73})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{73})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = [
     "jfrog",
     "artifactory",
@@ -2297,7 +2297,7 @@ keywords = [
 [[rules]]
 id = "jfrog-identity-token"
 description = "Discovered a JFrog Identity Token, potentially compromising access to JFrog services and sensitive software artifacts."
-regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = [
     "jfrog",
     "artifactory",
@@ -2308,7 +2308,7 @@ keywords = [
 [[rules]]
 id = "jwt"
 description = "Uncovered a JSON Web Token, which may lead to unauthorized access to web applications and sensitive user data."
-regex = '''\b(ey[a-zA-Z0-9]{17,}\.ey[a-zA-Z0-9\/\\_-]{17,}\.(?:[a-zA-Z0-9\/\\_-]{10,}={0,2})?)(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(ey[a-zA-Z0-9]{17,}\.ey[a-zA-Z0-9\/\\_-]{17,}\.(?:[a-zA-Z0-9\/\\_-]{10,}={0,2})?)(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = ["ey"]
 
@@ -2322,7 +2322,7 @@ keywords = ["zxlk"]
 [[rules]]
 id = "kraken-access-token"
 description = "Identified a Kraken Access Token, potentially compromising cryptocurrency trading accounts and financial security."
-regex = '''(?i)[\w.-]{0,50}?(?:kraken)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9\/=_\+\-]{80,90})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kraken)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9\/=_\+\-]{80,90})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["kraken"]
 
 [[rules]]
@@ -2340,19 +2340,19 @@ regexes = [
 [[rules]]
 id = "kucoin-access-token"
 description = "Found a Kucoin Access Token, risking unauthorized access to cryptocurrency exchange services and transactions."
-regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{24})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{24})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["kucoin"]
 
 [[rules]]
 id = "kucoin-secret-key"
 description = "Discovered a Kucoin Secret Key, which could lead to compromised cryptocurrency operations and financial data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["kucoin"]
 
 [[rules]]
 id = "launchdarkly-access-token"
 description = "Uncovered a Launchdarkly Access Token, potentially compromising feature flag management and application functionality."
-regex = '''(?i)[\w.-]{0,50}?(?:launchdarkly)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:launchdarkly)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["launchdarkly"]
 
 [[rules]]
@@ -2365,14 +2365,14 @@ keywords = ["lin_api_"]
 [[rules]]
 id = "linear-client-secret"
 description = "Identified a Linear Client Secret, which may compromise secure integrations and sensitive project management data."
-regex = '''(?i)[\w.-]{0,50}?(?:linear)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linear)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = ["linear"]
 
 [[rules]]
 id = "linkedin-client-id"
 description = "Found a LinkedIn Client ID, risking unauthorized access to LinkedIn integrations and professional data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{14})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{14})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "linkedin",
@@ -2383,7 +2383,7 @@ keywords = [
 [[rules]]
 id = "linkedin-client-secret"
 description = "Discovered a LinkedIn Client secret, potentially compromising LinkedIn application integrations and user data."
-regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{16})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{16})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "linkedin",
@@ -2394,7 +2394,7 @@ keywords = [
 [[rules]]
 id = "lob-api-key"
 description = "Uncovered a Lob API Key, which could lead to unauthorized access to mailing and address verification services."
-regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}((live|test)_[a-f0-9]{35})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}((live|test)_[a-f0-9]{35})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = [
     "test_",
     "live_",
@@ -2403,7 +2403,7 @@ keywords = [
 [[rules]]
 id = "lob-pub-api-key"
 description = "Detected a Lob Publishable API Key, posing a risk of exposing mail and print service integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}((test|live)_pub_[a-f0-9]{31})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}((test|live)_pub_[a-f0-9]{31})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = [
     "test_pub",
     "live_pub",
@@ -2413,43 +2413,43 @@ keywords = [
 [[rules]]
 id = "mailchimp-api-key"
 description = "Identified a Mailchimp API key, potentially compromising email marketing campaigns and subscriber data."
-regex = '''(?i)[\w.-]{0,50}?(?:MailchimpSDK.initialize|mailchimp)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{32}-us\d\d)(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:MailchimpSDK.initialize|mailchimp)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{32}-us\d\d)(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["mailchimp"]
 
 [[rules]]
 id = "mailgun-private-api-token"
 description = "Found a Mailgun private API token, risking unauthorized email service operations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(key-[a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(key-[a-f0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mailgun-pub-key"
 description = "Discovered a Mailgun public validation key, which could expose email verification processes and associated data."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(pubkey-[a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(pubkey-[a-f0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mailgun-signing-key"
 description = "Uncovered a Mailgun webhook signing key, potentially compromising email automation and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mapbox-api-token"
 description = "Detected a MapBox API token, posing a risk to geospatial services and sensitive location data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:mapbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(pk\.[a-z0-9]{60}\.[a-z0-9]{22})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mapbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(pk\.[a-z0-9]{60}\.[a-z0-9]{22})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["mapbox"]
 
 [[rules]]
 id = "mattermost-access-token"
 description = "Identified a Mattermost Access Token, which may compromise team communication channels and data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:mattermost)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{26})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mattermost)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{26})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["mattermost"]
 
 [[rules]]
 id = "messagebird-api-token"
 description = "Found a MessageBird API token, risking unauthorized access to communication platforms and message data."
-regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{25})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{25})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = [
     "messagebird",
     "message-bird",
@@ -2459,7 +2459,7 @@ keywords = [
 [[rules]]
 id = "messagebird-client-id"
 description = "Discovered a MessageBird client ID, potentially compromising API integrations and sensitive communication data."
-regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = [
     "messagebird",
     "message-bird",
@@ -2479,25 +2479,25 @@ keywords = [
 [[rules]]
 id = "netlify-access-token"
 description = "Detected a Netlify Access Token, potentially compromising web hosting services and site management."
-regex = '''(?i)[\w.-]{0,50}?(?:netlify)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{40,46})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:netlify)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{40,46})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["netlify"]
 
 [[rules]]
 id = "new-relic-browser-api-token"
 description = "Identified a New Relic ingest browser API token, risking unauthorized access to application performance data and analytics."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(NRJS-[a-f0-9]{19})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(NRJS-[a-f0-9]{19})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["nrjs-"]
 
 [[rules]]
 id = "new-relic-insert-key"
 description = "Discovered a New Relic insight insert key, compromising data injection into the platform."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(NRII-[a-z0-9-]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(NRII-[a-z0-9-]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["nrii-"]
 
 [[rules]]
 id = "new-relic-user-api-id"
 description = "Found a New Relic user API ID, posing a risk to application monitoring services and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = [
     "new-relic",
     "newrelic",
@@ -2507,13 +2507,13 @@ keywords = [
 [[rules]]
 id = "new-relic-user-api-key"
 description = "Discovered a New Relic user API Key, which could lead to compromised application insights and performance monitoring."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(NRAK-[a-z0-9]{27})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(NRAK-[a-z0-9]{27})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["nrak"]
 
 [[rules]]
 id = "npm-access-token"
 description = "Uncovered an npm access token, potentially compromising package management and code repository access."
-regex = '''(?i)\b(npm_[a-z0-9]{36})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)\b(npm_[a-z0-9]{36})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = ["npm_"]
 
@@ -2535,7 +2535,7 @@ regexes = [
 [[rules]]
 id = "nytimes-access-token"
 description = "Detected a Nytimes Access Token, risking unauthorized access to New York Times APIs and content services."
-regex = '''(?i)[\w.-]{0,50}?(?:nytimes|new-york-times,|newyorktimes)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:nytimes|new-york-times,|newyorktimes)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = [
     "nytimes",
     "new-york-times",
@@ -2545,21 +2545,21 @@ keywords = [
 [[rules]]
 id = "octopus-deploy-api-key"
 description = "Discovered a potential Octopus Deploy API key, risking application deployments and operational security."
-regex = '''\b(API-[A-Z0-9]{26})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(API-[A-Z0-9]{26})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = ["api-"]
 
 [[rules]]
 id = "okta-access-token"
 description = "Identified an Okta Access Token, which may compromise identity management services and user authentication data."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Oo]kta|OKTA))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(00[\w=\-]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Oo]kta|OKTA))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(00[\w=\-]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 4
 keywords = ["okta"]
 
 [[rules]]
 id = "openai-api-key"
 description = "Found an OpenAI API Key, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''\b(sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = ["t3blbkfj"]
 
@@ -2573,55 +2573,55 @@ keywords = ["sha256~"]
 [[rules]]
 id = "plaid-api-token"
 description = "Discovered a Plaid API Token, potentially compromising financial data aggregation and banking services."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["plaid"]
 
 [[rules]]
 id = "plaid-client-id"
 description = "Uncovered a Plaid Client ID, which could lead to unauthorized financial service integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{24})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{24})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3.5
 keywords = ["plaid"]
 
 [[rules]]
 id = "plaid-secret-key"
 description = "Detected a Plaid Secret key, risking unauthorized access to financial accounts and sensitive transaction data."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{30})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{30})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3.5
 keywords = ["plaid"]
 
 [[rules]]
 id = "planetscale-api-token"
 description = "Identified a PlanetScale API token, potentially compromising database management and operations."
-regex = '''\b(pscale_tkn_(?i)[\w=\.-]{32,64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(pscale_tkn_(?i)[\w=\.-]{32,64})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = ["pscale_tkn_"]
 
 [[rules]]
 id = "planetscale-oauth-token"
 description = "Found a PlanetScale OAuth token, posing a risk to database access control and sensitive data integrity."
-regex = '''\b(pscale_oauth_[\w=\.-]{32,64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(pscale_oauth_[\w=\.-]{32,64})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = ["pscale_oauth_"]
 
 [[rules]]
 id = "planetscale-password"
 description = "Discovered a PlanetScale password, which could lead to unauthorized database operations and data breaches."
-regex = '''(?i)\b(pscale_pw_(?i)[\w=\.-]{32,64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)\b(pscale_pw_(?i)[\w=\.-]{32,64})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = ["pscale_pw_"]
 
 [[rules]]
 id = "postman-api-token"
 description = "Uncovered a Postman API token, potentially compromising API testing and development workflows."
-regex = '''\b(PMAK-(?i)[a-f0-9]{24}\-[a-f0-9]{34})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(PMAK-(?i)[a-f0-9]{24}\-[a-f0-9]{34})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = ["pmak-"]
 
 [[rules]]
 id = "prefect-api-token"
 description = "Detected a Prefect API token, risking unauthorized access to workflow management and automation services."
-regex = '''\b(pnu_[a-zA-Z0-9]{36})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(pnu_[a-zA-Z0-9]{36})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = ["pnu_"]
 
@@ -2634,7 +2634,7 @@ keywords = ["-----begin"]
 [[rules]]
 id = "privateai-api-token"
 description = "Identified a PrivateAI Token, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:private[_-]?ai)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:private[_-]?ai)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = [
     "privateai",
@@ -2645,7 +2645,7 @@ keywords = [
 [[rules]]
 id = "pulumi-api-token"
 description = "Found a Pulumi API token, posing a risk to infrastructure as code services and cloud resource management."
-regex = '''\b(pul-[a-f0-9]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(pul-[a-f0-9]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = ["pul-"]
 
@@ -2659,66 +2659,66 @@ keywords = ["pypi-ageichlwas5vcmc"]
 [[rules]]
 id = "rapidapi-access-token"
 description = "Uncovered a RapidAPI Access Token, which could lead to unauthorized access to various APIs and data services."
-regex = '''(?i)[\w.-]{0,50}?(?:rapidapi)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9_-]{50})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:rapidapi)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9_-]{50})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["rapidapi"]
 
 [[rules]]
 id = "readme-api-token"
 description = "Detected a Readme API token, risking unauthorized documentation management and content exposure."
-regex = '''\b(rdme_[a-z0-9]{70})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(rdme_[a-z0-9]{70})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = ["rdme_"]
 
 [[rules]]
 id = "rubygems-api-token"
 description = "Identified a Rubygem API token, potentially compromising Ruby library distribution and package management."
-regex = '''\b(rubygems_[a-f0-9]{48})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(rubygems_[a-f0-9]{48})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = ["rubygems_"]
 
 [[rules]]
 id = "scalingo-api-token"
 description = "Found a Scalingo API token, posing a risk to cloud platform services and application deployment security."
-regex = '''\b(tk-us-[\w-]{48})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(tk-us-[\w-]{48})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = ["tk-us-"]
 
 [[rules]]
 id = "sendbird-access-id"
 description = "Discovered a Sendbird Access ID, which could compromise chat and messaging platform integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["sendbird"]
 
 [[rules]]
 id = "sendbird-access-token"
 description = "Uncovered a Sendbird Access Token, potentially risking unauthorized access to communication services and user data."
-regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["sendbird"]
 
 [[rules]]
 id = "sendgrid-api-token"
 description = "Detected a SendGrid API token, posing a risk of unauthorized email service operations and data exposure."
-regex = '''\b(SG\.(?i)[a-z0-9=_\-\.]{66})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(SG\.(?i)[a-z0-9=_\-\.]{66})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = ["sg."]
 
 [[rules]]
 id = "sendinblue-api-token"
 description = "Identified a Sendinblue API token, which may compromise email marketing services and subscriber data privacy."
-regex = '''\b(xkeysib-[a-f0-9]{64}\-(?i)[a-z0-9]{16})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(xkeysib-[a-f0-9]{64}\-(?i)[a-z0-9]{16})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = ["xkeysib-"]
 
 [[rules]]
 id = "sentry-access-token"
 description = "Found a Sentry Access Token, risking unauthorized access to error tracking services and sensitive application data."
-regex = '''(?i)[\w.-]{0,50}?(?:sentry)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sentry)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["sentry"]
 
 [[rules]]
 id = "shippo-api-token"
 description = "Discovered a Shippo API token, potentially compromising shipping services and customer order data."
-regex = '''\b(shippo_(?:live|test)_[a-fA-F0-9]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(shippo_(?:live|test)_[a-fA-F0-9]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = ["shippo_"]
 
@@ -2753,7 +2753,7 @@ keywords = ["shpss_"]
 [[rules]]
 id = "sidekiq-secret"
 description = "Discovered a Sidekiq Secret, which could lead to compromised background job processing and application data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:BUNDLE_ENTERPRISE__CONTRIBSYS__COM|BUNDLE_GEMS__CONTRIBSYS__COM)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{8}:[a-f0-9]{8})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:BUNDLE_ENTERPRISE__CONTRIBSYS__COM|BUNDLE_GEMS__CONTRIBSYS__COM)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{8}:[a-f0-9]{8})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = [
     "bundle_enterprise__contribsys__com",
     "bundle_gems__contribsys__com",
@@ -2845,13 +2845,13 @@ keywords = ["hooks.slack.com"]
 [[rules]]
 id = "snyk-api-token"
 description = "Uncovered a Snyk API token, potentially compromising software vulnerability scanning and code security."
-regex = '''(?i)[\w.-]{0,50}?(?:snyk[_.-]?(?:(?:api|oauth)[_.-]?)?(?:key|token))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:snyk[_.-]?(?:(?:api|oauth)[_.-]?)?(?:key|token))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["snyk"]
 
 [[rules]]
 id = "square-access-token"
 description = "Detected a Square Access Token, risking unauthorized payment processing and financial transaction exposure."
-regex = '''\b((?:EAAA|sq0atp-)[\w-]{22,60})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b((?:EAAA|sq0atp-)[\w-]{22,60})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "sq0atp-",
@@ -2861,13 +2861,13 @@ keywords = [
 [[rules]]
 id = "squarespace-access-token"
 description = "Identified a Squarespace Access Token, which may compromise website management and content control on Squarespace."
-regex = '''(?i)[\w.-]{0,50}?(?:squarespace)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:squarespace)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["squarespace"]
 
 [[rules]]
 id = "stripe-access-token"
 description = "Found a Stripe Access Token, posing a risk to payment processing services and sensitive financial data."
-regex = '''\b((?:sk|rk)_(?:test|live|prod)_[a-zA-Z0-9]{10,99})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b((?:sk|rk)_(?:test|live|prod)_[a-zA-Z0-9]{10,99})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "sk_test",
@@ -2881,27 +2881,27 @@ keywords = [
 [[rules]]
 id = "sumologic-access-id"
 description = "Discovered a SumoLogic Access ID, potentially compromising log management services and data analytics integrity."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(su[a-zA-Z0-9]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(su[a-zA-Z0-9]{12})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = ["sumo"]
 
 [[rules]]
 id = "sumologic-access-token"
 description = "Uncovered a SumoLogic Access Token, which could lead to unauthorized access to log data and analytics insights."
-regex = '''(?i)[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3
 keywords = ["sumo"]
 
 [[rules]]
 id = "telegram-bot-api-token"
 description = "Detected a Telegram Bot API Token, risking unauthorized bot operations and message interception on Telegram."
-regex = '''(?i)[\w.-]{0,50}?(?:telegr)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9]{5,16}:(?-i:A)[a-z0-9_\-]{34})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:telegr)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9]{5,16}:(?-i:A)[a-z0-9_\-]{34})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["telegr"]
 
 [[rules]]
 id = "travisci-access-token"
 description = "Identified a Travis CI Access Token, potentially compromising continuous integration services and codebase security."
-regex = '''(?i)[\w.-]{0,50}?(?:travis)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{22})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:travis)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{22})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["travis"]
 
 [[rules]]
@@ -2914,56 +2914,56 @@ keywords = ["sk"]
 [[rules]]
 id = "twitch-api-token"
 description = "Discovered a Twitch API token, which could compromise streaming services and account integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:twitch)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{30})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitch)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{30})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["twitch"]
 
 [[rules]]
 id = "twitter-access-secret"
 description = "Uncovered a Twitter Access Secret, potentially risking unauthorized Twitter integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{45})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{45})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-access-token"
 description = "Detected a Twitter Access Token, posing a risk of unauthorized account operations and social media data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9]{15,25}-[a-zA-Z0-9]{20,40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9]{15,25}-[a-zA-Z0-9]{20,40})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-api-key"
 description = "Identified a Twitter API Key, which may compromise Twitter application integrations and user data security."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{25})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{25})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-api-secret"
 description = "Found a Twitter API Secret, risking the security of Twitter app integrations and sensitive data access."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{50})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{50})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-bearer-token"
 description = "Discovered a Twitter Bearer Token, potentially compromising API access and data retrieval from Twitter."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(A{22}[a-zA-Z0-9%]{80,100})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(A{22}[a-zA-Z0-9%]{80,100})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "typeform-api-token"
 description = "Uncovered a Typeform API token, which could lead to unauthorized survey management and data collection."
-regex = '''(?i)[\w.-]{0,50}?(?:typeform)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(tfp_[a-z0-9\-_\.=]{59})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:typeform)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(tfp_[a-z0-9\-_\.=]{59})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["tfp_"]
 
 [[rules]]
 id = "vault-batch-token"
 description = "Detected a Vault Batch Token, risking unauthorized access to secret management services and sensitive data."
-regex = '''\b(hvb\.[\w-]{138,300})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b(hvb\.[\w-]{138,300})(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 4
 keywords = ["hvb."]
 
 [[rules]]
 id = "vault-service-token"
 description = "Identified a Vault Service Token, potentially compromising infrastructure security and access to sensitive credentials."
-regex = '''\b((?:hvs\.[\w-]{90,120}|s\.(?i:[a-z0-9]{24})))(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''\b((?:hvs\.[\w-]{90,120}|s\.(?i:[a-z0-9]{24})))(?:[\s\'\"\x60&;\\<,)]|$)'''
 entropy = 3.5
 keywords = [
     "hvs.",
@@ -2978,24 +2978,24 @@ regexes = [
 [[rules]]
 id = "yandex-access-token"
 description = "Found a Yandex Access Token, posing a risk to Yandex service integrations and user data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "yandex-api-key"
 description = "Discovered a Yandex API Key, which could lead to unauthorized access to Yandex services and data manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(AQVN[A-Za-z0-9_\-]{35,38})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(AQVN[A-Za-z0-9_\-]{35,38})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "yandex-aws-access-token"
 description = "Uncovered a Yandex AWS Access Token, potentially compromising cloud resource access and data security on Yandex Cloud."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(YC[a-zA-Z0-9_\-]{38})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(YC[a-zA-Z0-9_\-]{38})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "zendesk-secret-key"
 description = "Detected a Zendesk Secret Key, risking unauthorized access to customer support services and sensitive ticketing data."
-regex = '''(?i)[\w.-]{0,50}?(?:zendesk)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:zendesk)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
 keywords = ["zendesk"]
 

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -67,13 +67,13 @@ keywords = ["ops_"]
 [[rules]]
 id = "adafruit-api-key"
 description = "Identified a potential Adafruit API Key, which could lead to unauthorized access to Adafruit services and sensitive data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:adafruit)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9_-]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:adafruit)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9_-]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["adafruit"]
 
 [[rules]]
 id = "adobe-client-id"
 description = "Detected a pattern that resembles an Adobe OAuth Web Client ID, posing a risk of compromised Adobe integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:adobe)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:adobe)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["adobe"]
 
@@ -93,13 +93,13 @@ keywords = ["age-secret-key-1"]
 [[rules]]
 id = "airtable-api-key"
 description = "Uncovered a possible Airtable API Key, potentially compromising database access and leading to data leakage or alteration."
-regex = '''(?i)[\w.-]{0,50}?(?:airtable)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{17})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:airtable)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{17})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["airtable"]
 
 [[rules]]
 id = "algolia-api-key"
 description = "Identified an Algolia API Key, which could result in unauthorized search operations and data exposure on Algolia-managed platforms."
-regex = '''(?i)[\w.-]{0,50}?(?:algolia)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:algolia)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["algolia"]
 
 [[rules]]
@@ -112,26 +112,26 @@ keywords = ["ltai"]
 [[rules]]
 id = "alibaba-secret-key"
 description = "Discovered a potential Alibaba Cloud Secret Key, potentially allowing unauthorized operations and data access within Alibaba Cloud."
-regex = '''(?i)[\w.-]{0,50}?(?:alibaba)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{30})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:alibaba)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{30})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["alibaba"]
 
 [[rules]]
 id = "asana-client-id"
 description = "Discovered a potential Asana Client ID, risking unauthorized access to Asana projects and sensitive task information."
-regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9]{16})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9]{16})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["asana"]
 
 [[rules]]
 id = "asana-client-secret"
 description = "Identified an Asana Client Secret, which could lead to compromised project management integrity and unauthorized access."
-regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["asana"]
 
 [[rules]]
 id = "atlassian-api-token"
 description = "Detected an Atlassian API token, posing a threat to project management and collaboration tool security and data confidentiality."
-regex = '''(?i)[\w.-]{0,50}?(?:atlassian|confluence|jira)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{24})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:atlassian|confluence|jira)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{24})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "atlassian",
     "confluence",
@@ -178,31 +178,31 @@ keywords = ["q~"]
 [[rules]]
 id = "beamer-api-token"
 description = "Detected a Beamer API token, potentially compromising content management and exposing sensitive notifications and updates."
-regex = '''(?i)[\w.-]{0,50}?(?:beamer)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(b_[a-z0-9=_\-]{44})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:beamer)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(b_[a-z0-9=_\-]{44})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["beamer"]
 
 [[rules]]
 id = "bitbucket-client-id"
 description = "Discovered a potential Bitbucket Client ID, risking unauthorized repository access and potential codebase exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["bitbucket"]
 
 [[rules]]
 id = "bitbucket-client-secret"
 description = "Discovered a potential Bitbucket Client Secret, posing a risk of compromised code repositories and unauthorized access."
-regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9=_\-]{64})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["bitbucket"]
 
 [[rules]]
 id = "bittrex-access-key"
 description = "Identified a Bittrex Access Key, which could lead to unauthorized access to cryptocurrency trading accounts and financial loss."
-regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["bittrex"]
 
 [[rules]]
 id = "bittrex-secret-key"
 description = "Detected a Bittrex Secret Key, potentially compromising cryptocurrency transactions and financial security."
-regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["bittrex"]
 
 [[rules]]
@@ -215,14 +215,14 @@ keywords = ["clojars_"]
 [[rules]]
 id = "cloudflare-api-key"
 description = "Detected a Cloudflare API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9_-]{40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9_-]{40})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["cloudflare"]
 
 [[rules]]
 id = "cloudflare-global-api-key"
 description = "Detected a Cloudflare Global API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{37})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{37})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["cloudflare"]
 
@@ -239,13 +239,13 @@ keywords = [
 [[rules]]
 id = "codecov-access-token"
 description = "Found a pattern resembling a Codecov Access Token, posing a risk of unauthorized access to code coverage reports and sensitive data."
-regex = '''(?i)[\w.-]{0,50}?(?:codecov)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:codecov)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["codecov"]
 
 [[rules]]
 id = "cohere-api-token"
 description = "Identified a Cohere Token, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:cohere|CO_API_KEY)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-zA-Z0-9]{40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:cohere|CO_API_KEY)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-zA-Z0-9]{40})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 4
 keywords = [
     "cohere",
@@ -255,25 +255,25 @@ keywords = [
 [[rules]]
 id = "coinbase-access-token"
 description = "Detected a Coinbase Access Token, posing a risk of unauthorized access to cryptocurrency accounts and financial transactions."
-regex = '''(?i)[\w.-]{0,50}?(?:coinbase)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9_-]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:coinbase)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9_-]{64})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["coinbase"]
 
 [[rules]]
 id = "confluent-access-token"
 description = "Identified a Confluent Access Token, which could compromise access to streaming data platforms and sensitive data flow."
-regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{16})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{16})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["confluent"]
 
 [[rules]]
 id = "confluent-secret-key"
 description = "Found a Confluent Secret Key, potentially risking unauthorized operations and data access within Confluent services."
-regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["confluent"]
 
 [[rules]]
 id = "contentful-delivery-api-token"
 description = "Discovered a Contentful delivery API token, posing a risk to content management systems and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:contentful)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{43})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:contentful)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9=_\-]{43})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["contentful"]
 
 [[rules]]
@@ -310,13 +310,13 @@ keywords = ["dapi"]
 [[rules]]
 id = "datadog-access-token"
 description = "Detected a Datadog Access Token, potentially risking monitoring and analytics data exposure and manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:datadog)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:datadog)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{40})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["datadog"]
 
 [[rules]]
 id = "defined-networking-api-token"
 description = "Identified a Defined Networking API token, which could lead to unauthorized network operations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:dnkey)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dnkey)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["dnkey"]
 
 [[rules]]
@@ -342,20 +342,20 @@ keywords = ["dor_v1_"]
 [[rules]]
 id = "discord-api-token"
 description = "Detected a Discord API key, potentially compromising communication channels and user data privacy on Discord."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["discord"]
 
 [[rules]]
 id = "discord-client-id"
 description = "Identified a Discord client ID, which may lead to unauthorized integrations and data exposure in Discord applications."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9]{18})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9]{18})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["discord"]
 
 [[rules]]
 id = "discord-client-secret"
 description = "Discovered a potential Discord client secret, risking compromised Discord bot integrations and data leaks."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9=_\-]{32})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["discord"]
 
@@ -369,25 +369,25 @@ keywords = ["dp.pt."]
 [[rules]]
 id = "droneci-access-token"
 description = "Detected a Droneci Access Token, potentially compromising continuous integration and deployment workflows."
-regex = '''(?i)[\w.-]{0,50}?(?:droneci)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:droneci)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["droneci"]
 
 [[rules]]
 id = "dropbox-api-token"
 description = "Identified a Dropbox API secret, which could lead to unauthorized file access and data breaches in Dropbox storage."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{15})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{15})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
 id = "dropbox-long-lived-api-token"
 description = "Found a Dropbox long-lived API token, risking prolonged unauthorized access to cloud storage and sensitive data."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
 id = "dropbox-short-lived-api-token"
 description = "Discovered a Dropbox short-lived API token, posing a risk of temporary but potentially harmful data access and manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(sl\.[a-z0-9\-=_]{135})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(sl\.[a-z0-9\-=_]{135})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
@@ -421,7 +421,7 @@ keywords = ["eztk"]
 [[rules]]
 id = "etsy-access-token"
 description = "Found an Etsy Access Token, potentially compromising Etsy shop management and customer data."
-regex = '''(?i)[\w.-]{0,50}?(?:(?-i:ETSY|[Ee]tsy))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{24})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:(?-i:ETSY|[Ee]tsy))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{24})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["etsy"]
 
@@ -444,38 +444,38 @@ keywords = [
 [[rules]]
 id = "facebook-secret"
 description = "Discovered a Facebook Application secret, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:facebook)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:facebook)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["facebook"]
 
 [[rules]]
 id = "fastly-api-token"
 description = "Uncovered a Fastly API key, which may compromise CDN and edge cloud services, leading to content delivery and security issues."
-regex = '''(?i)[\w.-]{0,50}?(?:fastly)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:fastly)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9=_\-]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["fastly"]
 
 [[rules]]
 id = "finicity-api-token"
 description = "Detected a Finicity API token, potentially risking financial data access and unauthorized financial operations."
-regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["finicity"]
 
 [[rules]]
 id = "finicity-client-secret"
 description = "Identified a Finicity Client Secret, which could lead to compromised financial service integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{20})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{20})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["finicity"]
 
 [[rules]]
 id = "finnhub-access-token"
 description = "Found a Finnhub Access Token, risking unauthorized access to financial market data and analytics."
-regex = '''(?i)[\w.-]{0,50}?(?:finnhub)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{20})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finnhub)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{20})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["finnhub"]
 
 [[rules]]
 id = "flickr-access-token"
 description = "Discovered a Flickr Access Token, posing a risk of unauthorized photo management and potential data leakage."
-regex = '''(?i)[\w.-]{0,50}?(?:flickr)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:flickr)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["flickr"]
 
 [[rules]]
@@ -519,7 +519,7 @@ keywords = ["fio-u-"]
 [[rules]]
 id = "freshbooks-access-token"
 description = "Discovered a Freshbooks Access Token, posing a risk to accounting software access and sensitive financial data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:freshbooks)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:freshbooks)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["freshbooks"]
 
 [[rules]]
@@ -532,7 +532,7 @@ keywords = ["aiza"]
 [[rules]]
 id = "generic-api-key"
 description = "Detected a Generic API Key, potentially exposing access to various services and sensitive operations."
-regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passwd|password|secret|token)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([\w.=-]{10,150})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passwd|password|secret|token)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([\w.=-]{10,150})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3.5
 keywords = [
     "access",
@@ -2173,13 +2173,13 @@ keywords = ["_gitlab_session="]
 [[rules]]
 id = "gitter-access-token"
 description = "Uncovered a Gitter Access Token, which may lead to unauthorized access to chat and communication services."
-regex = '''(?i)[\w.-]{0,50}?(?:gitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9_-]{40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:gitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9_-]{40})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["gitter"]
 
 [[rules]]
 id = "gocardless-api-token"
 description = "Detected a GoCardless API token, potentially risking unauthorized direct debit payment operations and financial data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:gocardless)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(live_(?i)[a-z0-9\-_=]{40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:gocardless)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(live_(?i)[a-z0-9\-_=]{40})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "live_",
     "gocardless",
@@ -2225,7 +2225,7 @@ keywords = ["atlasv1"]
 [[rules]]
 id = "hashicorp-tf-password"
 description = "Identified a HashiCorp Terraform password field, risking unauthorized infrastructure configuration and security breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:administrator_login_password|password)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}("[a-z0-9=_\-]{8,20}")(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:administrator_login_password|password)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}("[a-z0-9=_\-]{8,20}")(?:['"\x60\s;\\<,)]|$)'''
 path = '''(?i)\.(?:tf|hcl)$'''
 entropy = 2
 keywords = [
@@ -2236,13 +2236,13 @@ keywords = [
 [[rules]]
 id = "heroku-api-key"
 description = "Detected a Heroku API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:heroku)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:heroku)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["heroku"]
 
 [[rules]]
 id = "hubspot-api-key"
 description = "Found a HubSpot API Token, posing a risk to CRM data integrity and unauthorized marketing operations."
-regex = '''(?i)[\w.-]{0,50}?(?:hubspot)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:hubspot)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["hubspot"]
 
 [[rules]]
@@ -2269,7 +2269,7 @@ keywords = ["ico-"]
 [[rules]]
 id = "intercom-api-key"
 description = "Identified an Intercom API Token, which could compromise customer communication channels and data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:intercom)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{60})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:intercom)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9=_\-]{60})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["intercom"]
 
 [[rules]]
@@ -2286,7 +2286,7 @@ keywords = [
 [[rules]]
 id = "jfrog-api-key"
 description = "Found a JFrog API Key, posing a risk of unauthorized access to software artifact repositories and build pipelines."
-regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{73})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{73})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "jfrog",
     "artifactory",
@@ -2297,7 +2297,7 @@ keywords = [
 [[rules]]
 id = "jfrog-identity-token"
 description = "Discovered a JFrog Identity Token, potentially compromising access to JFrog services and sensitive software artifacts."
-regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "jfrog",
     "artifactory",
@@ -2322,7 +2322,7 @@ keywords = ["zxlk"]
 [[rules]]
 id = "kraken-access-token"
 description = "Identified a Kraken Access Token, potentially compromising cryptocurrency trading accounts and financial security."
-regex = '''(?i)[\w.-]{0,50}?(?:kraken)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9\/=_\+\-]{80,90})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kraken)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9\/=_\+\-]{80,90})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["kraken"]
 
 [[rules]]
@@ -2340,19 +2340,19 @@ regexes = [
 [[rules]]
 id = "kucoin-access-token"
 description = "Found a Kucoin Access Token, risking unauthorized access to cryptocurrency exchange services and transactions."
-regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{24})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{24})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["kucoin"]
 
 [[rules]]
 id = "kucoin-secret-key"
 description = "Discovered a Kucoin Secret Key, which could lead to compromised cryptocurrency operations and financial data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["kucoin"]
 
 [[rules]]
 id = "launchdarkly-access-token"
 description = "Uncovered a Launchdarkly Access Token, potentially compromising feature flag management and application functionality."
-regex = '''(?i)[\w.-]{0,50}?(?:launchdarkly)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:launchdarkly)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9=_\-]{40})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["launchdarkly"]
 
 [[rules]]
@@ -2365,14 +2365,14 @@ keywords = ["lin_api_"]
 [[rules]]
 id = "linear-client-secret"
 description = "Identified a Linear Client Secret, which may compromise secure integrations and sensitive project management data."
-regex = '''(?i)[\w.-]{0,50}?(?:linear)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linear)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["linear"]
 
 [[rules]]
 id = "linkedin-client-id"
 description = "Found a LinkedIn Client ID, risking unauthorized access to LinkedIn integrations and professional data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{14})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{14})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "linkedin",
@@ -2383,7 +2383,7 @@ keywords = [
 [[rules]]
 id = "linkedin-client-secret"
 description = "Discovered a LinkedIn Client secret, potentially compromising LinkedIn application integrations and user data."
-regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{16})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{16})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "linkedin",
@@ -2394,7 +2394,7 @@ keywords = [
 [[rules]]
 id = "lob-api-key"
 description = "Uncovered a Lob API Key, which could lead to unauthorized access to mailing and address verification services."
-regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}((live|test)_[a-f0-9]{35})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}((live|test)_[a-f0-9]{35})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "test_",
     "live_",
@@ -2403,7 +2403,7 @@ keywords = [
 [[rules]]
 id = "lob-pub-api-key"
 description = "Detected a Lob Publishable API Key, posing a risk of exposing mail and print service integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}((test|live)_pub_[a-f0-9]{31})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}((test|live)_pub_[a-f0-9]{31})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "test_pub",
     "live_pub",
@@ -2413,43 +2413,43 @@ keywords = [
 [[rules]]
 id = "mailchimp-api-key"
 description = "Identified a Mailchimp API key, potentially compromising email marketing campaigns and subscriber data."
-regex = '''(?i)[\w.-]{0,50}?(?:MailchimpSDK.initialize|mailchimp)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{32}-us\d\d)(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:MailchimpSDK.initialize|mailchimp)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{32}-us\d\d)(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["mailchimp"]
 
 [[rules]]
 id = "mailgun-private-api-token"
 description = "Found a Mailgun private API token, risking unauthorized email service operations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(key-[a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(key-[a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mailgun-pub-key"
 description = "Discovered a Mailgun public validation key, which could expose email verification processes and associated data."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(pubkey-[a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(pubkey-[a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mailgun-signing-key"
 description = "Uncovered a Mailgun webhook signing key, potentially compromising email automation and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mapbox-api-token"
 description = "Detected a MapBox API token, posing a risk to geospatial services and sensitive location data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:mapbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(pk\.[a-z0-9]{60}\.[a-z0-9]{22})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mapbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(pk\.[a-z0-9]{60}\.[a-z0-9]{22})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["mapbox"]
 
 [[rules]]
 id = "mattermost-access-token"
 description = "Identified a Mattermost Access Token, which may compromise team communication channels and data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:mattermost)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{26})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mattermost)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{26})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["mattermost"]
 
 [[rules]]
 id = "messagebird-api-token"
 description = "Found a MessageBird API token, risking unauthorized access to communication platforms and message data."
-regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{25})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{25})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "messagebird",
     "message-bird",
@@ -2459,7 +2459,7 @@ keywords = [
 [[rules]]
 id = "messagebird-client-id"
 description = "Discovered a MessageBird client ID, potentially compromising API integrations and sensitive communication data."
-regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "messagebird",
     "message-bird",
@@ -2479,25 +2479,25 @@ keywords = [
 [[rules]]
 id = "netlify-access-token"
 description = "Detected a Netlify Access Token, potentially compromising web hosting services and site management."
-regex = '''(?i)[\w.-]{0,50}?(?:netlify)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{40,46})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:netlify)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9=_\-]{40,46})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["netlify"]
 
 [[rules]]
 id = "new-relic-browser-api-token"
 description = "Identified a New Relic ingest browser API token, risking unauthorized access to application performance data and analytics."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(NRJS-[a-f0-9]{19})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(NRJS-[a-f0-9]{19})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["nrjs-"]
 
 [[rules]]
 id = "new-relic-insert-key"
 description = "Discovered a New Relic insight insert key, compromising data injection into the platform."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(NRII-[a-z0-9-]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(NRII-[a-z0-9-]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["nrii-"]
 
 [[rules]]
 id = "new-relic-user-api-id"
 description = "Found a New Relic user API ID, posing a risk to application monitoring services and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "new-relic",
     "newrelic",
@@ -2507,7 +2507,7 @@ keywords = [
 [[rules]]
 id = "new-relic-user-api-key"
 description = "Discovered a New Relic user API Key, which could lead to compromised application insights and performance monitoring."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(NRAK-[a-z0-9]{27})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(NRAK-[a-z0-9]{27})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["nrak"]
 
 [[rules]]
@@ -2535,7 +2535,7 @@ regexes = [
 [[rules]]
 id = "nytimes-access-token"
 description = "Detected a Nytimes Access Token, risking unauthorized access to New York Times APIs and content services."
-regex = '''(?i)[\w.-]{0,50}?(?:nytimes|new-york-times,|newyorktimes)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:nytimes|new-york-times,|newyorktimes)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9=_\-]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "nytimes",
     "new-york-times",
@@ -2552,7 +2552,7 @@ keywords = ["api-"]
 [[rules]]
 id = "okta-access-token"
 description = "Identified an Okta Access Token, which may compromise identity management services and user authentication data."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Oo]kta|OKTA))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(00[\w=\-]{40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Oo]kta|OKTA))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(00[\w=\-]{40})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 4
 keywords = ["okta"]
 
@@ -2573,20 +2573,20 @@ keywords = ["sha256~"]
 [[rules]]
 id = "plaid-api-token"
 description = "Discovered a Plaid API Token, potentially compromising financial data aggregation and banking services."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["plaid"]
 
 [[rules]]
 id = "plaid-client-id"
 description = "Uncovered a Plaid Client ID, which could lead to unauthorized financial service integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{24})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{24})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3.5
 keywords = ["plaid"]
 
 [[rules]]
 id = "plaid-secret-key"
 description = "Detected a Plaid Secret key, risking unauthorized access to financial accounts and sensitive transaction data."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{30})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{30})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3.5
 keywords = ["plaid"]
 
@@ -2634,7 +2634,7 @@ keywords = ["-----begin"]
 [[rules]]
 id = "privateai-api-token"
 description = "Identified a PrivateAI Token, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:private[_-]?ai)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:private[_-]?ai)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = [
     "privateai",
@@ -2659,7 +2659,7 @@ keywords = ["pypi-ageichlwas5vcmc"]
 [[rules]]
 id = "rapidapi-access-token"
 description = "Uncovered a RapidAPI Access Token, which could lead to unauthorized access to various APIs and data services."
-regex = '''(?i)[\w.-]{0,50}?(?:rapidapi)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9_-]{50})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:rapidapi)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9_-]{50})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["rapidapi"]
 
 [[rules]]
@@ -2686,13 +2686,13 @@ keywords = ["tk-us-"]
 [[rules]]
 id = "sendbird-access-id"
 description = "Discovered a Sendbird Access ID, which could compromise chat and messaging platform integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["sendbird"]
 
 [[rules]]
 id = "sendbird-access-token"
 description = "Uncovered a Sendbird Access Token, potentially risking unauthorized access to communication services and user data."
-regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{40})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["sendbird"]
 
 [[rules]]
@@ -2712,7 +2712,7 @@ keywords = ["xkeysib-"]
 [[rules]]
 id = "sentry-access-token"
 description = "Found a Sentry Access Token, risking unauthorized access to error tracking services and sensitive application data."
-regex = '''(?i)[\w.-]{0,50}?(?:sentry)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sentry)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["sentry"]
 
 [[rules]]
@@ -2753,7 +2753,7 @@ keywords = ["shpss_"]
 [[rules]]
 id = "sidekiq-secret"
 description = "Discovered a Sidekiq Secret, which could lead to compromised background job processing and application data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:BUNDLE_ENTERPRISE__CONTRIBSYS__COM|BUNDLE_GEMS__CONTRIBSYS__COM)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{8}:[a-f0-9]{8})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:BUNDLE_ENTERPRISE__CONTRIBSYS__COM|BUNDLE_GEMS__CONTRIBSYS__COM)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{8}:[a-f0-9]{8})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "bundle_enterprise__contribsys__com",
     "bundle_gems__contribsys__com",
@@ -2845,7 +2845,7 @@ keywords = ["hooks.slack.com"]
 [[rules]]
 id = "snyk-api-token"
 description = "Uncovered a Snyk API token, potentially compromising software vulnerability scanning and code security."
-regex = '''(?i)[\w.-]{0,50}?(?:snyk[_.-]?(?:(?:api|oauth)[_.-]?)?(?:key|token))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:snyk[_.-]?(?:(?:api|oauth)[_.-]?)?(?:key|token))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["snyk"]
 
 [[rules]]
@@ -2861,7 +2861,7 @@ keywords = [
 [[rules]]
 id = "squarespace-access-token"
 description = "Identified a Squarespace Access Token, which may compromise website management and content control on Squarespace."
-regex = '''(?i)[\w.-]{0,50}?(?:squarespace)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:squarespace)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["squarespace"]
 
 [[rules]]
@@ -2881,27 +2881,27 @@ keywords = [
 [[rules]]
 id = "sumologic-access-id"
 description = "Discovered a SumoLogic Access ID, potentially compromising log management services and data analytics integrity."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(su[a-zA-Z0-9]{12})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(su[a-zA-Z0-9]{12})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["sumo"]
 
 [[rules]]
 id = "sumologic-access-token"
 description = "Uncovered a SumoLogic Access Token, which could lead to unauthorized access to log data and analytics insights."
-regex = '''(?i)[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["sumo"]
 
 [[rules]]
 id = "telegram-bot-api-token"
 description = "Detected a Telegram Bot API Token, risking unauthorized bot operations and message interception on Telegram."
-regex = '''(?i)[\w.-]{0,50}?(?:telegr)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9]{5,16}:(?-i:A)[a-z0-9_\-]{34})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:telegr)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9]{5,16}:(?-i:A)[a-z0-9_\-]{34})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["telegr"]
 
 [[rules]]
 id = "travisci-access-token"
 description = "Identified a Travis CI Access Token, potentially compromising continuous integration services and codebase security."
-regex = '''(?i)[\w.-]{0,50}?(?:travis)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{22})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:travis)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{22})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["travis"]
 
 [[rules]]
@@ -2914,43 +2914,43 @@ keywords = ["sk"]
 [[rules]]
 id = "twitch-api-token"
 description = "Discovered a Twitch API token, which could compromise streaming services and account integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:twitch)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{30})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitch)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{30})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["twitch"]
 
 [[rules]]
 id = "twitter-access-secret"
 description = "Uncovered a Twitter Access Secret, potentially risking unauthorized Twitter integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{45})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{45})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-access-token"
 description = "Detected a Twitter Access Token, posing a risk of unauthorized account operations and social media data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9]{15,25}-[a-zA-Z0-9]{20,40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9]{15,25}-[a-zA-Z0-9]{20,40})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-api-key"
 description = "Identified a Twitter API Key, which may compromise Twitter application integrations and user data security."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{25})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{25})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-api-secret"
 description = "Found a Twitter API Secret, risking the security of Twitter app integrations and sensitive data access."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{50})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{50})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-bearer-token"
 description = "Discovered a Twitter Bearer Token, potentially compromising API access and data retrieval from Twitter."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(A{22}[a-zA-Z0-9%]{80,100})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(A{22}[a-zA-Z0-9%]{80,100})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "typeform-api-token"
 description = "Uncovered a Typeform API token, which could lead to unauthorized survey management and data collection."
-regex = '''(?i)[\w.-]{0,50}?(?:typeform)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(tfp_[a-z0-9\-_\.=]{59})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:typeform)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(tfp_[a-z0-9\-_\.=]{59})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["tfp_"]
 
 [[rules]]
@@ -2978,24 +2978,24 @@ regexes = [
 [[rules]]
 id = "yandex-access-token"
 description = "Found a Yandex Access Token, posing a risk to Yandex service integrations and user data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "yandex-api-key"
 description = "Discovered a Yandex API Key, which could lead to unauthorized access to Yandex services and data manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(AQVN[A-Za-z0-9_\-]{35,38})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(AQVN[A-Za-z0-9_\-]{35,38})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "yandex-aws-access-token"
 description = "Uncovered a Yandex AWS Access Token, potentially compromising cloud resource access and data security on Yandex Cloud."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(YC[a-zA-Z0-9_\-]{38})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(YC[a-zA-Z0-9_\-]{38})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "zendesk-secret-key"
 description = "Detected a Zendesk Secret Key, risking unauthorized access to customer support services and sensitive ticketing data."
-regex = '''(?i)[\w.-]{0,50}?(?:zendesk)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:zendesk)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{40})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["zendesk"]
 

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -67,13 +67,13 @@ keywords = ["ops_"]
 [[rules]]
 id = "adafruit-api-key"
 description = "Identified a potential Adafruit API Key, which could lead to unauthorized access to Adafruit services and sensitive data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:adafruit)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:adafruit)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["adafruit"]
 
 [[rules]]
 id = "adobe-client-id"
 description = "Detected a pattern that resembles an Adobe OAuth Web Client ID, posing a risk of compromised Adobe integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:adobe)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:adobe)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["adobe"]
 
@@ -93,13 +93,13 @@ keywords = ["age-secret-key-1"]
 [[rules]]
 id = "airtable-api-key"
 description = "Uncovered a possible Airtable API Key, potentially compromising database access and leading to data leakage or alteration."
-regex = '''(?i)[\w.-]{0,50}?(?:airtable)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{17})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:airtable)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{17})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["airtable"]
 
 [[rules]]
 id = "algolia-api-key"
 description = "Identified an Algolia API Key, which could result in unauthorized search operations and data exposure on Algolia-managed platforms."
-regex = '''(?i)[\w.-]{0,50}?(?:algolia)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:algolia)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["algolia"]
 
 [[rules]]
@@ -112,26 +112,26 @@ keywords = ["ltai"]
 [[rules]]
 id = "alibaba-secret-key"
 description = "Discovered a potential Alibaba Cloud Secret Key, potentially allowing unauthorized operations and data access within Alibaba Cloud."
-regex = '''(?i)[\w.-]{0,50}?(?:alibaba)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{30})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:alibaba)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{30})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["alibaba"]
 
 [[rules]]
 id = "asana-client-id"
 description = "Discovered a potential Asana Client ID, risking unauthorized access to Asana projects and sensitive task information."
-regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9]{16})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9]{16})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["asana"]
 
 [[rules]]
 id = "asana-client-secret"
 description = "Identified an Asana Client Secret, which could lead to compromised project management integrity and unauthorized access."
-regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["asana"]
 
 [[rules]]
 id = "atlassian-api-token"
 description = "Detected an Atlassian API token, posing a threat to project management and collaboration tool security and data confidentiality."
-regex = '''(?i)[\w.-]{0,50}?(?:atlassian|confluence|jira)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:atlassian|confluence|jira)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "atlassian",
     "confluence",
@@ -178,31 +178,31 @@ keywords = ["q~"]
 [[rules]]
 id = "beamer-api-token"
 description = "Detected a Beamer API token, potentially compromising content management and exposing sensitive notifications and updates."
-regex = '''(?i)[\w.-]{0,50}?(?:beamer)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(b_[a-z0-9=_\-]{44})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:beamer)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(b_[a-z0-9=_\-]{44})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["beamer"]
 
 [[rules]]
 id = "bitbucket-client-id"
 description = "Discovered a potential Bitbucket Client ID, risking unauthorized repository access and potential codebase exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["bitbucket"]
 
 [[rules]]
 id = "bitbucket-client-secret"
 description = "Discovered a potential Bitbucket Client Secret, posing a risk of compromised code repositories and unauthorized access."
-regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["bitbucket"]
 
 [[rules]]
 id = "bittrex-access-key"
 description = "Identified a Bittrex Access Key, which could lead to unauthorized access to cryptocurrency trading accounts and financial loss."
-regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["bittrex"]
 
 [[rules]]
 id = "bittrex-secret-key"
 description = "Detected a Bittrex Secret Key, potentially compromising cryptocurrency transactions and financial security."
-regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["bittrex"]
 
 [[rules]]
@@ -215,14 +215,14 @@ keywords = ["clojars_"]
 [[rules]]
 id = "cloudflare-api-key"
 description = "Detected a Cloudflare API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["cloudflare"]
 
 [[rules]]
 id = "cloudflare-global-api-key"
 description = "Detected a Cloudflare Global API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{37})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{37})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["cloudflare"]
 
@@ -239,13 +239,13 @@ keywords = [
 [[rules]]
 id = "codecov-access-token"
 description = "Found a pattern resembling a Codecov Access Token, posing a risk of unauthorized access to code coverage reports and sensitive data."
-regex = '''(?i)[\w.-]{0,50}?(?:codecov)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:codecov)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["codecov"]
 
 [[rules]]
 id = "cohere-api-token"
 description = "Identified a Cohere Token, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:cohere|CO_API_KEY)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-zA-Z0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:cohere|CO_API_KEY)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3})(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-zA-Z0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 4
 keywords = [
     "cohere",
@@ -255,25 +255,25 @@ keywords = [
 [[rules]]
 id = "coinbase-access-token"
 description = "Detected a Coinbase Access Token, posing a risk of unauthorized access to cryptocurrency accounts and financial transactions."
-regex = '''(?i)[\w.-]{0,50}?(?:coinbase)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:coinbase)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["coinbase"]
 
 [[rules]]
 id = "confluent-access-token"
 description = "Identified a Confluent Access Token, which could compromise access to streaming data platforms and sensitive data flow."
-regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{16})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{16})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["confluent"]
 
 [[rules]]
 id = "confluent-secret-key"
 description = "Found a Confluent Secret Key, potentially risking unauthorized operations and data access within Confluent services."
-regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["confluent"]
 
 [[rules]]
 id = "contentful-delivery-api-token"
 description = "Discovered a Contentful delivery API token, posing a risk to content management systems and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:contentful)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{43})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:contentful)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{43})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["contentful"]
 
 [[rules]]
@@ -310,13 +310,13 @@ keywords = ["dapi"]
 [[rules]]
 id = "datadog-access-token"
 description = "Detected a Datadog Access Token, potentially risking monitoring and analytics data exposure and manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:datadog)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:datadog)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["datadog"]
 
 [[rules]]
 id = "defined-networking-api-token"
 description = "Identified a Defined Networking API token, which could lead to unauthorized network operations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:dnkey)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dnkey)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["dnkey"]
 
 [[rules]]
@@ -342,20 +342,20 @@ keywords = ["dor_v1_"]
 [[rules]]
 id = "discord-api-token"
 description = "Detected a Discord API key, potentially compromising communication channels and user data privacy on Discord."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["discord"]
 
 [[rules]]
 id = "discord-client-id"
 description = "Identified a Discord client ID, which may lead to unauthorized integrations and data exposure in Discord applications."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9]{18})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9]{18})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["discord"]
 
 [[rules]]
 id = "discord-client-secret"
 description = "Discovered a potential Discord client secret, risking compromised Discord bot integrations and data leaks."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["discord"]
 
@@ -369,25 +369,25 @@ keywords = ["dp.pt."]
 [[rules]]
 id = "droneci-access-token"
 description = "Detected a Droneci Access Token, potentially compromising continuous integration and deployment workflows."
-regex = '''(?i)[\w.-]{0,50}?(?:droneci)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:droneci)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["droneci"]
 
 [[rules]]
 id = "dropbox-api-token"
 description = "Identified a Dropbox API secret, which could lead to unauthorized file access and data breaches in Dropbox storage."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{15})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{15})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
 id = "dropbox-long-lived-api-token"
 description = "Found a Dropbox long-lived API token, risking prolonged unauthorized access to cloud storage and sensitive data."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
 id = "dropbox-short-lived-api-token"
 description = "Discovered a Dropbox short-lived API token, posing a risk of temporary but potentially harmful data access and manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(sl\.[a-z0-9\-=_]{135})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(sl\.[a-z0-9\-=_]{135})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
@@ -421,7 +421,7 @@ keywords = ["eztk"]
 [[rules]]
 id = "etsy-access-token"
 description = "Found an Etsy Access Token, potentially compromising Etsy shop management and customer data."
-regex = '''(?i)[\w.-]{0,50}?(?:(?-i:ETSY|[Ee]tsy))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:(?-i:ETSY|[Ee]tsy))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["etsy"]
 
@@ -444,38 +444,38 @@ keywords = [
 [[rules]]
 id = "facebook-secret"
 description = "Discovered a Facebook Application secret, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:facebook)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:facebook)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["facebook"]
 
 [[rules]]
 id = "fastly-api-token"
 description = "Uncovered a Fastly API key, which may compromise CDN and edge cloud services, leading to content delivery and security issues."
-regex = '''(?i)[\w.-]{0,50}?(?:fastly)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:fastly)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["fastly"]
 
 [[rules]]
 id = "finicity-api-token"
 description = "Detected a Finicity API token, potentially risking financial data access and unauthorized financial operations."
-regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["finicity"]
 
 [[rules]]
 id = "finicity-client-secret"
 description = "Identified a Finicity Client Secret, which could lead to compromised financial service integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["finicity"]
 
 [[rules]]
 id = "finnhub-access-token"
 description = "Found a Finnhub Access Token, risking unauthorized access to financial market data and analytics."
-regex = '''(?i)[\w.-]{0,50}?(?:finnhub)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finnhub)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["finnhub"]
 
 [[rules]]
 id = "flickr-access-token"
 description = "Discovered a Flickr Access Token, posing a risk of unauthorized photo management and potential data leakage."
-regex = '''(?i)[\w.-]{0,50}?(?:flickr)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:flickr)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["flickr"]
 
 [[rules]]
@@ -519,7 +519,7 @@ keywords = ["fio-u-"]
 [[rules]]
 id = "freshbooks-access-token"
 description = "Discovered a Freshbooks Access Token, posing a risk to accounting software access and sensitive financial data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:freshbooks)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:freshbooks)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["freshbooks"]
 
 [[rules]]
@@ -532,7 +532,7 @@ keywords = ["aiza"]
 [[rules]]
 id = "generic-api-key"
 description = "Detected a Generic API Key, potentially exposing access to various services and sensitive operations."
-regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passwd|password|secret|token)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([\w.=-]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passwd|password|secret|token)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([\w.=-]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3.5
 keywords = [
     "access",
@@ -2173,13 +2173,13 @@ keywords = ["_gitlab_session="]
 [[rules]]
 id = "gitter-access-token"
 description = "Uncovered a Gitter Access Token, which may lead to unauthorized access to chat and communication services."
-regex = '''(?i)[\w.-]{0,50}?(?:gitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:gitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["gitter"]
 
 [[rules]]
 id = "gocardless-api-token"
 description = "Detected a GoCardless API token, potentially risking unauthorized direct debit payment operations and financial data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:gocardless)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(live_(?i)[a-z0-9\-_=]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:gocardless)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(live_(?i)[a-z0-9\-_=]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "live_",
     "gocardless",
@@ -2225,7 +2225,7 @@ keywords = ["atlasv1"]
 [[rules]]
 id = "hashicorp-tf-password"
 description = "Identified a HashiCorp Terraform password field, risking unauthorized infrastructure configuration and security breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:administrator_login_password|password)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}("[a-z0-9=_\-]{8,20}")(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:administrator_login_password|password)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}("[a-z0-9=_\-]{8,20}")(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 path = '''(?i)\.(?:tf|hcl)$'''
 entropy = 2
 keywords = [
@@ -2236,13 +2236,13 @@ keywords = [
 [[rules]]
 id = "heroku-api-key"
 description = "Detected a Heroku API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:heroku)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:heroku)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["heroku"]
 
 [[rules]]
 id = "hubspot-api-key"
 description = "Found a HubSpot API Token, posing a risk to CRM data integrity and unauthorized marketing operations."
-regex = '''(?i)[\w.-]{0,50}?(?:hubspot)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:hubspot)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["hubspot"]
 
 [[rules]]
@@ -2269,7 +2269,7 @@ keywords = ["ico-"]
 [[rules]]
 id = "intercom-api-key"
 description = "Identified an Intercom API Token, which could compromise customer communication channels and data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:intercom)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{60})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:intercom)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{60})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["intercom"]
 
 [[rules]]
@@ -2286,7 +2286,7 @@ keywords = [
 [[rules]]
 id = "jfrog-api-key"
 description = "Found a JFrog API Key, posing a risk of unauthorized access to software artifact repositories and build pipelines."
-regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{73})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{73})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "jfrog",
     "artifactory",
@@ -2297,7 +2297,7 @@ keywords = [
 [[rules]]
 id = "jfrog-identity-token"
 description = "Discovered a JFrog Identity Token, potentially compromising access to JFrog services and sensitive software artifacts."
-regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "jfrog",
     "artifactory",
@@ -2322,7 +2322,7 @@ keywords = ["zxlk"]
 [[rules]]
 id = "kraken-access-token"
 description = "Identified a Kraken Access Token, potentially compromising cryptocurrency trading accounts and financial security."
-regex = '''(?i)[\w.-]{0,50}?(?:kraken)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9\/=_\+\-]{80,90})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kraken)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9\/=_\+\-]{80,90})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["kraken"]
 
 [[rules]]
@@ -2340,19 +2340,19 @@ regexes = [
 [[rules]]
 id = "kucoin-access-token"
 description = "Found a Kucoin Access Token, risking unauthorized access to cryptocurrency exchange services and transactions."
-regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["kucoin"]
 
 [[rules]]
 id = "kucoin-secret-key"
 description = "Discovered a Kucoin Secret Key, which could lead to compromised cryptocurrency operations and financial data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["kucoin"]
 
 [[rules]]
 id = "launchdarkly-access-token"
 description = "Uncovered a Launchdarkly Access Token, potentially compromising feature flag management and application functionality."
-regex = '''(?i)[\w.-]{0,50}?(?:launchdarkly)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:launchdarkly)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["launchdarkly"]
 
 [[rules]]
@@ -2365,14 +2365,14 @@ keywords = ["lin_api_"]
 [[rules]]
 id = "linear-client-secret"
 description = "Identified a Linear Client Secret, which may compromise secure integrations and sensitive project management data."
-regex = '''(?i)[\w.-]{0,50}?(?:linear)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linear)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["linear"]
 
 [[rules]]
 id = "linkedin-client-id"
 description = "Found a LinkedIn Client ID, risking unauthorized access to LinkedIn integrations and professional data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{14})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{14})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = [
     "linkedin",
@@ -2383,7 +2383,7 @@ keywords = [
 [[rules]]
 id = "linkedin-client-secret"
 description = "Discovered a LinkedIn Client secret, potentially compromising LinkedIn application integrations and user data."
-regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{16})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{16})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = [
     "linkedin",
@@ -2394,7 +2394,7 @@ keywords = [
 [[rules]]
 id = "lob-api-key"
 description = "Uncovered a Lob API Key, which could lead to unauthorized access to mailing and address verification services."
-regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}((live|test)_[a-f0-9]{35})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}((live|test)_[a-f0-9]{35})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "test_",
     "live_",
@@ -2403,7 +2403,7 @@ keywords = [
 [[rules]]
 id = "lob-pub-api-key"
 description = "Detected a Lob Publishable API Key, posing a risk of exposing mail and print service integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}((test|live)_pub_[a-f0-9]{31})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}((test|live)_pub_[a-f0-9]{31})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "test_pub",
     "live_pub",
@@ -2413,43 +2413,43 @@ keywords = [
 [[rules]]
 id = "mailchimp-api-key"
 description = "Identified a Mailchimp API key, potentially compromising email marketing campaigns and subscriber data."
-regex = '''(?i)[\w.-]{0,50}?(?:MailchimpSDK.initialize|mailchimp)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32}-us\d\d)(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:MailchimpSDK.initialize|mailchimp)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32}-us\d\d)(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["mailchimp"]
 
 [[rules]]
 id = "mailgun-private-api-token"
 description = "Found a Mailgun private API token, risking unauthorized email service operations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(key-[a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(key-[a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mailgun-pub-key"
 description = "Discovered a Mailgun public validation key, which could expose email verification processes and associated data."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(pubkey-[a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(pubkey-[a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mailgun-signing-key"
 description = "Uncovered a Mailgun webhook signing key, potentially compromising email automation and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mapbox-api-token"
 description = "Detected a MapBox API token, posing a risk to geospatial services and sensitive location data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:mapbox)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(pk\.[a-z0-9]{60}\.[a-z0-9]{22})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mapbox)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(pk\.[a-z0-9]{60}\.[a-z0-9]{22})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["mapbox"]
 
 [[rules]]
 id = "mattermost-access-token"
 description = "Identified a Mattermost Access Token, which may compromise team communication channels and data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:mattermost)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{26})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mattermost)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{26})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["mattermost"]
 
 [[rules]]
 id = "messagebird-api-token"
 description = "Found a MessageBird API token, risking unauthorized access to communication platforms and message data."
-regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{25})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{25})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "messagebird",
     "message-bird",
@@ -2459,7 +2459,7 @@ keywords = [
 [[rules]]
 id = "messagebird-client-id"
 description = "Discovered a MessageBird client ID, potentially compromising API integrations and sensitive communication data."
-regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "messagebird",
     "message-bird",
@@ -2479,25 +2479,25 @@ keywords = [
 [[rules]]
 id = "netlify-access-token"
 description = "Detected a Netlify Access Token, potentially compromising web hosting services and site management."
-regex = '''(?i)[\w.-]{0,50}?(?:netlify)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{40,46})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:netlify)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{40,46})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["netlify"]
 
 [[rules]]
 id = "new-relic-browser-api-token"
 description = "Identified a New Relic ingest browser API token, risking unauthorized access to application performance data and analytics."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(NRJS-[a-f0-9]{19})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(NRJS-[a-f0-9]{19})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["nrjs-"]
 
 [[rules]]
 id = "new-relic-insert-key"
 description = "Discovered a New Relic insight insert key, compromising data injection into the platform."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(NRII-[a-z0-9-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(NRII-[a-z0-9-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["nrii-"]
 
 [[rules]]
 id = "new-relic-user-api-id"
 description = "Found a New Relic user API ID, posing a risk to application monitoring services and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "new-relic",
     "newrelic",
@@ -2507,7 +2507,7 @@ keywords = [
 [[rules]]
 id = "new-relic-user-api-key"
 description = "Discovered a New Relic user API Key, which could lead to compromised application insights and performance monitoring."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(NRAK-[a-z0-9]{27})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(NRAK-[a-z0-9]{27})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["nrak"]
 
 [[rules]]
@@ -2535,7 +2535,7 @@ regexes = [
 [[rules]]
 id = "nytimes-access-token"
 description = "Detected a Nytimes Access Token, risking unauthorized access to New York Times APIs and content services."
-regex = '''(?i)[\w.-]{0,50}?(?:nytimes|new-york-times,|newyorktimes)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:nytimes|new-york-times,|newyorktimes)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "nytimes",
     "new-york-times",
@@ -2552,7 +2552,7 @@ keywords = ["api-"]
 [[rules]]
 id = "okta-access-token"
 description = "Identified an Okta Access Token, which may compromise identity management services and user authentication data."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Oo]kta|OKTA))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(00[\w=\-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Oo]kta|OKTA))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3})(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(00[\w=\-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 4
 keywords = ["okta"]
 
@@ -2573,20 +2573,20 @@ keywords = ["sha256~"]
 [[rules]]
 id = "plaid-api-token"
 description = "Discovered a Plaid API Token, potentially compromising financial data aggregation and banking services."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["plaid"]
 
 [[rules]]
 id = "plaid-client-id"
 description = "Uncovered a Plaid Client ID, which could lead to unauthorized financial service integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3.5
 keywords = ["plaid"]
 
 [[rules]]
 id = "plaid-secret-key"
 description = "Detected a Plaid Secret key, risking unauthorized access to financial accounts and sensitive transaction data."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{30})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{30})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3.5
 keywords = ["plaid"]
 
@@ -2634,7 +2634,7 @@ keywords = ["-----begin"]
 [[rules]]
 id = "privateai-api-token"
 description = "Identified a PrivateAI Token, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:private[_-]?ai)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:private[_-]?ai)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3})(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = [
     "privateai",
@@ -2659,7 +2659,7 @@ keywords = ["pypi-ageichlwas5vcmc"]
 [[rules]]
 id = "rapidapi-access-token"
 description = "Uncovered a RapidAPI Access Token, which could lead to unauthorized access to various APIs and data services."
-regex = '''(?i)[\w.-]{0,50}?(?:rapidapi)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{50})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:rapidapi)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{50})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["rapidapi"]
 
 [[rules]]
@@ -2686,13 +2686,13 @@ keywords = ["tk-us-"]
 [[rules]]
 id = "sendbird-access-id"
 description = "Discovered a Sendbird Access ID, which could compromise chat and messaging platform integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["sendbird"]
 
 [[rules]]
 id = "sendbird-access-token"
 description = "Uncovered a Sendbird Access Token, potentially risking unauthorized access to communication services and user data."
-regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["sendbird"]
 
 [[rules]]
@@ -2712,7 +2712,7 @@ keywords = ["xkeysib-"]
 [[rules]]
 id = "sentry-access-token"
 description = "Found a Sentry Access Token, risking unauthorized access to error tracking services and sensitive application data."
-regex = '''(?i)[\w.-]{0,50}?(?:sentry)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sentry)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["sentry"]
 
 [[rules]]
@@ -2753,7 +2753,7 @@ keywords = ["shpss_"]
 [[rules]]
 id = "sidekiq-secret"
 description = "Discovered a Sidekiq Secret, which could lead to compromised background job processing and application data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:BUNDLE_ENTERPRISE__CONTRIBSYS__COM|BUNDLE_GEMS__CONTRIBSYS__COM)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{8}:[a-f0-9]{8})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:BUNDLE_ENTERPRISE__CONTRIBSYS__COM|BUNDLE_GEMS__CONTRIBSYS__COM)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{8}:[a-f0-9]{8})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "bundle_enterprise__contribsys__com",
     "bundle_gems__contribsys__com",
@@ -2845,7 +2845,7 @@ keywords = ["hooks.slack.com"]
 [[rules]]
 id = "snyk-api-token"
 description = "Uncovered a Snyk API token, potentially compromising software vulnerability scanning and code security."
-regex = '''(?i)[\w.-]{0,50}?(?:snyk[_.-]?(?:(?:api|oauth)[_.-]?)?(?:key|token))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:snyk[_.-]?(?:(?:api|oauth)[_.-]?)?(?:key|token))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["snyk"]
 
 [[rules]]
@@ -2861,7 +2861,7 @@ keywords = [
 [[rules]]
 id = "squarespace-access-token"
 description = "Identified a Squarespace Access Token, which may compromise website management and content control on Squarespace."
-regex = '''(?i)[\w.-]{0,50}?(?:squarespace)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:squarespace)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["squarespace"]
 
 [[rules]]
@@ -2881,14 +2881,14 @@ keywords = [
 [[rules]]
 id = "sumologic-access-id"
 description = "Discovered a SumoLogic Access ID, potentially compromising log management services and data analytics integrity."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(su[a-zA-Z0-9]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3})(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(su[a-zA-Z0-9]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["sumo"]
 
 [[rules]]
 id = "sumologic-access-token"
 description = "Uncovered a SumoLogic Access Token, which could lead to unauthorized access to log data and analytics insights."
-regex = '''(?i)[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["sumo"]
 
@@ -2901,7 +2901,7 @@ keywords = ["telegr"]
 [[rules]]
 id = "travisci-access-token"
 description = "Identified a Travis CI Access Token, potentially compromising continuous integration services and codebase security."
-regex = '''(?i)[\w.-]{0,50}?(?:travis)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{22})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:travis)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{22})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["travis"]
 
 [[rules]]
@@ -2914,43 +2914,43 @@ keywords = ["sk"]
 [[rules]]
 id = "twitch-api-token"
 description = "Discovered a Twitch API token, which could compromise streaming services and account integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:twitch)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{30})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitch)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{30})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["twitch"]
 
 [[rules]]
 id = "twitter-access-secret"
 description = "Uncovered a Twitter Access Secret, potentially risking unauthorized Twitter integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{45})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{45})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-access-token"
 description = "Detected a Twitter Access Token, posing a risk of unauthorized account operations and social media data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9]{15,25}-[a-zA-Z0-9]{20,40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9]{15,25}-[a-zA-Z0-9]{20,40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-api-key"
 description = "Identified a Twitter API Key, which may compromise Twitter application integrations and user data security."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{25})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{25})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-api-secret"
 description = "Found a Twitter API Secret, risking the security of Twitter app integrations and sensitive data access."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{50})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{50})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-bearer-token"
 description = "Discovered a Twitter Bearer Token, potentially compromising API access and data retrieval from Twitter."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(A{22}[a-zA-Z0-9%]{80,100})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(A{22}[a-zA-Z0-9%]{80,100})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "typeform-api-token"
 description = "Uncovered a Typeform API token, which could lead to unauthorized survey management and data collection."
-regex = '''(?i)[\w.-]{0,50}?(?:typeform)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(tfp_[a-z0-9\-_\.=]{59})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:typeform)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(tfp_[a-z0-9\-_\.=]{59})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["tfp_"]
 
 [[rules]]
@@ -2978,24 +2978,24 @@ regexes = [
 [[rules]]
 id = "yandex-access-token"
 description = "Found a Yandex Access Token, posing a risk to Yandex service integrations and user data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "yandex-api-key"
 description = "Discovered a Yandex API Key, which could lead to unauthorized access to Yandex services and data manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(AQVN[A-Za-z0-9_\-]{35,38})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(AQVN[A-Za-z0-9_\-]{35,38})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "yandex-aws-access-token"
 description = "Uncovered a Yandex AWS Access Token, potentially compromising cloud resource access and data security on Yandex Cloud."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(YC[a-zA-Z0-9_\-]{38})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}(YC[a-zA-Z0-9_\-]{38})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "zendesk-secret-key"
 description = "Detected a Zendesk Secret Key, risking unauthorized access to customer support services and sensitive ticketing data."
-regex = '''(?i)[\w.-]{0,50}?(?:zendesk)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:zendesk)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:[<>?+]?=|:{1,3}=|>|=>|:)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["zendesk"]
 

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -67,20 +67,20 @@ keywords = ["ops_"]
 [[rules]]
 id = "adafruit-api-key"
 description = "Identified a potential Adafruit API Key, which could lead to unauthorized access to Adafruit services and sensitive data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:adafruit)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9_-]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:adafruit)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9_-]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["adafruit"]
 
 [[rules]]
 id = "adobe-client-id"
 description = "Detected a pattern that resembles an Adobe OAuth Web Client ID, posing a risk of compromised Adobe integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:adobe)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:adobe)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["adobe"]
 
 [[rules]]
 id = "adobe-client-secret"
 description = "Discovered a potential Adobe Client Secret, which, if exposed, could allow unauthorized Adobe service access and data manipulation."
-regex = '''\b(p8e-(?i)[a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(p8e-(?i)[a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["p8e-"]
 
@@ -93,45 +93,45 @@ keywords = ["age-secret-key-1"]
 [[rules]]
 id = "airtable-api-key"
 description = "Uncovered a possible Airtable API Key, potentially compromising database access and leading to data leakage or alteration."
-regex = '''(?i)[\w.-]{0,50}?(?:airtable)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{17})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:airtable)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{17})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["airtable"]
 
 [[rules]]
 id = "algolia-api-key"
 description = "Identified an Algolia API Key, which could result in unauthorized search operations and data exposure on Algolia-managed platforms."
-regex = '''(?i)[\w.-]{0,50}?(?:algolia)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:algolia)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["algolia"]
 
 [[rules]]
 id = "alibaba-access-key-id"
 description = "Detected an Alibaba Cloud AccessKey ID, posing a risk of unauthorized cloud resource access and potential data compromise."
-regex = '''\b(LTAI(?i)[a-z0-9]{20})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(LTAI(?i)[a-z0-9]{20})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["ltai"]
 
 [[rules]]
 id = "alibaba-secret-key"
 description = "Discovered a potential Alibaba Cloud Secret Key, potentially allowing unauthorized operations and data access within Alibaba Cloud."
-regex = '''(?i)[\w.-]{0,50}?(?:alibaba)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{30})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:alibaba)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{30})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["alibaba"]
 
 [[rules]]
 id = "asana-client-id"
 description = "Discovered a potential Asana Client ID, risking unauthorized access to Asana projects and sensitive task information."
-regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9]{16})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9]{16})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["asana"]
 
 [[rules]]
 id = "asana-client-secret"
 description = "Identified an Asana Client Secret, which could lead to compromised project management integrity and unauthorized access."
-regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["asana"]
 
 [[rules]]
 id = "atlassian-api-token"
 description = "Detected an Atlassian API token, posing a threat to project management and collaboration tool security and data confidentiality."
-regex = '''(?i)[\w.-]{0,50}?(?:atlassian|confluence|jira)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{24})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:atlassian|confluence|jira)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{24})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "atlassian",
     "confluence",
@@ -141,7 +141,7 @@ keywords = [
 [[rules]]
 id = "authress-service-client-access-key"
 description = "Uncovered a possible Authress Service Client Access Key, which may compromise access control services and sensitive data."
-regex = '''\b((?:sc|ext|scauth|authress)_(?i)[a-z0-9]{5,30}\.[a-z0-9]{4,6}\.(?-i:acc)[_-][a-z0-9-]{10,32}\.[a-z0-9+/_=-]{30,120})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b((?:sc|ext|scauth|authress)_(?i)[a-z0-9]{5,30}\.[a-z0-9]{4,6}\.(?-i:acc)[_-][a-z0-9-]{10,32}\.[a-z0-9+/_=-]{30,120})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "sc_",
@@ -178,31 +178,31 @@ keywords = ["q~"]
 [[rules]]
 id = "beamer-api-token"
 description = "Detected a Beamer API token, potentially compromising content management and exposing sensitive notifications and updates."
-regex = '''(?i)[\w.-]{0,50}?(?:beamer)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(b_[a-z0-9=_\-]{44})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:beamer)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(b_[a-z0-9=_\-]{44})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["beamer"]
 
 [[rules]]
 id = "bitbucket-client-id"
 description = "Discovered a potential Bitbucket Client ID, risking unauthorized repository access and potential codebase exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["bitbucket"]
 
 [[rules]]
 id = "bitbucket-client-secret"
 description = "Discovered a potential Bitbucket Client Secret, posing a risk of compromised code repositories and unauthorized access."
-regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9=_\-]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9=_\-]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["bitbucket"]
 
 [[rules]]
 id = "bittrex-access-key"
 description = "Identified a Bittrex Access Key, which could lead to unauthorized access to cryptocurrency trading accounts and financial loss."
-regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["bittrex"]
 
 [[rules]]
 id = "bittrex-secret-key"
 description = "Detected a Bittrex Secret Key, potentially compromising cryptocurrency transactions and financial security."
-regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["bittrex"]
 
 [[rules]]
@@ -215,21 +215,21 @@ keywords = ["clojars_"]
 [[rules]]
 id = "cloudflare-api-key"
 description = "Detected a Cloudflare API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9_-]{40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9_-]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["cloudflare"]
 
 [[rules]]
 id = "cloudflare-global-api-key"
 description = "Detected a Cloudflare Global API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{37})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{37})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["cloudflare"]
 
 [[rules]]
 id = "cloudflare-origin-ca-key"
 description = "Detected a Cloudflare Origin CA Key, potentially compromising cloud application deployments and operational security."
-regex = '''\b(v1\.0-[a-f0-9]{24}-[a-f0-9]{146})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(v1\.0-[a-f0-9]{24}-[a-f0-9]{146})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "cloudflare",
@@ -239,13 +239,13 @@ keywords = [
 [[rules]]
 id = "codecov-access-token"
 description = "Found a pattern resembling a Codecov Access Token, posing a risk of unauthorized access to code coverage reports and sensitive data."
-regex = '''(?i)[\w.-]{0,50}?(?:codecov)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:codecov)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["codecov"]
 
 [[rules]]
 id = "cohere-api-token"
 description = "Identified a Cohere Token, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:cohere|CO_API_KEY)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-zA-Z0-9]{40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:cohere|CO_API_KEY)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-zA-Z0-9]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 4
 keywords = [
     "cohere",
@@ -255,25 +255,25 @@ keywords = [
 [[rules]]
 id = "coinbase-access-token"
 description = "Detected a Coinbase Access Token, posing a risk of unauthorized access to cryptocurrency accounts and financial transactions."
-regex = '''(?i)[\w.-]{0,50}?(?:coinbase)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9_-]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:coinbase)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9_-]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["coinbase"]
 
 [[rules]]
 id = "confluent-access-token"
 description = "Identified a Confluent Access Token, which could compromise access to streaming data platforms and sensitive data flow."
-regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{16})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{16})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["confluent"]
 
 [[rules]]
 id = "confluent-secret-key"
 description = "Found a Confluent Secret Key, potentially risking unauthorized operations and data access within Confluent services."
-regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["confluent"]
 
 [[rules]]
 id = "contentful-delivery-api-token"
 description = "Discovered a Contentful delivery API token, posing a risk to content management systems and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:contentful)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9=_\-]{43})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:contentful)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9=_\-]{43})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["contentful"]
 
 [[rules]]
@@ -303,59 +303,59 @@ regexes = [
 [[rules]]
 id = "databricks-api-token"
 description = "Uncovered a Databricks API token, which may compromise big data analytics platforms and sensitive data processing."
-regex = '''\b(dapi[a-f0-9]{32}(?:-\d)?)(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(dapi[a-f0-9]{32}(?:-\d)?)(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["dapi"]
 
 [[rules]]
 id = "datadog-access-token"
 description = "Detected a Datadog Access Token, potentially risking monitoring and analytics data exposure and manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:datadog)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:datadog)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["datadog"]
 
 [[rules]]
 id = "defined-networking-api-token"
 description = "Identified a Defined Networking API token, which could lead to unauthorized network operations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:dnkey)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dnkey)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["dnkey"]
 
 [[rules]]
 id = "digitalocean-access-token"
 description = "Found a DigitalOcean OAuth Access Token, risking unauthorized cloud resource access and data compromise."
-regex = '''\b(doo_v1_[a-f0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(doo_v1_[a-f0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["doo_v1_"]
 
 [[rules]]
 id = "digitalocean-pat"
 description = "Discovered a DigitalOcean Personal Access Token, posing a threat to cloud infrastructure security and data privacy."
-regex = '''\b(dop_v1_[a-f0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(dop_v1_[a-f0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["dop_v1_"]
 
 [[rules]]
 id = "digitalocean-refresh-token"
 description = "Uncovered a DigitalOcean OAuth Refresh Token, which could allow prolonged unauthorized access and resource manipulation."
-regex = '''(?i)\b(dor_v1_[a-f0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)\b(dor_v1_[a-f0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["dor_v1_"]
 
 [[rules]]
 id = "discord-api-token"
 description = "Detected a Discord API key, potentially compromising communication channels and user data privacy on Discord."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["discord"]
 
 [[rules]]
 id = "discord-client-id"
 description = "Identified a Discord client ID, which may lead to unauthorized integrations and data exposure in Discord applications."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9]{18})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9]{18})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["discord"]
 
 [[rules]]
 id = "discord-client-secret"
 description = "Discovered a potential Discord client secret, risking compromised Discord bot integrations and data leaks."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9=_\-]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9=_\-]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["discord"]
 
@@ -369,25 +369,25 @@ keywords = ["dp.pt."]
 [[rules]]
 id = "droneci-access-token"
 description = "Detected a Droneci Access Token, potentially compromising continuous integration and deployment workflows."
-regex = '''(?i)[\w.-]{0,50}?(?:droneci)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:droneci)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["droneci"]
 
 [[rules]]
 id = "dropbox-api-token"
 description = "Identified a Dropbox API secret, which could lead to unauthorized file access and data breaches in Dropbox storage."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{15})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{15})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
 id = "dropbox-long-lived-api-token"
 description = "Found a Dropbox long-lived API token, risking prolonged unauthorized access to cloud storage and sensitive data."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
 id = "dropbox-short-lived-api-token"
 description = "Discovered a Dropbox short-lived API token, posing a risk of temporary but potentially harmful data access and manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(sl\.[a-z0-9\-=_]{135})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(sl\.[a-z0-9\-=_]{135})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
@@ -421,20 +421,20 @@ keywords = ["eztk"]
 [[rules]]
 id = "etsy-access-token"
 description = "Found an Etsy Access Token, potentially compromising Etsy shop management and customer data."
-regex = '''(?i)[\w.-]{0,50}?(?:(?-i:ETSY|[Ee]tsy))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{24})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:(?-i:ETSY|[Ee]tsy))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{24})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["etsy"]
 
 [[rules]]
 id = "facebook-access-token"
 description = "Discovered a Facebook Access Token, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''(?i)\b(\d{15,16}(\||%)[0-9a-z\-_]{27,40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)\b(\d{15,16}(\||%)[0-9a-z\-_]{27,40})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 
 [[rules]]
 id = "facebook-page-access-token"
 description = "Discovered a Facebook Page Access Token, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''\b(EAA[MC](?i)[a-z0-9]{100,})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(EAA[MC](?i)[a-z0-9]{100,})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 4
 keywords = [
     "eaam",
@@ -444,38 +444,38 @@ keywords = [
 [[rules]]
 id = "facebook-secret"
 description = "Discovered a Facebook Application secret, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:facebook)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:facebook)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["facebook"]
 
 [[rules]]
 id = "fastly-api-token"
 description = "Uncovered a Fastly API key, which may compromise CDN and edge cloud services, leading to content delivery and security issues."
-regex = '''(?i)[\w.-]{0,50}?(?:fastly)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9=_\-]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:fastly)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9=_\-]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["fastly"]
 
 [[rules]]
 id = "finicity-api-token"
 description = "Detected a Finicity API token, potentially risking financial data access and unauthorized financial operations."
-regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["finicity"]
 
 [[rules]]
 id = "finicity-client-secret"
 description = "Identified a Finicity Client Secret, which could lead to compromised financial service integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{20})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{20})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["finicity"]
 
 [[rules]]
 id = "finnhub-access-token"
 description = "Found a Finnhub Access Token, risking unauthorized access to financial market data and analytics."
-regex = '''(?i)[\w.-]{0,50}?(?:finnhub)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{20})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finnhub)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{20})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["finnhub"]
 
 [[rules]]
 id = "flickr-access-token"
 description = "Discovered a Flickr Access Token, posing a risk of unauthorized photo management and potential data leakage."
-regex = '''(?i)[\w.-]{0,50}?(?:flickr)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:flickr)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["flickr"]
 
 [[rules]]
@@ -502,7 +502,7 @@ keywords = ["flwseck_test"]
 [[rules]]
 id = "flyio-access-token"
 description = "Uncovered a Fly.io API key"
-regex = '''\b((?:fo1_[\w-]{43}|fm1[ar]_[a-zA-Z0-9+\/]{100,}={0,3}|fm2_[a-zA-Z0-9+\/]{100,}={0,3}))(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b((?:fo1_[\w-]{43}|fm1[ar]_[a-zA-Z0-9+\/]{100,}={0,3}|fm2_[a-zA-Z0-9+\/]{100,}={0,3}))(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 4
 keywords = [
     "fo1_",
@@ -519,20 +519,20 @@ keywords = ["fio-u-"]
 [[rules]]
 id = "freshbooks-access-token"
 description = "Discovered a Freshbooks Access Token, posing a risk to accounting software access and sensitive financial data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:freshbooks)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:freshbooks)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["freshbooks"]
 
 [[rules]]
 id = "gcp-api-key"
 description = "Uncovered a GCP API key, which could lead to unauthorized access to Google Cloud services and data breaches."
-regex = '''\b(AIza[\w-]{35})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(AIza[\w-]{35})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["aiza"]
 
 [[rules]]
 id = "generic-api-key"
 description = "Detected a Generic API Key, potentially exposing access to various services and sensitive operations."
-regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passwd|password|secret|token)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([\w.=-]{10,150})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passwd|password|secret|token)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([\w.=-]{10,150})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3.5
 keywords = [
     "access",
@@ -2173,13 +2173,13 @@ keywords = ["_gitlab_session="]
 [[rules]]
 id = "gitter-access-token"
 description = "Uncovered a Gitter Access Token, which may lead to unauthorized access to chat and communication services."
-regex = '''(?i)[\w.-]{0,50}?(?:gitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9_-]{40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:gitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9_-]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["gitter"]
 
 [[rules]]
 id = "gocardless-api-token"
 description = "Detected a GoCardless API token, potentially risking unauthorized direct debit payment operations and financial data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:gocardless)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(live_(?i)[a-z0-9\-_=]{40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:gocardless)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(live_(?i)[a-z0-9\-_=]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "live_",
     "gocardless",
@@ -2188,21 +2188,21 @@ keywords = [
 [[rules]]
 id = "grafana-api-key"
 description = "Identified a Grafana API key, which could compromise monitoring dashboards and sensitive data analytics."
-regex = '''(?i)\b(eyJrIjoi[A-Za-z0-9]{70,400}={0,3})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)\b(eyJrIjoi[A-Za-z0-9]{70,400}={0,3})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["eyjrijoi"]
 
 [[rules]]
 id = "grafana-cloud-api-token"
 description = "Found a Grafana cloud API token, risking unauthorized access to cloud-based monitoring services and data exposure."
-regex = '''(?i)\b(glc_[A-Za-z0-9+/]{32,400}={0,3})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)\b(glc_[A-Za-z0-9+/]{32,400}={0,3})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["glc_"]
 
 [[rules]]
 id = "grafana-service-account-token"
 description = "Discovered a Grafana service account token, posing a risk of compromised monitoring services and data integrity."
-regex = '''(?i)\b(glsa_[A-Za-z0-9]{32}_[A-Fa-f0-9]{8})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)\b(glsa_[A-Za-z0-9]{32}_[A-Fa-f0-9]{8})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["glsa_"]
 
@@ -2225,7 +2225,7 @@ keywords = ["atlasv1"]
 [[rules]]
 id = "hashicorp-tf-password"
 description = "Identified a HashiCorp Terraform password field, risking unauthorized infrastructure configuration and security breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:administrator_login_password|password)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}("[a-z0-9=_\-]{8,20}")(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:administrator_login_password|password)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}("[a-z0-9=_\-]{8,20}")(?:[\'\"\x60\s;\\<,)]|$)'''
 path = '''(?i)\.(?:tf|hcl)$'''
 entropy = 2
 keywords = [
@@ -2236,46 +2236,46 @@ keywords = [
 [[rules]]
 id = "heroku-api-key"
 description = "Detected a Heroku API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:heroku)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:heroku)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["heroku"]
 
 [[rules]]
 id = "hubspot-api-key"
 description = "Found a HubSpot API Token, posing a risk to CRM data integrity and unauthorized marketing operations."
-regex = '''(?i)[\w.-]{0,50}?(?:hubspot)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:hubspot)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["hubspot"]
 
 [[rules]]
 id = "huggingface-access-token"
 description = "Discovered a Hugging Face Access token, which could lead to unauthorized access to AI models and sensitive data."
-regex = '''\b(hf_(?i:[a-z]{34}))(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(hf_(?i:[a-z]{34}))(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["hf_"]
 
 [[rules]]
 id = "huggingface-organization-api-token"
 description = "Uncovered a Hugging Face Organization API token, potentially compromising AI organization accounts and associated data."
-regex = '''\b(api_org_(?i:[a-z]{34}))(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(api_org_(?i:[a-z]{34}))(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["api_org_"]
 
 [[rules]]
 id = "infracost-api-token"
 description = "Detected an Infracost API Token, risking unauthorized access to cloud cost estimation tools and financial data."
-regex = '''\b(ico-[a-zA-Z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(ico-[a-zA-Z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["ico-"]
 
 [[rules]]
 id = "intercom-api-key"
 description = "Identified an Intercom API Token, which could compromise customer communication channels and data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:intercom)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9=_\-]{60})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:intercom)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9=_\-]{60})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["intercom"]
 
 [[rules]]
 id = "intra42-client-secret"
 description = "Found a Intra42 client secret, which could lead to unauthorized access to the 42School API and sensitive data."
-regex = '''\b(s-s4t2(?:ud|af)-(?i)[abcdef0123456789]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(s-s4t2(?:ud|af)-(?i)[abcdef0123456789]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = [
     "intra",
@@ -2286,7 +2286,7 @@ keywords = [
 [[rules]]
 id = "jfrog-api-key"
 description = "Found a JFrog API Key, posing a risk of unauthorized access to software artifact repositories and build pipelines."
-regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{73})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{73})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "jfrog",
     "artifactory",
@@ -2297,7 +2297,7 @@ keywords = [
 [[rules]]
 id = "jfrog-identity-token"
 description = "Discovered a JFrog Identity Token, potentially compromising access to JFrog services and sensitive software artifacts."
-regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "jfrog",
     "artifactory",
@@ -2308,7 +2308,7 @@ keywords = [
 [[rules]]
 id = "jwt"
 description = "Uncovered a JSON Web Token, which may lead to unauthorized access to web applications and sensitive user data."
-regex = '''\b(ey[a-zA-Z0-9]{17,}\.ey[a-zA-Z0-9\/\\_-]{17,}\.(?:[a-zA-Z0-9\/\\_-]{10,}={0,2})?)(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(ey[a-zA-Z0-9]{17,}\.ey[a-zA-Z0-9\/\\_-]{17,}\.(?:[a-zA-Z0-9\/\\_-]{10,}={0,2})?)(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["ey"]
 
@@ -2322,7 +2322,7 @@ keywords = ["zxlk"]
 [[rules]]
 id = "kraken-access-token"
 description = "Identified a Kraken Access Token, potentially compromising cryptocurrency trading accounts and financial security."
-regex = '''(?i)[\w.-]{0,50}?(?:kraken)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9\/=_\+\-]{80,90})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kraken)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9\/=_\+\-]{80,90})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["kraken"]
 
 [[rules]]
@@ -2340,19 +2340,19 @@ regexes = [
 [[rules]]
 id = "kucoin-access-token"
 description = "Found a Kucoin Access Token, risking unauthorized access to cryptocurrency exchange services and transactions."
-regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{24})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{24})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["kucoin"]
 
 [[rules]]
 id = "kucoin-secret-key"
 description = "Discovered a Kucoin Secret Key, which could lead to compromised cryptocurrency operations and financial data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["kucoin"]
 
 [[rules]]
 id = "launchdarkly-access-token"
 description = "Uncovered a Launchdarkly Access Token, potentially compromising feature flag management and application functionality."
-regex = '''(?i)[\w.-]{0,50}?(?:launchdarkly)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9=_\-]{40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:launchdarkly)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9=_\-]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["launchdarkly"]
 
 [[rules]]
@@ -2365,14 +2365,14 @@ keywords = ["lin_api_"]
 [[rules]]
 id = "linear-client-secret"
 description = "Identified a Linear Client Secret, which may compromise secure integrations and sensitive project management data."
-regex = '''(?i)[\w.-]{0,50}?(?:linear)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linear)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["linear"]
 
 [[rules]]
 id = "linkedin-client-id"
 description = "Found a LinkedIn Client ID, risking unauthorized access to LinkedIn integrations and professional data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{14})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{14})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "linkedin",
@@ -2383,7 +2383,7 @@ keywords = [
 [[rules]]
 id = "linkedin-client-secret"
 description = "Discovered a LinkedIn Client secret, potentially compromising LinkedIn application integrations and user data."
-regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{16})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{16})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "linkedin",
@@ -2394,7 +2394,7 @@ keywords = [
 [[rules]]
 id = "lob-api-key"
 description = "Uncovered a Lob API Key, which could lead to unauthorized access to mailing and address verification services."
-regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}((live|test)_[a-f0-9]{35})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}((live|test)_[a-f0-9]{35})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "test_",
     "live_",
@@ -2403,7 +2403,7 @@ keywords = [
 [[rules]]
 id = "lob-pub-api-key"
 description = "Detected a Lob Publishable API Key, posing a risk of exposing mail and print service integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}((test|live)_pub_[a-f0-9]{31})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}((test|live)_pub_[a-f0-9]{31})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "test_pub",
     "live_pub",
@@ -2413,43 +2413,43 @@ keywords = [
 [[rules]]
 id = "mailchimp-api-key"
 description = "Identified a Mailchimp API key, potentially compromising email marketing campaigns and subscriber data."
-regex = '''(?i)[\w.-]{0,50}?(?:MailchimpSDK.initialize|mailchimp)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{32}-us\d\d)(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:MailchimpSDK.initialize|mailchimp)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{32}-us\d\d)(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["mailchimp"]
 
 [[rules]]
 id = "mailgun-private-api-token"
 description = "Found a Mailgun private API token, risking unauthorized email service operations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(key-[a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(key-[a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mailgun-pub-key"
 description = "Discovered a Mailgun public validation key, which could expose email verification processes and associated data."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(pubkey-[a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(pubkey-[a-f0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mailgun-signing-key"
 description = "Uncovered a Mailgun webhook signing key, potentially compromising email automation and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mapbox-api-token"
 description = "Detected a MapBox API token, posing a risk to geospatial services and sensitive location data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:mapbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(pk\.[a-z0-9]{60}\.[a-z0-9]{22})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mapbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(pk\.[a-z0-9]{60}\.[a-z0-9]{22})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["mapbox"]
 
 [[rules]]
 id = "mattermost-access-token"
 description = "Identified a Mattermost Access Token, which may compromise team communication channels and data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:mattermost)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{26})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mattermost)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{26})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["mattermost"]
 
 [[rules]]
 id = "messagebird-api-token"
 description = "Found a MessageBird API token, risking unauthorized access to communication platforms and message data."
-regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{25})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{25})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "messagebird",
     "message-bird",
@@ -2459,7 +2459,7 @@ keywords = [
 [[rules]]
 id = "messagebird-client-id"
 description = "Discovered a MessageBird client ID, potentially compromising API integrations and sensitive communication data."
-regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "messagebird",
     "message-bird",
@@ -2479,25 +2479,25 @@ keywords = [
 [[rules]]
 id = "netlify-access-token"
 description = "Detected a Netlify Access Token, potentially compromising web hosting services and site management."
-regex = '''(?i)[\w.-]{0,50}?(?:netlify)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9=_\-]{40,46})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:netlify)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9=_\-]{40,46})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["netlify"]
 
 [[rules]]
 id = "new-relic-browser-api-token"
 description = "Identified a New Relic ingest browser API token, risking unauthorized access to application performance data and analytics."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(NRJS-[a-f0-9]{19})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(NRJS-[a-f0-9]{19})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["nrjs-"]
 
 [[rules]]
 id = "new-relic-insert-key"
 description = "Discovered a New Relic insight insert key, compromising data injection into the platform."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(NRII-[a-z0-9-]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(NRII-[a-z0-9-]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["nrii-"]
 
 [[rules]]
 id = "new-relic-user-api-id"
 description = "Found a New Relic user API ID, posing a risk to application monitoring services and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "new-relic",
     "newrelic",
@@ -2507,13 +2507,13 @@ keywords = [
 [[rules]]
 id = "new-relic-user-api-key"
 description = "Discovered a New Relic user API Key, which could lead to compromised application insights and performance monitoring."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(NRAK-[a-z0-9]{27})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(NRAK-[a-z0-9]{27})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["nrak"]
 
 [[rules]]
 id = "npm-access-token"
 description = "Uncovered an npm access token, potentially compromising package management and code repository access."
-regex = '''(?i)\b(npm_[a-z0-9]{36})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)\b(npm_[a-z0-9]{36})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["npm_"]
 
@@ -2535,7 +2535,7 @@ regexes = [
 [[rules]]
 id = "nytimes-access-token"
 description = "Detected a Nytimes Access Token, risking unauthorized access to New York Times APIs and content services."
-regex = '''(?i)[\w.-]{0,50}?(?:nytimes|new-york-times,|newyorktimes)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9=_\-]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:nytimes|new-york-times,|newyorktimes)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9=_\-]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "nytimes",
     "new-york-times",
@@ -2545,21 +2545,21 @@ keywords = [
 [[rules]]
 id = "octopus-deploy-api-key"
 description = "Discovered a potential Octopus Deploy API key, risking application deployments and operational security."
-regex = '''\b(API-[A-Z0-9]{26})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(API-[A-Z0-9]{26})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["api-"]
 
 [[rules]]
 id = "okta-access-token"
 description = "Identified an Okta Access Token, which may compromise identity management services and user authentication data."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Oo]kta|OKTA))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(00[\w=\-]{40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Oo]kta|OKTA))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(00[\w=\-]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 4
 keywords = ["okta"]
 
 [[rules]]
 id = "openai-api-key"
 description = "Found an OpenAI API Key, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''\b(sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["t3blbkfj"]
 
@@ -2573,55 +2573,55 @@ keywords = ["sha256~"]
 [[rules]]
 id = "plaid-api-token"
 description = "Discovered a Plaid API Token, potentially compromising financial data aggregation and banking services."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["plaid"]
 
 [[rules]]
 id = "plaid-client-id"
 description = "Uncovered a Plaid Client ID, which could lead to unauthorized financial service integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{24})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{24})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3.5
 keywords = ["plaid"]
 
 [[rules]]
 id = "plaid-secret-key"
 description = "Detected a Plaid Secret key, risking unauthorized access to financial accounts and sensitive transaction data."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{30})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{30})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3.5
 keywords = ["plaid"]
 
 [[rules]]
 id = "planetscale-api-token"
 description = "Identified a PlanetScale API token, potentially compromising database management and operations."
-regex = '''\b(pscale_tkn_(?i)[\w=\.-]{32,64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(pscale_tkn_(?i)[\w=\.-]{32,64})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["pscale_tkn_"]
 
 [[rules]]
 id = "planetscale-oauth-token"
 description = "Found a PlanetScale OAuth token, posing a risk to database access control and sensitive data integrity."
-regex = '''\b(pscale_oauth_[\w=\.-]{32,64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(pscale_oauth_[\w=\.-]{32,64})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["pscale_oauth_"]
 
 [[rules]]
 id = "planetscale-password"
 description = "Discovered a PlanetScale password, which could lead to unauthorized database operations and data breaches."
-regex = '''(?i)\b(pscale_pw_(?i)[\w=\.-]{32,64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)\b(pscale_pw_(?i)[\w=\.-]{32,64})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["pscale_pw_"]
 
 [[rules]]
 id = "postman-api-token"
 description = "Uncovered a Postman API token, potentially compromising API testing and development workflows."
-regex = '''\b(PMAK-(?i)[a-f0-9]{24}\-[a-f0-9]{34})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(PMAK-(?i)[a-f0-9]{24}\-[a-f0-9]{34})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["pmak-"]
 
 [[rules]]
 id = "prefect-api-token"
 description = "Detected a Prefect API token, risking unauthorized access to workflow management and automation services."
-regex = '''\b(pnu_[a-zA-Z0-9]{36})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(pnu_[a-zA-Z0-9]{36})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["pnu_"]
 
@@ -2634,7 +2634,7 @@ keywords = ["-----begin"]
 [[rules]]
 id = "privateai-api-token"
 description = "Identified a PrivateAI Token, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:private[_-]?ai)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:private[_-]?ai)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{32})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = [
     "privateai",
@@ -2645,7 +2645,7 @@ keywords = [
 [[rules]]
 id = "pulumi-api-token"
 description = "Found a Pulumi API token, posing a risk to infrastructure as code services and cloud resource management."
-regex = '''\b(pul-[a-f0-9]{40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(pul-[a-f0-9]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["pul-"]
 
@@ -2659,66 +2659,66 @@ keywords = ["pypi-ageichlwas5vcmc"]
 [[rules]]
 id = "rapidapi-access-token"
 description = "Uncovered a RapidAPI Access Token, which could lead to unauthorized access to various APIs and data services."
-regex = '''(?i)[\w.-]{0,50}?(?:rapidapi)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9_-]{50})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:rapidapi)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9_-]{50})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["rapidapi"]
 
 [[rules]]
 id = "readme-api-token"
 description = "Detected a Readme API token, risking unauthorized documentation management and content exposure."
-regex = '''\b(rdme_[a-z0-9]{70})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(rdme_[a-z0-9]{70})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["rdme_"]
 
 [[rules]]
 id = "rubygems-api-token"
 description = "Identified a Rubygem API token, potentially compromising Ruby library distribution and package management."
-regex = '''\b(rubygems_[a-f0-9]{48})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(rubygems_[a-f0-9]{48})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["rubygems_"]
 
 [[rules]]
 id = "scalingo-api-token"
 description = "Found a Scalingo API token, posing a risk to cloud platform services and application deployment security."
-regex = '''\b(tk-us-[\w-]{48})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(tk-us-[\w-]{48})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["tk-us-"]
 
 [[rules]]
 id = "sendbird-access-id"
 description = "Discovered a Sendbird Access ID, which could compromise chat and messaging platform integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["sendbird"]
 
 [[rules]]
 id = "sendbird-access-token"
 description = "Uncovered a Sendbird Access Token, potentially risking unauthorized access to communication services and user data."
-regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["sendbird"]
 
 [[rules]]
 id = "sendgrid-api-token"
 description = "Detected a SendGrid API token, posing a risk of unauthorized email service operations and data exposure."
-regex = '''\b(SG\.(?i)[a-z0-9=_\-\.]{66})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(SG\.(?i)[a-z0-9=_\-\.]{66})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["sg."]
 
 [[rules]]
 id = "sendinblue-api-token"
 description = "Identified a Sendinblue API token, which may compromise email marketing services and subscriber data privacy."
-regex = '''\b(xkeysib-[a-f0-9]{64}\-(?i)[a-z0-9]{16})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(xkeysib-[a-f0-9]{64}\-(?i)[a-z0-9]{16})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["xkeysib-"]
 
 [[rules]]
 id = "sentry-access-token"
 description = "Found a Sentry Access Token, risking unauthorized access to error tracking services and sensitive application data."
-regex = '''(?i)[\w.-]{0,50}?(?:sentry)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sentry)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["sentry"]
 
 [[rules]]
 id = "shippo-api-token"
 description = "Discovered a Shippo API token, potentially compromising shipping services and customer order data."
-regex = '''\b(shippo_(?:live|test)_[a-fA-F0-9]{40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(shippo_(?:live|test)_[a-fA-F0-9]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["shippo_"]
 
@@ -2753,7 +2753,7 @@ keywords = ["shpss_"]
 [[rules]]
 id = "sidekiq-secret"
 description = "Discovered a Sidekiq Secret, which could lead to compromised background job processing and application data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:BUNDLE_ENTERPRISE__CONTRIBSYS__COM|BUNDLE_GEMS__CONTRIBSYS__COM)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-f0-9]{8}:[a-f0-9]{8})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:BUNDLE_ENTERPRISE__CONTRIBSYS__COM|BUNDLE_GEMS__CONTRIBSYS__COM)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-f0-9]{8}:[a-f0-9]{8})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = [
     "bundle_enterprise__contribsys__com",
     "bundle_gems__contribsys__com",
@@ -2845,13 +2845,13 @@ keywords = ["hooks.slack.com"]
 [[rules]]
 id = "snyk-api-token"
 description = "Uncovered a Snyk API token, potentially compromising software vulnerability scanning and code security."
-regex = '''(?i)[\w.-]{0,50}?(?:snyk[_.-]?(?:(?:api|oauth)[_.-]?)?(?:key|token))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:snyk[_.-]?(?:(?:api|oauth)[_.-]?)?(?:key|token))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["snyk"]
 
 [[rules]]
 id = "square-access-token"
 description = "Detected a Square Access Token, risking unauthorized payment processing and financial transaction exposure."
-regex = '''\b((?:EAAA|sq0atp-)[\w-]{22,60})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b((?:EAAA|sq0atp-)[\w-]{22,60})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "sq0atp-",
@@ -2861,13 +2861,13 @@ keywords = [
 [[rules]]
 id = "squarespace-access-token"
 description = "Identified a Squarespace Access Token, which may compromise website management and content control on Squarespace."
-regex = '''(?i)[\w.-]{0,50}?(?:squarespace)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:squarespace)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["squarespace"]
 
 [[rules]]
 id = "stripe-access-token"
 description = "Found a Stripe Access Token, posing a risk to payment processing services and sensitive financial data."
-regex = '''\b((?:sk|rk)_(?:test|live|prod)_[a-zA-Z0-9]{10,99})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b((?:sk|rk)_(?:test|live|prod)_[a-zA-Z0-9]{10,99})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "sk_test",
@@ -2881,27 +2881,27 @@ keywords = [
 [[rules]]
 id = "sumologic-access-id"
 description = "Discovered a SumoLogic Access ID, potentially compromising log management services and data analytics integrity."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(su[a-zA-Z0-9]{12})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(su[a-zA-Z0-9]{12})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["sumo"]
 
 [[rules]]
 id = "sumologic-access-token"
 description = "Uncovered a SumoLogic Access Token, which could lead to unauthorized access to log data and analytics insights."
-regex = '''(?i)[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{64})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["sumo"]
 
 [[rules]]
 id = "telegram-bot-api-token"
 description = "Detected a Telegram Bot API Token, risking unauthorized bot operations and message interception on Telegram."
-regex = '''(?i)[\w.-]{0,50}?(?:telegr)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9]{5,16}:(?-i:A)[a-z0-9_\-]{34})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:telegr)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9]{5,16}:(?-i:A)[a-z0-9_\-]{34})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["telegr"]
 
 [[rules]]
 id = "travisci-access-token"
 description = "Identified a Travis CI Access Token, potentially compromising continuous integration services and codebase security."
-regex = '''(?i)[\w.-]{0,50}?(?:travis)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{22})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:travis)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{22})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["travis"]
 
 [[rules]]
@@ -2914,56 +2914,56 @@ keywords = ["sk"]
 [[rules]]
 id = "twitch-api-token"
 description = "Discovered a Twitch API token, which could compromise streaming services and account integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:twitch)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{30})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitch)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{30})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["twitch"]
 
 [[rules]]
 id = "twitter-access-secret"
 description = "Uncovered a Twitter Access Secret, potentially risking unauthorized Twitter integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{45})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{45})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-access-token"
 description = "Detected a Twitter Access Token, posing a risk of unauthorized account operations and social media data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([0-9]{15,25}-[a-zA-Z0-9]{20,40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([0-9]{15,25}-[a-zA-Z0-9]{20,40})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-api-key"
 description = "Identified a Twitter API Key, which may compromise Twitter application integrations and user data security."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{25})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{25})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-api-secret"
 description = "Found a Twitter API Secret, risking the security of Twitter app integrations and sensitive data access."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{50})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{50})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-bearer-token"
 description = "Discovered a Twitter Bearer Token, potentially compromising API access and data retrieval from Twitter."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(A{22}[a-zA-Z0-9%]{80,100})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(A{22}[a-zA-Z0-9%]{80,100})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "typeform-api-token"
 description = "Uncovered a Typeform API token, which could lead to unauthorized survey management and data collection."
-regex = '''(?i)[\w.-]{0,50}?(?:typeform)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(tfp_[a-z0-9\-_\.=]{59})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:typeform)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(tfp_[a-z0-9\-_\.=]{59})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["tfp_"]
 
 [[rules]]
 id = "vault-batch-token"
 description = "Detected a Vault Batch Token, risking unauthorized access to secret management services and sensitive data."
-regex = '''\b(hvb\.[\w-]{138,300})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b(hvb\.[\w-]{138,300})(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 4
 keywords = ["hvb."]
 
 [[rules]]
 id = "vault-service-token"
 description = "Identified a Vault Service Token, potentially compromising infrastructure security and access to sensitive credentials."
-regex = '''\b((?:hvs\.[\w-]{90,120}|s\.(?i:[a-z0-9]{24})))(?:['"\x60\s;\\<,)]|$)'''
+regex = '''\b((?:hvs\.[\w-]{90,120}|s\.(?i:[a-z0-9]{24})))(?:[\'\"\x60\s;\\<,)]|$)'''
 entropy = 3.5
 keywords = [
     "hvs.",
@@ -2978,24 +2978,24 @@ regexes = [
 [[rules]]
 id = "yandex-access-token"
 description = "Found a Yandex Access Token, posing a risk to Yandex service integrations and user data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "yandex-api-key"
 description = "Discovered a Yandex API Key, which could lead to unauthorized access to Yandex services and data manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(AQVN[A-Za-z0-9_\-]{35,38})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(AQVN[A-Za-z0-9_\-]{35,38})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "yandex-aws-access-token"
 description = "Uncovered a Yandex AWS Access Token, potentially compromising cloud resource access and data security on Yandex Cloud."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}(YC[a-zA-Z0-9_\-]{38})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}(YC[a-zA-Z0-9_\-]{38})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "zendesk-secret-key"
 description = "Detected a Zendesk Secret Key, risking unauthorized access to customer support services and sensitive ticketing data."
-regex = '''(?i)[\w.-]{0,50}?(?:zendesk)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*(?:'|")|[\x60\s=|>]){0,5}([a-z0-9]{40})(?:['"\x60\s;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:zendesk)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s=|>]){0,5}([a-z0-9]{40})(?:[\'\"\x60\s;\\<,)]|$)'''
 keywords = ["zendesk"]
 

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -67,20 +67,20 @@ keywords = ["ops_"]
 [[rules]]
 id = "adafruit-api-key"
 description = "Identified a potential Adafruit API Key, which could lead to unauthorized access to Adafruit services and sensitive data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:adafruit)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9_-]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:adafruit)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["adafruit"]
 
 [[rules]]
 id = "adobe-client-id"
 description = "Detected a pattern that resembles an Adobe OAuth Web Client ID, posing a risk of compromised Adobe integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:adobe)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:adobe)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["adobe"]
 
 [[rules]]
 id = "adobe-client-secret"
 description = "Discovered a potential Adobe Client Secret, which, if exposed, could allow unauthorized Adobe service access and data manipulation."
-regex = '''\b(p8e-(?i)[a-z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(p8e-(?i)[a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["p8e-"]
 
@@ -93,45 +93,45 @@ keywords = ["age-secret-key-1"]
 [[rules]]
 id = "airtable-api-key"
 description = "Uncovered a possible Airtable API Key, potentially compromising database access and leading to data leakage or alteration."
-regex = '''(?i)[\w.-]{0,50}?(?:airtable)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{17})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:airtable)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{17})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["airtable"]
 
 [[rules]]
 id = "algolia-api-key"
 description = "Identified an Algolia API Key, which could result in unauthorized search operations and data exposure on Algolia-managed platforms."
-regex = '''(?i)[\w.-]{0,50}?(?:algolia)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:algolia)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["algolia"]
 
 [[rules]]
 id = "alibaba-access-key-id"
 description = "Detected an Alibaba Cloud AccessKey ID, posing a risk of unauthorized cloud resource access and potential data compromise."
-regex = '''\b(LTAI(?i)[a-z0-9]{20})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(LTAI(?i)[a-z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["ltai"]
 
 [[rules]]
 id = "alibaba-secret-key"
 description = "Discovered a potential Alibaba Cloud Secret Key, potentially allowing unauthorized operations and data access within Alibaba Cloud."
-regex = '''(?i)[\w.-]{0,50}?(?:alibaba)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{30})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:alibaba)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{30})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["alibaba"]
 
 [[rules]]
 id = "asana-client-id"
 description = "Discovered a potential Asana Client ID, risking unauthorized access to Asana projects and sensitive task information."
-regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9]{16})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9]{16})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["asana"]
 
 [[rules]]
 id = "asana-client-secret"
 description = "Identified an Asana Client Secret, which could lead to compromised project management integrity and unauthorized access."
-regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["asana"]
 
 [[rules]]
 id = "atlassian-api-token"
 description = "Detected an Atlassian API token, posing a threat to project management and collaboration tool security and data confidentiality."
-regex = '''(?i)[\w.-]{0,50}?(?:atlassian|confluence|jira)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{24})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:atlassian|confluence|jira)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "atlassian",
     "confluence",
@@ -141,7 +141,7 @@ keywords = [
 [[rules]]
 id = "authress-service-client-access-key"
 description = "Uncovered a possible Authress Service Client Access Key, which may compromise access control services and sensitive data."
-regex = '''\b((?:sc|ext|scauth|authress)_(?i)[a-z0-9]{5,30}\.[a-z0-9]{4,6}\.(?-i:acc)[_-][a-z0-9-]{10,32}\.[a-z0-9+/_=-]{30,120})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b((?:sc|ext|scauth|authress)_(?i)[a-z0-9]{5,30}\.[a-z0-9]{4,6}\.(?-i:acc)[_-][a-z0-9-]{10,32}\.[a-z0-9+/_=-]{30,120})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = [
     "sc_",
@@ -178,31 +178,31 @@ keywords = ["q~"]
 [[rules]]
 id = "beamer-api-token"
 description = "Detected a Beamer API token, potentially compromising content management and exposing sensitive notifications and updates."
-regex = '''(?i)[\w.-]{0,50}?(?:beamer)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(b_[a-z0-9=_\-]{44})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:beamer)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(b_[a-z0-9=_\-]{44})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["beamer"]
 
 [[rules]]
 id = "bitbucket-client-id"
 description = "Discovered a potential Bitbucket Client ID, risking unauthorized repository access and potential codebase exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["bitbucket"]
 
 [[rules]]
 id = "bitbucket-client-secret"
 description = "Discovered a potential Bitbucket Client Secret, posing a risk of compromised code repositories and unauthorized access."
-regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["bitbucket"]
 
 [[rules]]
 id = "bittrex-access-key"
 description = "Identified a Bittrex Access Key, which could lead to unauthorized access to cryptocurrency trading accounts and financial loss."
-regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["bittrex"]
 
 [[rules]]
 id = "bittrex-secret-key"
 description = "Detected a Bittrex Secret Key, potentially compromising cryptocurrency transactions and financial security."
-regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["bittrex"]
 
 [[rules]]
@@ -215,21 +215,21 @@ keywords = ["clojars_"]
 [[rules]]
 id = "cloudflare-api-key"
 description = "Detected a Cloudflare API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9_-]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["cloudflare"]
 
 [[rules]]
 id = "cloudflare-global-api-key"
 description = "Detected a Cloudflare Global API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{37})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{37})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["cloudflare"]
 
 [[rules]]
 id = "cloudflare-origin-ca-key"
 description = "Detected a Cloudflare Origin CA Key, potentially compromising cloud application deployments and operational security."
-regex = '''\b(v1\.0-[a-f0-9]{24}-[a-f0-9]{146})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(v1\.0-[a-f0-9]{24}-[a-f0-9]{146})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = [
     "cloudflare",
@@ -239,13 +239,13 @@ keywords = [
 [[rules]]
 id = "codecov-access-token"
 description = "Found a pattern resembling a Codecov Access Token, posing a risk of unauthorized access to code coverage reports and sensitive data."
-regex = '''(?i)[\w.-]{0,50}?(?:codecov)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:codecov)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["codecov"]
 
 [[rules]]
 id = "cohere-api-token"
 description = "Identified a Cohere Token, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:cohere|CO_API_KEY)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-zA-Z0-9]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:cohere|CO_API_KEY)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-zA-Z0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 4
 keywords = [
     "cohere",
@@ -255,25 +255,25 @@ keywords = [
 [[rules]]
 id = "coinbase-access-token"
 description = "Detected a Coinbase Access Token, posing a risk of unauthorized access to cryptocurrency accounts and financial transactions."
-regex = '''(?i)[\w.-]{0,50}?(?:coinbase)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9_-]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:coinbase)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["coinbase"]
 
 [[rules]]
 id = "confluent-access-token"
 description = "Identified a Confluent Access Token, which could compromise access to streaming data platforms and sensitive data flow."
-regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{16})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{16})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["confluent"]
 
 [[rules]]
 id = "confluent-secret-key"
 description = "Found a Confluent Secret Key, potentially risking unauthorized operations and data access within Confluent services."
-regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["confluent"]
 
 [[rules]]
 id = "contentful-delivery-api-token"
 description = "Discovered a Contentful delivery API token, posing a risk to content management systems and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:contentful)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{43})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:contentful)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{43})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["contentful"]
 
 [[rules]]
@@ -303,59 +303,59 @@ regexes = [
 [[rules]]
 id = "databricks-api-token"
 description = "Uncovered a Databricks API token, which may compromise big data analytics platforms and sensitive data processing."
-regex = '''\b(dapi[a-f0-9]{32}(?:-\d)?)(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(dapi[a-f0-9]{32}(?:-\d)?)(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["dapi"]
 
 [[rules]]
 id = "datadog-access-token"
 description = "Detected a Datadog Access Token, potentially risking monitoring and analytics data exposure and manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:datadog)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:datadog)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["datadog"]
 
 [[rules]]
 id = "defined-networking-api-token"
 description = "Identified a Defined Networking API token, which could lead to unauthorized network operations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:dnkey)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dnkey)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["dnkey"]
 
 [[rules]]
 id = "digitalocean-access-token"
 description = "Found a DigitalOcean OAuth Access Token, risking unauthorized cloud resource access and data compromise."
-regex = '''\b(doo_v1_[a-f0-9]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(doo_v1_[a-f0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["doo_v1_"]
 
 [[rules]]
 id = "digitalocean-pat"
 description = "Discovered a DigitalOcean Personal Access Token, posing a threat to cloud infrastructure security and data privacy."
-regex = '''\b(dop_v1_[a-f0-9]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(dop_v1_[a-f0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["dop_v1_"]
 
 [[rules]]
 id = "digitalocean-refresh-token"
 description = "Uncovered a DigitalOcean OAuth Refresh Token, which could allow prolonged unauthorized access and resource manipulation."
-regex = '''(?i)\b(dor_v1_[a-f0-9]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)\b(dor_v1_[a-f0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["dor_v1_"]
 
 [[rules]]
 id = "discord-api-token"
 description = "Detected a Discord API key, potentially compromising communication channels and user data privacy on Discord."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["discord"]
 
 [[rules]]
 id = "discord-client-id"
 description = "Identified a Discord client ID, which may lead to unauthorized integrations and data exposure in Discord applications."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9]{18})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9]{18})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["discord"]
 
 [[rules]]
 id = "discord-client-secret"
 description = "Discovered a potential Discord client secret, risking compromised Discord bot integrations and data leaks."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["discord"]
 
@@ -369,25 +369,25 @@ keywords = ["dp.pt."]
 [[rules]]
 id = "droneci-access-token"
 description = "Detected a Droneci Access Token, potentially compromising continuous integration and deployment workflows."
-regex = '''(?i)[\w.-]{0,50}?(?:droneci)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:droneci)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["droneci"]
 
 [[rules]]
 id = "dropbox-api-token"
 description = "Identified a Dropbox API secret, which could lead to unauthorized file access and data breaches in Dropbox storage."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{15})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{15})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
 id = "dropbox-long-lived-api-token"
 description = "Found a Dropbox long-lived API token, risking prolonged unauthorized access to cloud storage and sensitive data."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
 id = "dropbox-short-lived-api-token"
 description = "Discovered a Dropbox short-lived API token, posing a risk of temporary but potentially harmful data access and manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(sl\.[a-z0-9\-=_]{135})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(sl\.[a-z0-9\-=_]{135})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
@@ -421,20 +421,20 @@ keywords = ["eztk"]
 [[rules]]
 id = "etsy-access-token"
 description = "Found an Etsy Access Token, potentially compromising Etsy shop management and customer data."
-regex = '''(?i)[\w.-]{0,50}?(?:(?-i:ETSY|[Ee]tsy))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{24})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:(?-i:ETSY|[Ee]tsy))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["etsy"]
 
 [[rules]]
 id = "facebook-access-token"
 description = "Discovered a Facebook Access Token, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''(?i)\b(\d{15,16}(\||%)[0-9a-z\-_]{27,40})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)\b(\d{15,16}(\||%)[0-9a-z\-_]{27,40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 
 [[rules]]
 id = "facebook-page-access-token"
 description = "Discovered a Facebook Page Access Token, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''\b(EAA[MC](?i)[a-z0-9]{100,})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(EAA[MC](?i)[a-z0-9]{100,})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 4
 keywords = [
     "eaam",
@@ -444,38 +444,38 @@ keywords = [
 [[rules]]
 id = "facebook-secret"
 description = "Discovered a Facebook Application secret, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:facebook)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:facebook)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["facebook"]
 
 [[rules]]
 id = "fastly-api-token"
 description = "Uncovered a Fastly API key, which may compromise CDN and edge cloud services, leading to content delivery and security issues."
-regex = '''(?i)[\w.-]{0,50}?(?:fastly)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:fastly)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["fastly"]
 
 [[rules]]
 id = "finicity-api-token"
 description = "Detected a Finicity API token, potentially risking financial data access and unauthorized financial operations."
-regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["finicity"]
 
 [[rules]]
 id = "finicity-client-secret"
 description = "Identified a Finicity Client Secret, which could lead to compromised financial service integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{20})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["finicity"]
 
 [[rules]]
 id = "finnhub-access-token"
 description = "Found a Finnhub Access Token, risking unauthorized access to financial market data and analytics."
-regex = '''(?i)[\w.-]{0,50}?(?:finnhub)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{20})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finnhub)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["finnhub"]
 
 [[rules]]
 id = "flickr-access-token"
 description = "Discovered a Flickr Access Token, posing a risk of unauthorized photo management and potential data leakage."
-regex = '''(?i)[\w.-]{0,50}?(?:flickr)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:flickr)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["flickr"]
 
 [[rules]]
@@ -502,7 +502,7 @@ keywords = ["flwseck_test"]
 [[rules]]
 id = "flyio-access-token"
 description = "Uncovered a Fly.io API key"
-regex = '''\b((?:fo1_[\w-]{43}|fm1[ar]_[a-zA-Z0-9+\/]{100,}={0,3}|fm2_[a-zA-Z0-9+\/]{100,}={0,3}))(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b((?:fo1_[\w-]{43}|fm1[ar]_[a-zA-Z0-9+\/]{100,}={0,3}|fm2_[a-zA-Z0-9+\/]{100,}={0,3}))(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 4
 keywords = [
     "fo1_",
@@ -519,20 +519,20 @@ keywords = ["fio-u-"]
 [[rules]]
 id = "freshbooks-access-token"
 description = "Discovered a Freshbooks Access Token, posing a risk to accounting software access and sensitive financial data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:freshbooks)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:freshbooks)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["freshbooks"]
 
 [[rules]]
 id = "gcp-api-key"
 description = "Uncovered a GCP API key, which could lead to unauthorized access to Google Cloud services and data breaches."
-regex = '''\b(AIza[\w-]{35})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(AIza[\w-]{35})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["aiza"]
 
 [[rules]]
 id = "generic-api-key"
 description = "Detected a Generic API Key, potentially exposing access to various services and sensitive operations."
-regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passwd|password|secret|token)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([\w.=-]{10,150})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passwd|password|secret|token)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([\w.=-]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3.5
 keywords = [
     "access",
@@ -2173,13 +2173,13 @@ keywords = ["_gitlab_session="]
 [[rules]]
 id = "gitter-access-token"
 description = "Uncovered a Gitter Access Token, which may lead to unauthorized access to chat and communication services."
-regex = '''(?i)[\w.-]{0,50}?(?:gitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9_-]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:gitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["gitter"]
 
 [[rules]]
 id = "gocardless-api-token"
 description = "Detected a GoCardless API token, potentially risking unauthorized direct debit payment operations and financial data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:gocardless)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(live_(?i)[a-z0-9\-_=]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:gocardless)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(live_(?i)[a-z0-9\-_=]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "live_",
     "gocardless",
@@ -2188,21 +2188,21 @@ keywords = [
 [[rules]]
 id = "grafana-api-key"
 description = "Identified a Grafana API key, which could compromise monitoring dashboards and sensitive data analytics."
-regex = '''(?i)\b(eyJrIjoi[A-Za-z0-9]{70,400}={0,3})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)\b(eyJrIjoi[A-Za-z0-9]{70,400}={0,3})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["eyjrijoi"]
 
 [[rules]]
 id = "grafana-cloud-api-token"
 description = "Found a Grafana cloud API token, risking unauthorized access to cloud-based monitoring services and data exposure."
-regex = '''(?i)\b(glc_[A-Za-z0-9+/]{32,400}={0,3})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)\b(glc_[A-Za-z0-9+/]{32,400}={0,3})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["glc_"]
 
 [[rules]]
 id = "grafana-service-account-token"
 description = "Discovered a Grafana service account token, posing a risk of compromised monitoring services and data integrity."
-regex = '''(?i)\b(glsa_[A-Za-z0-9]{32}_[A-Fa-f0-9]{8})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)\b(glsa_[A-Za-z0-9]{32}_[A-Fa-f0-9]{8})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["glsa_"]
 
@@ -2225,7 +2225,7 @@ keywords = ["atlasv1"]
 [[rules]]
 id = "hashicorp-tf-password"
 description = "Identified a HashiCorp Terraform password field, risking unauthorized infrastructure configuration and security breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:administrator_login_password|password)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}("[a-z0-9=_\-]{8,20}")(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:administrator_login_password|password)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}("[a-z0-9=_\-]{8,20}")(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 path = '''(?i)\.(?:tf|hcl)$'''
 entropy = 2
 keywords = [
@@ -2236,46 +2236,46 @@ keywords = [
 [[rules]]
 id = "heroku-api-key"
 description = "Detected a Heroku API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:heroku)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:heroku)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["heroku"]
 
 [[rules]]
 id = "hubspot-api-key"
 description = "Found a HubSpot API Token, posing a risk to CRM data integrity and unauthorized marketing operations."
-regex = '''(?i)[\w.-]{0,50}?(?:hubspot)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:hubspot)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["hubspot"]
 
 [[rules]]
 id = "huggingface-access-token"
 description = "Discovered a Hugging Face Access token, which could lead to unauthorized access to AI models and sensitive data."
-regex = '''\b(hf_(?i:[a-z]{34}))(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(hf_(?i:[a-z]{34}))(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["hf_"]
 
 [[rules]]
 id = "huggingface-organization-api-token"
 description = "Uncovered a Hugging Face Organization API token, potentially compromising AI organization accounts and associated data."
-regex = '''\b(api_org_(?i:[a-z]{34}))(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(api_org_(?i:[a-z]{34}))(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["api_org_"]
 
 [[rules]]
 id = "infracost-api-token"
 description = "Detected an Infracost API Token, risking unauthorized access to cloud cost estimation tools and financial data."
-regex = '''\b(ico-[a-zA-Z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(ico-[a-zA-Z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["ico-"]
 
 [[rules]]
 id = "intercom-api-key"
 description = "Identified an Intercom API Token, which could compromise customer communication channels and data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:intercom)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{60})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:intercom)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{60})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["intercom"]
 
 [[rules]]
 id = "intra42-client-secret"
 description = "Found a Intra42 client secret, which could lead to unauthorized access to the 42School API and sensitive data."
-regex = '''\b(s-s4t2(?:ud|af)-(?i)[abcdef0123456789]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(s-s4t2(?:ud|af)-(?i)[abcdef0123456789]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = [
     "intra",
@@ -2286,7 +2286,7 @@ keywords = [
 [[rules]]
 id = "jfrog-api-key"
 description = "Found a JFrog API Key, posing a risk of unauthorized access to software artifact repositories and build pipelines."
-regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{73})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{73})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "jfrog",
     "artifactory",
@@ -2297,7 +2297,7 @@ keywords = [
 [[rules]]
 id = "jfrog-identity-token"
 description = "Discovered a JFrog Identity Token, potentially compromising access to JFrog services and sensitive software artifacts."
-regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "jfrog",
     "artifactory",
@@ -2308,7 +2308,7 @@ keywords = [
 [[rules]]
 id = "jwt"
 description = "Uncovered a JSON Web Token, which may lead to unauthorized access to web applications and sensitive user data."
-regex = '''\b(ey[a-zA-Z0-9]{17,}\.ey[a-zA-Z0-9\/\\_-]{17,}\.(?:[a-zA-Z0-9\/\\_-]{10,}={0,2})?)(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(ey[a-zA-Z0-9]{17,}\.ey[a-zA-Z0-9\/\\_-]{17,}\.(?:[a-zA-Z0-9\/\\_-]{10,}={0,2})?)(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["ey"]
 
@@ -2322,7 +2322,7 @@ keywords = ["zxlk"]
 [[rules]]
 id = "kraken-access-token"
 description = "Identified a Kraken Access Token, potentially compromising cryptocurrency trading accounts and financial security."
-regex = '''(?i)[\w.-]{0,50}?(?:kraken)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9\/=_\+\-]{80,90})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kraken)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9\/=_\+\-]{80,90})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["kraken"]
 
 [[rules]]
@@ -2340,19 +2340,19 @@ regexes = [
 [[rules]]
 id = "kucoin-access-token"
 description = "Found a Kucoin Access Token, risking unauthorized access to cryptocurrency exchange services and transactions."
-regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{24})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["kucoin"]
 
 [[rules]]
 id = "kucoin-secret-key"
 description = "Discovered a Kucoin Secret Key, which could lead to compromised cryptocurrency operations and financial data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["kucoin"]
 
 [[rules]]
 id = "launchdarkly-access-token"
 description = "Uncovered a Launchdarkly Access Token, potentially compromising feature flag management and application functionality."
-regex = '''(?i)[\w.-]{0,50}?(?:launchdarkly)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:launchdarkly)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["launchdarkly"]
 
 [[rules]]
@@ -2365,14 +2365,14 @@ keywords = ["lin_api_"]
 [[rules]]
 id = "linear-client-secret"
 description = "Identified a Linear Client Secret, which may compromise secure integrations and sensitive project management data."
-regex = '''(?i)[\w.-]{0,50}?(?:linear)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linear)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["linear"]
 
 [[rules]]
 id = "linkedin-client-id"
 description = "Found a LinkedIn Client ID, risking unauthorized access to LinkedIn integrations and professional data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{14})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{14})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = [
     "linkedin",
@@ -2383,7 +2383,7 @@ keywords = [
 [[rules]]
 id = "linkedin-client-secret"
 description = "Discovered a LinkedIn Client secret, potentially compromising LinkedIn application integrations and user data."
-regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{16})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{16})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = [
     "linkedin",
@@ -2394,7 +2394,7 @@ keywords = [
 [[rules]]
 id = "lob-api-key"
 description = "Uncovered a Lob API Key, which could lead to unauthorized access to mailing and address verification services."
-regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}((live|test)_[a-f0-9]{35})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}((live|test)_[a-f0-9]{35})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "test_",
     "live_",
@@ -2403,7 +2403,7 @@ keywords = [
 [[rules]]
 id = "lob-pub-api-key"
 description = "Detected a Lob Publishable API Key, posing a risk of exposing mail and print service integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}((test|live)_pub_[a-f0-9]{31})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}((test|live)_pub_[a-f0-9]{31})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "test_pub",
     "live_pub",
@@ -2413,43 +2413,43 @@ keywords = [
 [[rules]]
 id = "mailchimp-api-key"
 description = "Identified a Mailchimp API key, potentially compromising email marketing campaigns and subscriber data."
-regex = '''(?i)[\w.-]{0,50}?(?:MailchimpSDK.initialize|mailchimp)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{32}-us\d\d)(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:MailchimpSDK.initialize|mailchimp)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{32}-us\d\d)(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["mailchimp"]
 
 [[rules]]
 id = "mailgun-private-api-token"
 description = "Found a Mailgun private API token, risking unauthorized email service operations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(key-[a-f0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(key-[a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mailgun-pub-key"
 description = "Discovered a Mailgun public validation key, which could expose email verification processes and associated data."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(pubkey-[a-f0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(pubkey-[a-f0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mailgun-signing-key"
 description = "Uncovered a Mailgun webhook signing key, potentially compromising email automation and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mapbox-api-token"
 description = "Detected a MapBox API token, posing a risk to geospatial services and sensitive location data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:mapbox)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(pk\.[a-z0-9]{60}\.[a-z0-9]{22})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mapbox)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(pk\.[a-z0-9]{60}\.[a-z0-9]{22})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["mapbox"]
 
 [[rules]]
 id = "mattermost-access-token"
 description = "Identified a Mattermost Access Token, which may compromise team communication channels and data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:mattermost)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{26})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mattermost)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{26})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["mattermost"]
 
 [[rules]]
 id = "messagebird-api-token"
 description = "Found a MessageBird API token, risking unauthorized access to communication platforms and message data."
-regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{25})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{25})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "messagebird",
     "message-bird",
@@ -2459,7 +2459,7 @@ keywords = [
 [[rules]]
 id = "messagebird-client-id"
 description = "Discovered a MessageBird client ID, potentially compromising API integrations and sensitive communication data."
-regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "messagebird",
     "message-bird",
@@ -2479,25 +2479,25 @@ keywords = [
 [[rules]]
 id = "netlify-access-token"
 description = "Detected a Netlify Access Token, potentially compromising web hosting services and site management."
-regex = '''(?i)[\w.-]{0,50}?(?:netlify)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{40,46})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:netlify)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{40,46})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["netlify"]
 
 [[rules]]
 id = "new-relic-browser-api-token"
 description = "Identified a New Relic ingest browser API token, risking unauthorized access to application performance data and analytics."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(NRJS-[a-f0-9]{19})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(NRJS-[a-f0-9]{19})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["nrjs-"]
 
 [[rules]]
 id = "new-relic-insert-key"
 description = "Discovered a New Relic insight insert key, compromising data injection into the platform."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(NRII-[a-z0-9-]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(NRII-[a-z0-9-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["nrii-"]
 
 [[rules]]
 id = "new-relic-user-api-id"
 description = "Found a New Relic user API ID, posing a risk to application monitoring services and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "new-relic",
     "newrelic",
@@ -2507,13 +2507,13 @@ keywords = [
 [[rules]]
 id = "new-relic-user-api-key"
 description = "Discovered a New Relic user API Key, which could lead to compromised application insights and performance monitoring."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(NRAK-[a-z0-9]{27})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(NRAK-[a-z0-9]{27})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["nrak"]
 
 [[rules]]
 id = "npm-access-token"
 description = "Uncovered an npm access token, potentially compromising package management and code repository access."
-regex = '''(?i)\b(npm_[a-z0-9]{36})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)\b(npm_[a-z0-9]{36})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["npm_"]
 
@@ -2535,7 +2535,7 @@ regexes = [
 [[rules]]
 id = "nytimes-access-token"
 description = "Detected a Nytimes Access Token, risking unauthorized access to New York Times APIs and content services."
-regex = '''(?i)[\w.-]{0,50}?(?:nytimes|new-york-times,|newyorktimes)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9=_\-]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:nytimes|new-york-times,|newyorktimes)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "nytimes",
     "new-york-times",
@@ -2545,21 +2545,21 @@ keywords = [
 [[rules]]
 id = "octopus-deploy-api-key"
 description = "Discovered a potential Octopus Deploy API key, risking application deployments and operational security."
-regex = '''\b(API-[A-Z0-9]{26})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(API-[A-Z0-9]{26})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["api-"]
 
 [[rules]]
 id = "okta-access-token"
 description = "Identified an Okta Access Token, which may compromise identity management services and user authentication data."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Oo]kta|OKTA))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(00[\w=\-]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Oo]kta|OKTA))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(00[\w=\-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 4
 keywords = ["okta"]
 
 [[rules]]
 id = "openai-api-key"
 description = "Found an OpenAI API Key, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''\b(sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["t3blbkfj"]
 
@@ -2573,55 +2573,55 @@ keywords = ["sha256~"]
 [[rules]]
 id = "plaid-api-token"
 description = "Discovered a Plaid API Token, potentially compromising financial data aggregation and banking services."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["plaid"]
 
 [[rules]]
 id = "plaid-client-id"
 description = "Uncovered a Plaid Client ID, which could lead to unauthorized financial service integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{24})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{24})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3.5
 keywords = ["plaid"]
 
 [[rules]]
 id = "plaid-secret-key"
 description = "Detected a Plaid Secret key, risking unauthorized access to financial accounts and sensitive transaction data."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{30})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{30})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3.5
 keywords = ["plaid"]
 
 [[rules]]
 id = "planetscale-api-token"
 description = "Identified a PlanetScale API token, potentially compromising database management and operations."
-regex = '''\b(pscale_tkn_(?i)[\w=\.-]{32,64})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(pscale_tkn_(?i)[\w=\.-]{32,64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["pscale_tkn_"]
 
 [[rules]]
 id = "planetscale-oauth-token"
 description = "Found a PlanetScale OAuth token, posing a risk to database access control and sensitive data integrity."
-regex = '''\b(pscale_oauth_[\w=\.-]{32,64})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(pscale_oauth_[\w=\.-]{32,64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["pscale_oauth_"]
 
 [[rules]]
 id = "planetscale-password"
 description = "Discovered a PlanetScale password, which could lead to unauthorized database operations and data breaches."
-regex = '''(?i)\b(pscale_pw_(?i)[\w=\.-]{32,64})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)\b(pscale_pw_(?i)[\w=\.-]{32,64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["pscale_pw_"]
 
 [[rules]]
 id = "postman-api-token"
 description = "Uncovered a Postman API token, potentially compromising API testing and development workflows."
-regex = '''\b(PMAK-(?i)[a-f0-9]{24}\-[a-f0-9]{34})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(PMAK-(?i)[a-f0-9]{24}\-[a-f0-9]{34})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["pmak-"]
 
 [[rules]]
 id = "prefect-api-token"
 description = "Detected a Prefect API token, risking unauthorized access to workflow management and automation services."
-regex = '''\b(pnu_[a-zA-Z0-9]{36})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(pnu_[a-zA-Z0-9]{36})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["pnu_"]
 
@@ -2634,7 +2634,7 @@ keywords = ["-----begin"]
 [[rules]]
 id = "privateai-api-token"
 description = "Identified a PrivateAI Token, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:private[_-]?ai)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{32})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:private[_-]?ai)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{32})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = [
     "privateai",
@@ -2645,7 +2645,7 @@ keywords = [
 [[rules]]
 id = "pulumi-api-token"
 description = "Found a Pulumi API token, posing a risk to infrastructure as code services and cloud resource management."
-regex = '''\b(pul-[a-f0-9]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(pul-[a-f0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["pul-"]
 
@@ -2659,66 +2659,66 @@ keywords = ["pypi-ageichlwas5vcmc"]
 [[rules]]
 id = "rapidapi-access-token"
 description = "Uncovered a RapidAPI Access Token, which could lead to unauthorized access to various APIs and data services."
-regex = '''(?i)[\w.-]{0,50}?(?:rapidapi)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9_-]{50})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:rapidapi)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9_-]{50})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["rapidapi"]
 
 [[rules]]
 id = "readme-api-token"
 description = "Detected a Readme API token, risking unauthorized documentation management and content exposure."
-regex = '''\b(rdme_[a-z0-9]{70})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(rdme_[a-z0-9]{70})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["rdme_"]
 
 [[rules]]
 id = "rubygems-api-token"
 description = "Identified a Rubygem API token, potentially compromising Ruby library distribution and package management."
-regex = '''\b(rubygems_[a-f0-9]{48})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(rubygems_[a-f0-9]{48})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["rubygems_"]
 
 [[rules]]
 id = "scalingo-api-token"
 description = "Found a Scalingo API token, posing a risk to cloud platform services and application deployment security."
-regex = '''\b(tk-us-[\w-]{48})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(tk-us-[\w-]{48})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["tk-us-"]
 
 [[rules]]
 id = "sendbird-access-id"
 description = "Discovered a Sendbird Access ID, which could compromise chat and messaging platform integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["sendbird"]
 
 [[rules]]
 id = "sendbird-access-token"
 description = "Uncovered a Sendbird Access Token, potentially risking unauthorized access to communication services and user data."
-regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["sendbird"]
 
 [[rules]]
 id = "sendgrid-api-token"
 description = "Detected a SendGrid API token, posing a risk of unauthorized email service operations and data exposure."
-regex = '''\b(SG\.(?i)[a-z0-9=_\-\.]{66})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(SG\.(?i)[a-z0-9=_\-\.]{66})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["sg."]
 
 [[rules]]
 id = "sendinblue-api-token"
 description = "Identified a Sendinblue API token, which may compromise email marketing services and subscriber data privacy."
-regex = '''\b(xkeysib-[a-f0-9]{64}\-(?i)[a-z0-9]{16})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(xkeysib-[a-f0-9]{64}\-(?i)[a-z0-9]{16})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["xkeysib-"]
 
 [[rules]]
 id = "sentry-access-token"
 description = "Found a Sentry Access Token, risking unauthorized access to error tracking services and sensitive application data."
-regex = '''(?i)[\w.-]{0,50}?(?:sentry)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sentry)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["sentry"]
 
 [[rules]]
 id = "shippo-api-token"
 description = "Discovered a Shippo API token, potentially compromising shipping services and customer order data."
-regex = '''\b(shippo_(?:live|test)_[a-fA-F0-9]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(shippo_(?:live|test)_[a-fA-F0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = ["shippo_"]
 
@@ -2753,7 +2753,7 @@ keywords = ["shpss_"]
 [[rules]]
 id = "sidekiq-secret"
 description = "Discovered a Sidekiq Secret, which could lead to compromised background job processing and application data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:BUNDLE_ENTERPRISE__CONTRIBSYS__COM|BUNDLE_GEMS__CONTRIBSYS__COM)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-f0-9]{8}:[a-f0-9]{8})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:BUNDLE_ENTERPRISE__CONTRIBSYS__COM|BUNDLE_GEMS__CONTRIBSYS__COM)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-f0-9]{8}:[a-f0-9]{8})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = [
     "bundle_enterprise__contribsys__com",
     "bundle_gems__contribsys__com",
@@ -2845,13 +2845,13 @@ keywords = ["hooks.slack.com"]
 [[rules]]
 id = "snyk-api-token"
 description = "Uncovered a Snyk API token, potentially compromising software vulnerability scanning and code security."
-regex = '''(?i)[\w.-]{0,50}?(?:snyk[_.-]?(?:(?:api|oauth)[_.-]?)?(?:key|token))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:snyk[_.-]?(?:(?:api|oauth)[_.-]?)?(?:key|token))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["snyk"]
 
 [[rules]]
 id = "square-access-token"
 description = "Detected a Square Access Token, risking unauthorized payment processing and financial transaction exposure."
-regex = '''\b((?:EAAA|sq0atp-)[\w-]{22,60})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b((?:EAAA|sq0atp-)[\w-]{22,60})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = [
     "sq0atp-",
@@ -2861,13 +2861,13 @@ keywords = [
 [[rules]]
 id = "squarespace-access-token"
 description = "Identified a Squarespace Access Token, which may compromise website management and content control on Squarespace."
-regex = '''(?i)[\w.-]{0,50}?(?:squarespace)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:squarespace)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["squarespace"]
 
 [[rules]]
 id = "stripe-access-token"
 description = "Found a Stripe Access Token, posing a risk to payment processing services and sensitive financial data."
-regex = '''\b((?:sk|rk)_(?:test|live|prod)_[a-zA-Z0-9]{10,99})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b((?:sk|rk)_(?:test|live|prod)_[a-zA-Z0-9]{10,99})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 2
 keywords = [
     "sk_test",
@@ -2881,27 +2881,27 @@ keywords = [
 [[rules]]
 id = "sumologic-access-id"
 description = "Discovered a SumoLogic Access ID, potentially compromising log management services and data analytics integrity."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(su[a-zA-Z0-9]{12})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(su[a-zA-Z0-9]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["sumo"]
 
 [[rules]]
 id = "sumologic-access-token"
 description = "Uncovered a SumoLogic Access Token, which could lead to unauthorized access to log data and analytics insights."
-regex = '''(?i)[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{64})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{64})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["sumo"]
 
 [[rules]]
 id = "telegram-bot-api-token"
 description = "Detected a Telegram Bot API Token, risking unauthorized bot operations and message interception on Telegram."
-regex = '''(?i)[\w.-]{0,50}?(?:telegr)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9]{5,16}:(?-i:A)[a-z0-9_\-]{34})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:telegr)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9]{5,16}:(?-i:A)[a-z0-9_\-]{34})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["telegr"]
 
 [[rules]]
 id = "travisci-access-token"
 description = "Identified a Travis CI Access Token, potentially compromising continuous integration services and codebase security."
-regex = '''(?i)[\w.-]{0,50}?(?:travis)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{22})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:travis)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{22})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["travis"]
 
 [[rules]]
@@ -2914,56 +2914,56 @@ keywords = ["sk"]
 [[rules]]
 id = "twitch-api-token"
 description = "Discovered a Twitch API token, which could compromise streaming services and account integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:twitch)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{30})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitch)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{30})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["twitch"]
 
 [[rules]]
 id = "twitter-access-secret"
 description = "Uncovered a Twitter Access Secret, potentially risking unauthorized Twitter integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{45})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{45})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-access-token"
 description = "Detected a Twitter Access Token, posing a risk of unauthorized account operations and social media data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([0-9]{15,25}-[a-zA-Z0-9]{20,40})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9]{15,25}-[a-zA-Z0-9]{20,40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-api-key"
 description = "Identified a Twitter API Key, which may compromise Twitter application integrations and user data security."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{25})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{25})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-api-secret"
 description = "Found a Twitter API Secret, risking the security of Twitter app integrations and sensitive data access."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{50})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{50})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-bearer-token"
 description = "Discovered a Twitter Bearer Token, potentially compromising API access and data retrieval from Twitter."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(A{22}[a-zA-Z0-9%]{80,100})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(A{22}[a-zA-Z0-9%]{80,100})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "typeform-api-token"
 description = "Uncovered a Typeform API token, which could lead to unauthorized survey management and data collection."
-regex = '''(?i)[\w.-]{0,50}?(?:typeform)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(tfp_[a-z0-9\-_\.=]{59})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:typeform)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(tfp_[a-z0-9\-_\.=]{59})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["tfp_"]
 
 [[rules]]
 id = "vault-batch-token"
 description = "Detected a Vault Batch Token, risking unauthorized access to secret management services and sensitive data."
-regex = '''\b(hvb\.[\w-]{138,300})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b(hvb\.[\w-]{138,300})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 4
 keywords = ["hvb."]
 
 [[rules]]
 id = "vault-service-token"
 description = "Identified a Vault Service Token, potentially compromising infrastructure security and access to sensitive credentials."
-regex = '''\b((?:hvs\.[\w-]{90,120}|s\.(?i:[a-z0-9]{24})))(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''\b((?:hvs\.[\w-]{90,120}|s\.(?i:[a-z0-9]{24})))(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3.5
 keywords = [
     "hvs.",
@@ -2978,24 +2978,24 @@ regexes = [
 [[rules]]
 id = "yandex-access-token"
 description = "Found a Yandex Access Token, posing a risk to Yandex service integrations and user data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "yandex-api-key"
 description = "Discovered a Yandex API Key, which could lead to unauthorized access to Yandex services and data manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(AQVN[A-Za-z0-9_\-]{35,38})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(AQVN[A-Za-z0-9_\-]{35,38})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "yandex-aws-access-token"
 description = "Uncovered a Yandex AWS Access Token, potentially compromising cloud resource access and data security on Yandex Cloud."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}(YC[a-zA-Z0-9_\-]{38})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(YC[a-zA-Z0-9_\-]{38})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "zendesk-secret-key"
 description = "Detected a Zendesk Secret Key, risking unauthorized access to customer support services and sensitive ticketing data."
-regex = '''(?i)[\w.-]{0,50}?(?:zendesk)(?:[\w \t.-]{0,20})(?:\\*[\'\"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,|\|)(?:\\*[\'"]|[\x60\s|>]){0,5}([a-z0-9]{40})(?:[\s\'\"\x60&;\\<,)]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:zendesk)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 keywords = ["zendesk"]
 

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -67,20 +67,20 @@ keywords = ["ops_"]
 [[rules]]
 id = "adafruit-api-key"
 description = "Identified a potential Adafruit API Key, which could lead to unauthorized access to Adafruit services and sensitive data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:adafruit)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9_-]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:adafruit)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9_-]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["adafruit"]
 
 [[rules]]
 id = "adobe-client-id"
 description = "Detected a pattern that resembles an Adobe OAuth Web Client ID, posing a risk of compromised Adobe integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:adobe)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:adobe)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["adobe"]
 
 [[rules]]
 id = "adobe-client-secret"
 description = "Discovered a potential Adobe Client Secret, which, if exposed, could allow unauthorized Adobe service access and data manipulation."
-regex = '''\b(p8e-(?i)[a-z0-9]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(p8e-(?i)[a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["p8e-"]
 
@@ -93,45 +93,45 @@ keywords = ["age-secret-key-1"]
 [[rules]]
 id = "airtable-api-key"
 description = "Uncovered a possible Airtable API Key, potentially compromising database access and leading to data leakage or alteration."
-regex = '''(?i)[\w.-]{0,50}?(?:airtable)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{17})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:airtable)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{17})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["airtable"]
 
 [[rules]]
 id = "algolia-api-key"
 description = "Identified an Algolia API Key, which could result in unauthorized search operations and data exposure on Algolia-managed platforms."
-regex = '''(?i)[\w.-]{0,50}?(?:algolia)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:algolia)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["algolia"]
 
 [[rules]]
 id = "alibaba-access-key-id"
 description = "Detected an Alibaba Cloud AccessKey ID, posing a risk of unauthorized cloud resource access and potential data compromise."
-regex = '''\b(LTAI(?i)[a-z0-9]{20})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(LTAI(?i)[a-z0-9]{20})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["ltai"]
 
 [[rules]]
 id = "alibaba-secret-key"
 description = "Discovered a potential Alibaba Cloud Secret Key, potentially allowing unauthorized operations and data access within Alibaba Cloud."
-regex = '''(?i)[\w.-]{0,50}?(?:alibaba)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{30})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:alibaba)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{30})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["alibaba"]
 
 [[rules]]
 id = "asana-client-id"
 description = "Discovered a potential Asana Client ID, risking unauthorized access to Asana projects and sensitive task information."
-regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9]{16})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9]{16})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["asana"]
 
 [[rules]]
 id = "asana-client-secret"
 description = "Identified an Asana Client Secret, which could lead to compromised project management integrity and unauthorized access."
-regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["asana"]
 
 [[rules]]
 id = "atlassian-api-token"
 description = "Detected an Atlassian API token, posing a threat to project management and collaboration tool security and data confidentiality."
-regex = '''(?i)[\w.-]{0,50}?(?:atlassian|confluence|jira)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{24})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:atlassian|confluence|jira)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{24})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "atlassian",
     "confluence",
@@ -141,7 +141,7 @@ keywords = [
 [[rules]]
 id = "authress-service-client-access-key"
 description = "Uncovered a possible Authress Service Client Access Key, which may compromise access control services and sensitive data."
-regex = '''\b((?:sc|ext|scauth|authress)_(?i)[a-z0-9]{5,30}\.[a-z0-9]{4,6}\.(?-i:acc)[_-][a-z0-9-]{10,32}\.[a-z0-9+/_=-]{30,120})(?:['"\x60\s;\\]|$)'''
+regex = '''\b((?:sc|ext|scauth|authress)_(?i)[a-z0-9]{5,30}\.[a-z0-9]{4,6}\.(?-i:acc)[_-][a-z0-9-]{10,32}\.[a-z0-9+/_=-]{30,120})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "sc_",
@@ -178,31 +178,31 @@ keywords = ["q~"]
 [[rules]]
 id = "beamer-api-token"
 description = "Detected a Beamer API token, potentially compromising content management and exposing sensitive notifications and updates."
-regex = '''(?i)[\w.-]{0,50}?(?:beamer)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(b_[a-z0-9=_\-]{44})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:beamer)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(b_[a-z0-9=_\-]{44})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["beamer"]
 
 [[rules]]
 id = "bitbucket-client-id"
 description = "Discovered a potential Bitbucket Client ID, risking unauthorized repository access and potential codebase exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["bitbucket"]
 
 [[rules]]
 id = "bitbucket-client-secret"
 description = "Discovered a potential Bitbucket Client Secret, posing a risk of compromised code repositories and unauthorized access."
-regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{64})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{64})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["bitbucket"]
 
 [[rules]]
 id = "bittrex-access-key"
 description = "Identified a Bittrex Access Key, which could lead to unauthorized access to cryptocurrency trading accounts and financial loss."
-regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["bittrex"]
 
 [[rules]]
 id = "bittrex-secret-key"
 description = "Detected a Bittrex Secret Key, potentially compromising cryptocurrency transactions and financial security."
-regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["bittrex"]
 
 [[rules]]
@@ -215,21 +215,21 @@ keywords = ["clojars_"]
 [[rules]]
 id = "cloudflare-api-key"
 description = "Detected a Cloudflare API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9_-]{40})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9_-]{40})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["cloudflare"]
 
 [[rules]]
 id = "cloudflare-global-api-key"
 description = "Detected a Cloudflare Global API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{37})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{37})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["cloudflare"]
 
 [[rules]]
 id = "cloudflare-origin-ca-key"
 description = "Detected a Cloudflare Origin CA Key, potentially compromising cloud application deployments and operational security."
-regex = '''\b(v1\.0-[a-f0-9]{24}-[a-f0-9]{146})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(v1\.0-[a-f0-9]{24}-[a-f0-9]{146})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "cloudflare",
@@ -239,13 +239,13 @@ keywords = [
 [[rules]]
 id = "codecov-access-token"
 description = "Found a pattern resembling a Codecov Access Token, posing a risk of unauthorized access to code coverage reports and sensitive data."
-regex = '''(?i)[\w.-]{0,50}?(?:codecov)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:codecov)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["codecov"]
 
 [[rules]]
 id = "cohere-api-token"
 description = "Identified a Cohere Token, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:cohere|CO_API_KEY)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-zA-Z0-9]{40})(?:['"\x60\s;\\]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:cohere|CO_API_KEY)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-zA-Z0-9]{40})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 4
 keywords = [
     "cohere",
@@ -255,25 +255,25 @@ keywords = [
 [[rules]]
 id = "coinbase-access-token"
 description = "Detected a Coinbase Access Token, posing a risk of unauthorized access to cryptocurrency accounts and financial transactions."
-regex = '''(?i)[\w.-]{0,50}?(?:coinbase)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9_-]{64})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:coinbase)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9_-]{64})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["coinbase"]
 
 [[rules]]
 id = "confluent-access-token"
 description = "Identified a Confluent Access Token, which could compromise access to streaming data platforms and sensitive data flow."
-regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{16})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{16})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["confluent"]
 
 [[rules]]
 id = "confluent-secret-key"
 description = "Found a Confluent Secret Key, potentially risking unauthorized operations and data access within Confluent services."
-regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["confluent"]
 
 [[rules]]
 id = "contentful-delivery-api-token"
 description = "Discovered a Contentful delivery API token, posing a risk to content management systems and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:contentful)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{43})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:contentful)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{43})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["contentful"]
 
 [[rules]]
@@ -303,59 +303,59 @@ regexes = [
 [[rules]]
 id = "databricks-api-token"
 description = "Uncovered a Databricks API token, which may compromise big data analytics platforms and sensitive data processing."
-regex = '''\b(dapi[a-f0-9]{32}(?:-\d)?)(?:['"\x60\s;\\]|$)'''
+regex = '''\b(dapi[a-f0-9]{32}(?:-\d)?)(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["dapi"]
 
 [[rules]]
 id = "datadog-access-token"
 description = "Detected a Datadog Access Token, potentially risking monitoring and analytics data exposure and manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:datadog)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{40})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:datadog)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{40})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["datadog"]
 
 [[rules]]
 id = "defined-networking-api-token"
 description = "Identified a Defined Networking API token, which could lead to unauthorized network operations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:dnkey)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dnkey)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["dnkey"]
 
 [[rules]]
 id = "digitalocean-access-token"
 description = "Found a DigitalOcean OAuth Access Token, risking unauthorized cloud resource access and data compromise."
-regex = '''\b(doo_v1_[a-f0-9]{64})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(doo_v1_[a-f0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["doo_v1_"]
 
 [[rules]]
 id = "digitalocean-pat"
 description = "Discovered a DigitalOcean Personal Access Token, posing a threat to cloud infrastructure security and data privacy."
-regex = '''\b(dop_v1_[a-f0-9]{64})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(dop_v1_[a-f0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["dop_v1_"]
 
 [[rules]]
 id = "digitalocean-refresh-token"
 description = "Uncovered a DigitalOcean OAuth Refresh Token, which could allow prolonged unauthorized access and resource manipulation."
-regex = '''(?i)\b(dor_v1_[a-f0-9]{64})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)\b(dor_v1_[a-f0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["dor_v1_"]
 
 [[rules]]
 id = "discord-api-token"
 description = "Detected a Discord API key, potentially compromising communication channels and user data privacy on Discord."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{64})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["discord"]
 
 [[rules]]
 id = "discord-client-id"
 description = "Identified a Discord client ID, which may lead to unauthorized integrations and data exposure in Discord applications."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9]{18})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9]{18})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["discord"]
 
 [[rules]]
 id = "discord-client-secret"
 description = "Discovered a potential Discord client secret, risking compromised Discord bot integrations and data leaks."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{32})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["discord"]
 
@@ -369,25 +369,25 @@ keywords = ["dp.pt."]
 [[rules]]
 id = "droneci-access-token"
 description = "Detected a Droneci Access Token, potentially compromising continuous integration and deployment workflows."
-regex = '''(?i)[\w.-]{0,50}?(?:droneci)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:droneci)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["droneci"]
 
 [[rules]]
 id = "dropbox-api-token"
 description = "Identified a Dropbox API secret, which could lead to unauthorized file access and data breaches in Dropbox storage."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{15})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{15})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
 id = "dropbox-long-lived-api-token"
 description = "Found a Dropbox long-lived API token, risking prolonged unauthorized access to cloud storage and sensitive data."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
 id = "dropbox-short-lived-api-token"
 description = "Discovered a Dropbox short-lived API token, posing a risk of temporary but potentially harmful data access and manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(sl\.[a-z0-9\-=_]{135})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(sl\.[a-z0-9\-=_]{135})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
@@ -421,20 +421,20 @@ keywords = ["eztk"]
 [[rules]]
 id = "etsy-access-token"
 description = "Found an Etsy Access Token, potentially compromising Etsy shop management and customer data."
-regex = '''(?i)[\w.-]{0,50}?(?:(?-i:ETSY|[Ee]tsy))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{24})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:(?-i:ETSY|[Ee]tsy))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{24})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["etsy"]
 
 [[rules]]
 id = "facebook-access-token"
 description = "Discovered a Facebook Access Token, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''(?i)\b(\d{15,16}(\||%)[0-9a-z\-_]{27,40})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)\b(\d{15,16}(\||%)[0-9a-z\-_]{27,40})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 
 [[rules]]
 id = "facebook-page-access-token"
 description = "Discovered a Facebook Page Access Token, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''\b(EAA[MC](?i)[a-z0-9]{100,})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(EAA[MC](?i)[a-z0-9]{100,})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 4
 keywords = [
     "eaam",
@@ -444,38 +444,38 @@ keywords = [
 [[rules]]
 id = "facebook-secret"
 description = "Discovered a Facebook Application secret, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:facebook)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:facebook)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["facebook"]
 
 [[rules]]
 id = "fastly-api-token"
 description = "Uncovered a Fastly API key, which may compromise CDN and edge cloud services, leading to content delivery and security issues."
-regex = '''(?i)[\w.-]{0,50}?(?:fastly)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:fastly)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["fastly"]
 
 [[rules]]
 id = "finicity-api-token"
 description = "Detected a Finicity API token, potentially risking financial data access and unauthorized financial operations."
-regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["finicity"]
 
 [[rules]]
 id = "finicity-client-secret"
 description = "Identified a Finicity Client Secret, which could lead to compromised financial service integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{20})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{20})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["finicity"]
 
 [[rules]]
 id = "finnhub-access-token"
 description = "Found a Finnhub Access Token, risking unauthorized access to financial market data and analytics."
-regex = '''(?i)[\w.-]{0,50}?(?:finnhub)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{20})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finnhub)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{20})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["finnhub"]
 
 [[rules]]
 id = "flickr-access-token"
 description = "Discovered a Flickr Access Token, posing a risk of unauthorized photo management and potential data leakage."
-regex = '''(?i)[\w.-]{0,50}?(?:flickr)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:flickr)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["flickr"]
 
 [[rules]]
@@ -502,7 +502,7 @@ keywords = ["flwseck_test"]
 [[rules]]
 id = "flyio-access-token"
 description = "Uncovered a Fly.io API key"
-regex = '''\b((?:fo1_[\w-]{43}|fm1[ar]_[a-zA-Z0-9+\/]{100,}={0,3}|fm2_[a-zA-Z0-9+\/]{100,}={0,3}))(?:['"\x60\s;\\]|$)'''
+regex = '''\b((?:fo1_[\w-]{43}|fm1[ar]_[a-zA-Z0-9+\/]{100,}={0,3}|fm2_[a-zA-Z0-9+\/]{100,}={0,3}))(?:['"\x60\s;\\<,)]|$)'''
 entropy = 4
 keywords = [
     "fo1_",
@@ -519,20 +519,20 @@ keywords = ["fio-u-"]
 [[rules]]
 id = "freshbooks-access-token"
 description = "Discovered a Freshbooks Access Token, posing a risk to accounting software access and sensitive financial data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:freshbooks)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:freshbooks)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["freshbooks"]
 
 [[rules]]
 id = "gcp-api-key"
 description = "Uncovered a GCP API key, which could lead to unauthorized access to Google Cloud services and data breaches."
-regex = '''\b(AIza[\w-]{35})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(AIza[\w-]{35})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["aiza"]
 
 [[rules]]
 id = "generic-api-key"
 description = "Detected a Generic API Key, potentially exposing access to various services and sensitive operations."
-regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passwd|password|secret|token)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([\w.=-]{10,150})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passwd|password|secret|token)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([\w.=-]{10,150})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3.5
 keywords = [
     "access",
@@ -2173,13 +2173,13 @@ keywords = ["_gitlab_session="]
 [[rules]]
 id = "gitter-access-token"
 description = "Uncovered a Gitter Access Token, which may lead to unauthorized access to chat and communication services."
-regex = '''(?i)[\w.-]{0,50}?(?:gitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9_-]{40})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:gitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9_-]{40})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["gitter"]
 
 [[rules]]
 id = "gocardless-api-token"
 description = "Detected a GoCardless API token, potentially risking unauthorized direct debit payment operations and financial data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:gocardless)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(live_(?i)[a-z0-9\-_=]{40})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:gocardless)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(live_(?i)[a-z0-9\-_=]{40})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "live_",
     "gocardless",
@@ -2188,21 +2188,21 @@ keywords = [
 [[rules]]
 id = "grafana-api-key"
 description = "Identified a Grafana API key, which could compromise monitoring dashboards and sensitive data analytics."
-regex = '''(?i)\b(eyJrIjoi[A-Za-z0-9]{70,400}={0,3})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)\b(eyJrIjoi[A-Za-z0-9]{70,400}={0,3})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["eyjrijoi"]
 
 [[rules]]
 id = "grafana-cloud-api-token"
 description = "Found a Grafana cloud API token, risking unauthorized access to cloud-based monitoring services and data exposure."
-regex = '''(?i)\b(glc_[A-Za-z0-9+/]{32,400}={0,3})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)\b(glc_[A-Za-z0-9+/]{32,400}={0,3})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["glc_"]
 
 [[rules]]
 id = "grafana-service-account-token"
 description = "Discovered a Grafana service account token, posing a risk of compromised monitoring services and data integrity."
-regex = '''(?i)\b(glsa_[A-Za-z0-9]{32}_[A-Fa-f0-9]{8})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)\b(glsa_[A-Za-z0-9]{32}_[A-Fa-f0-9]{8})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["glsa_"]
 
@@ -2225,7 +2225,7 @@ keywords = ["atlasv1"]
 [[rules]]
 id = "hashicorp-tf-password"
 description = "Identified a HashiCorp Terraform password field, risking unauthorized infrastructure configuration and security breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:administrator_login_password|password)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}("[a-z0-9=_\-]{8,20}")(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:administrator_login_password|password)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}("[a-z0-9=_\-]{8,20}")(?:['"\x60\s;\\<,)]|$)'''
 path = '''(?i)\.(?:tf|hcl)$'''
 entropy = 2
 keywords = [
@@ -2236,46 +2236,46 @@ keywords = [
 [[rules]]
 id = "heroku-api-key"
 description = "Detected a Heroku API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:heroku)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:heroku)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["heroku"]
 
 [[rules]]
 id = "hubspot-api-key"
 description = "Found a HubSpot API Token, posing a risk to CRM data integrity and unauthorized marketing operations."
-regex = '''(?i)[\w.-]{0,50}?(?:hubspot)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:hubspot)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["hubspot"]
 
 [[rules]]
 id = "huggingface-access-token"
 description = "Discovered a Hugging Face Access token, which could lead to unauthorized access to AI models and sensitive data."
-regex = '''(?:^|[\\'"` >=:])(hf_[a-zA-Z]{34})(?:$|[\\'"` <])'''
+regex = '''\b(hf_(?i:[a-z]{34}))(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["hf_"]
 
 [[rules]]
 id = "huggingface-organization-api-token"
 description = "Uncovered a Hugging Face Organization API token, potentially compromising AI organization accounts and associated data."
-regex = '''(?:^|[\\'"` >=:\(,)])(api_org_[a-zA-Z]{34})(?:$|[\\'"` <\),])'''
+regex = '''\b(api_org_(?i:[a-z]{34}))(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["api_org_"]
 
 [[rules]]
 id = "infracost-api-token"
 description = "Detected an Infracost API Token, risking unauthorized access to cloud cost estimation tools and financial data."
-regex = '''\b(ico-[a-zA-Z0-9]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(ico-[a-zA-Z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["ico-"]
 
 [[rules]]
 id = "intercom-api-key"
 description = "Identified an Intercom API Token, which could compromise customer communication channels and data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:intercom)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{60})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:intercom)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{60})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["intercom"]
 
 [[rules]]
 id = "intra42-client-secret"
 description = "Found a Intra42 client secret, which could lead to unauthorized access to the 42School API and sensitive data."
-regex = '''\b(s-s4t2(?:ud|af)-(?i)[abcdef0123456789]{64})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(s-s4t2(?:ud|af)-(?i)[abcdef0123456789]{64})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = [
     "intra",
@@ -2286,7 +2286,7 @@ keywords = [
 [[rules]]
 id = "jfrog-api-key"
 description = "Found a JFrog API Key, posing a risk of unauthorized access to software artifact repositories and build pipelines."
-regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{73})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{73})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "jfrog",
     "artifactory",
@@ -2297,7 +2297,7 @@ keywords = [
 [[rules]]
 id = "jfrog-identity-token"
 description = "Discovered a JFrog Identity Token, potentially compromising access to JFrog services and sensitive software artifacts."
-regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "jfrog",
     "artifactory",
@@ -2308,7 +2308,7 @@ keywords = [
 [[rules]]
 id = "jwt"
 description = "Uncovered a JSON Web Token, which may lead to unauthorized access to web applications and sensitive user data."
-regex = '''\b(ey[a-zA-Z0-9]{17,}\.ey[a-zA-Z0-9\/\\_-]{17,}\.(?:[a-zA-Z0-9\/\\_-]{10,}={0,2})?)(?:['"\x60\s;\\]|$)'''
+regex = '''\b(ey[a-zA-Z0-9]{17,}\.ey[a-zA-Z0-9\/\\_-]{17,}\.(?:[a-zA-Z0-9\/\\_-]{10,}={0,2})?)(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["ey"]
 
@@ -2322,7 +2322,7 @@ keywords = ["zxlk"]
 [[rules]]
 id = "kraken-access-token"
 description = "Identified a Kraken Access Token, potentially compromising cryptocurrency trading accounts and financial security."
-regex = '''(?i)[\w.-]{0,50}?(?:kraken)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9\/=_\+\-]{80,90})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kraken)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9\/=_\+\-]{80,90})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["kraken"]
 
 [[rules]]
@@ -2340,19 +2340,19 @@ regexes = [
 [[rules]]
 id = "kucoin-access-token"
 description = "Found a Kucoin Access Token, risking unauthorized access to cryptocurrency exchange services and transactions."
-regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{24})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{24})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["kucoin"]
 
 [[rules]]
 id = "kucoin-secret-key"
 description = "Discovered a Kucoin Secret Key, which could lead to compromised cryptocurrency operations and financial data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["kucoin"]
 
 [[rules]]
 id = "launchdarkly-access-token"
 description = "Uncovered a Launchdarkly Access Token, potentially compromising feature flag management and application functionality."
-regex = '''(?i)[\w.-]{0,50}?(?:launchdarkly)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{40})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:launchdarkly)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{40})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["launchdarkly"]
 
 [[rules]]
@@ -2365,14 +2365,14 @@ keywords = ["lin_api_"]
 [[rules]]
 id = "linear-client-secret"
 description = "Identified a Linear Client Secret, which may compromise secure integrations and sensitive project management data."
-regex = '''(?i)[\w.-]{0,50}?(?:linear)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linear)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["linear"]
 
 [[rules]]
 id = "linkedin-client-id"
 description = "Found a LinkedIn Client ID, risking unauthorized access to LinkedIn integrations and professional data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{14})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{14})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "linkedin",
@@ -2383,7 +2383,7 @@ keywords = [
 [[rules]]
 id = "linkedin-client-secret"
 description = "Discovered a LinkedIn Client secret, potentially compromising LinkedIn application integrations and user data."
-regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{16})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{16})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "linkedin",
@@ -2394,7 +2394,7 @@ keywords = [
 [[rules]]
 id = "lob-api-key"
 description = "Uncovered a Lob API Key, which could lead to unauthorized access to mailing and address verification services."
-regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}((live|test)_[a-f0-9]{35})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}((live|test)_[a-f0-9]{35})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "test_",
     "live_",
@@ -2403,7 +2403,7 @@ keywords = [
 [[rules]]
 id = "lob-pub-api-key"
 description = "Detected a Lob Publishable API Key, posing a risk of exposing mail and print service integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}((test|live)_pub_[a-f0-9]{31})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}((test|live)_pub_[a-f0-9]{31})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "test_pub",
     "live_pub",
@@ -2413,43 +2413,43 @@ keywords = [
 [[rules]]
 id = "mailchimp-api-key"
 description = "Identified a Mailchimp API key, potentially compromising email marketing campaigns and subscriber data."
-regex = '''(?i)[\w.-]{0,50}?(?:MailchimpSDK.initialize|mailchimp)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{32}-us\d\d)(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:MailchimpSDK.initialize|mailchimp)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{32}-us\d\d)(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["mailchimp"]
 
 [[rules]]
 id = "mailgun-private-api-token"
 description = "Found a Mailgun private API token, risking unauthorized email service operations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(key-[a-f0-9]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(key-[a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mailgun-pub-key"
 description = "Discovered a Mailgun public validation key, which could expose email verification processes and associated data."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(pubkey-[a-f0-9]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(pubkey-[a-f0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mailgun-signing-key"
 description = "Uncovered a Mailgun webhook signing key, potentially compromising email automation and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mapbox-api-token"
 description = "Detected a MapBox API token, posing a risk to geospatial services and sensitive location data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:mapbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(pk\.[a-z0-9]{60}\.[a-z0-9]{22})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mapbox)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(pk\.[a-z0-9]{60}\.[a-z0-9]{22})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["mapbox"]
 
 [[rules]]
 id = "mattermost-access-token"
 description = "Identified a Mattermost Access Token, which may compromise team communication channels and data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:mattermost)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{26})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mattermost)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{26})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["mattermost"]
 
 [[rules]]
 id = "messagebird-api-token"
 description = "Found a MessageBird API token, risking unauthorized access to communication platforms and message data."
-regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{25})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{25})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "messagebird",
     "message-bird",
@@ -2459,7 +2459,7 @@ keywords = [
 [[rules]]
 id = "messagebird-client-id"
 description = "Discovered a MessageBird client ID, potentially compromising API integrations and sensitive communication data."
-regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "messagebird",
     "message-bird",
@@ -2479,25 +2479,25 @@ keywords = [
 [[rules]]
 id = "netlify-access-token"
 description = "Detected a Netlify Access Token, potentially compromising web hosting services and site management."
-regex = '''(?i)[\w.-]{0,50}?(?:netlify)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{40,46})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:netlify)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{40,46})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["netlify"]
 
 [[rules]]
 id = "new-relic-browser-api-token"
 description = "Identified a New Relic ingest browser API token, risking unauthorized access to application performance data and analytics."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(NRJS-[a-f0-9]{19})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(NRJS-[a-f0-9]{19})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["nrjs-"]
 
 [[rules]]
 id = "new-relic-insert-key"
 description = "Discovered a New Relic insight insert key, compromising data injection into the platform."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(NRII-[a-z0-9-]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(NRII-[a-z0-9-]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["nrii-"]
 
 [[rules]]
 id = "new-relic-user-api-id"
 description = "Found a New Relic user API ID, posing a risk to application monitoring services and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "new-relic",
     "newrelic",
@@ -2507,13 +2507,13 @@ keywords = [
 [[rules]]
 id = "new-relic-user-api-key"
 description = "Discovered a New Relic user API Key, which could lead to compromised application insights and performance monitoring."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(NRAK-[a-z0-9]{27})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(NRAK-[a-z0-9]{27})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["nrak"]
 
 [[rules]]
 id = "npm-access-token"
 description = "Uncovered an npm access token, potentially compromising package management and code repository access."
-regex = '''(?i)\b(npm_[a-z0-9]{36})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)\b(npm_[a-z0-9]{36})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["npm_"]
 
@@ -2535,7 +2535,7 @@ regexes = [
 [[rules]]
 id = "nytimes-access-token"
 description = "Detected a Nytimes Access Token, risking unauthorized access to New York Times APIs and content services."
-regex = '''(?i)[\w.-]{0,50}?(?:nytimes|new-york-times,|newyorktimes)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:nytimes|new-york-times,|newyorktimes)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9=_\-]{32})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "nytimes",
     "new-york-times",
@@ -2545,21 +2545,21 @@ keywords = [
 [[rules]]
 id = "octopus-deploy-api-key"
 description = "Discovered a potential Octopus Deploy API key, risking application deployments and operational security."
-regex = '''\b(API-[A-Z0-9]{26})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(API-[A-Z0-9]{26})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["api-"]
 
 [[rules]]
 id = "okta-access-token"
 description = "Identified an Okta Access Token, which may compromise identity management services and user authentication data."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Oo]kta|OKTA))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(00[\w=\-]{40})(?:['"\x60\s;\\]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Oo]kta|OKTA))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(00[\w=\-]{40})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 4
 keywords = ["okta"]
 
 [[rules]]
 id = "openai-api-key"
 description = "Found an OpenAI API Key, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''\b(sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["t3blbkfj"]
 
@@ -2573,55 +2573,55 @@ keywords = ["sha256~"]
 [[rules]]
 id = "plaid-api-token"
 description = "Discovered a Plaid API Token, potentially compromising financial data aggregation and banking services."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["plaid"]
 
 [[rules]]
 id = "plaid-client-id"
 description = "Uncovered a Plaid Client ID, which could lead to unauthorized financial service integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{24})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{24})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3.5
 keywords = ["plaid"]
 
 [[rules]]
 id = "plaid-secret-key"
 description = "Detected a Plaid Secret key, risking unauthorized access to financial accounts and sensitive transaction data."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{30})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{30})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3.5
 keywords = ["plaid"]
 
 [[rules]]
 id = "planetscale-api-token"
 description = "Identified a PlanetScale API token, potentially compromising database management and operations."
-regex = '''\b(pscale_tkn_(?i)[\w=\.-]{32,64})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(pscale_tkn_(?i)[\w=\.-]{32,64})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["pscale_tkn_"]
 
 [[rules]]
 id = "planetscale-oauth-token"
 description = "Found a PlanetScale OAuth token, posing a risk to database access control and sensitive data integrity."
-regex = '''\b(pscale_oauth_[\w=\.-]{32,64})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(pscale_oauth_[\w=\.-]{32,64})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["pscale_oauth_"]
 
 [[rules]]
 id = "planetscale-password"
 description = "Discovered a PlanetScale password, which could lead to unauthorized database operations and data breaches."
-regex = '''(?i)\b(pscale_pw_(?i)[\w=\.-]{32,64})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)\b(pscale_pw_(?i)[\w=\.-]{32,64})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["pscale_pw_"]
 
 [[rules]]
 id = "postman-api-token"
 description = "Uncovered a Postman API token, potentially compromising API testing and development workflows."
-regex = '''\b(PMAK-(?i)[a-f0-9]{24}\-[a-f0-9]{34})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(PMAK-(?i)[a-f0-9]{24}\-[a-f0-9]{34})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["pmak-"]
 
 [[rules]]
 id = "prefect-api-token"
 description = "Detected a Prefect API token, risking unauthorized access to workflow management and automation services."
-regex = '''\b(pnu_[a-zA-Z0-9]{36})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(pnu_[a-zA-Z0-9]{36})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["pnu_"]
 
@@ -2634,7 +2634,7 @@ keywords = ["-----begin"]
 [[rules]]
 id = "privateai-api-token"
 description = "Identified a PrivateAI Token, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:private[_-]?ai)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:private[_-]?ai)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{32})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = [
     "privateai",
@@ -2645,7 +2645,7 @@ keywords = [
 [[rules]]
 id = "pulumi-api-token"
 description = "Found a Pulumi API token, posing a risk to infrastructure as code services and cloud resource management."
-regex = '''\b(pul-[a-f0-9]{40})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(pul-[a-f0-9]{40})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["pul-"]
 
@@ -2659,66 +2659,66 @@ keywords = ["pypi-ageichlwas5vcmc"]
 [[rules]]
 id = "rapidapi-access-token"
 description = "Uncovered a RapidAPI Access Token, which could lead to unauthorized access to various APIs and data services."
-regex = '''(?i)[\w.-]{0,50}?(?:rapidapi)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9_-]{50})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:rapidapi)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9_-]{50})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["rapidapi"]
 
 [[rules]]
 id = "readme-api-token"
 description = "Detected a Readme API token, risking unauthorized documentation management and content exposure."
-regex = '''\b(rdme_[a-z0-9]{70})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(rdme_[a-z0-9]{70})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["rdme_"]
 
 [[rules]]
 id = "rubygems-api-token"
 description = "Identified a Rubygem API token, potentially compromising Ruby library distribution and package management."
-regex = '''\b(rubygems_[a-f0-9]{48})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(rubygems_[a-f0-9]{48})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["rubygems_"]
 
 [[rules]]
 id = "scalingo-api-token"
 description = "Found a Scalingo API token, posing a risk to cloud platform services and application deployment security."
-regex = '''\b(tk-us-[\w-]{48})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(tk-us-[\w-]{48})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["tk-us-"]
 
 [[rules]]
 id = "sendbird-access-id"
 description = "Discovered a Sendbird Access ID, which could compromise chat and messaging platform integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["sendbird"]
 
 [[rules]]
 id = "sendbird-access-token"
 description = "Uncovered a Sendbird Access Token, potentially risking unauthorized access to communication services and user data."
-regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{40})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{40})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["sendbird"]
 
 [[rules]]
 id = "sendgrid-api-token"
 description = "Detected a SendGrid API token, posing a risk of unauthorized email service operations and data exposure."
-regex = '''\b(SG\.(?i)[a-z0-9=_\-\.]{66})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(SG\.(?i)[a-z0-9=_\-\.]{66})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["sg."]
 
 [[rules]]
 id = "sendinblue-api-token"
 description = "Identified a Sendinblue API token, which may compromise email marketing services and subscriber data privacy."
-regex = '''\b(xkeysib-[a-f0-9]{64}\-(?i)[a-z0-9]{16})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(xkeysib-[a-f0-9]{64}\-(?i)[a-z0-9]{16})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["xkeysib-"]
 
 [[rules]]
 id = "sentry-access-token"
 description = "Found a Sentry Access Token, risking unauthorized access to error tracking services and sensitive application data."
-regex = '''(?i)[\w.-]{0,50}?(?:sentry)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{64})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sentry)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["sentry"]
 
 [[rules]]
 id = "shippo-api-token"
 description = "Discovered a Shippo API token, potentially compromising shipping services and customer order data."
-regex = '''\b(shippo_(?:live|test)_[a-fA-F0-9]{40})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(shippo_(?:live|test)_[a-fA-F0-9]{40})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = ["shippo_"]
 
@@ -2753,7 +2753,7 @@ keywords = ["shpss_"]
 [[rules]]
 id = "sidekiq-secret"
 description = "Discovered a Sidekiq Secret, which could lead to compromised background job processing and application data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:BUNDLE_ENTERPRISE__CONTRIBSYS__COM|BUNDLE_GEMS__CONTRIBSYS__COM)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{8}:[a-f0-9]{8})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:BUNDLE_ENTERPRISE__CONTRIBSYS__COM|BUNDLE_GEMS__CONTRIBSYS__COM)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-f0-9]{8}:[a-f0-9]{8})(?:['"\x60\s;\\<,)]|$)'''
 keywords = [
     "bundle_enterprise__contribsys__com",
     "bundle_gems__contribsys__com",
@@ -2845,13 +2845,13 @@ keywords = ["hooks.slack.com"]
 [[rules]]
 id = "snyk-api-token"
 description = "Uncovered a Snyk API token, potentially compromising software vulnerability scanning and code security."
-regex = '''(?i)[\w.-]{0,50}?(?:snyk[_.-]?(?:(?:api|oauth)[_.-]?)?(?:key|token))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:snyk[_.-]?(?:(?:api|oauth)[_.-]?)?(?:key|token))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["snyk"]
 
 [[rules]]
 id = "square-access-token"
 description = "Detected a Square Access Token, risking unauthorized payment processing and financial transaction exposure."
-regex = '''\b((?:EAAA|sq0atp-)[\w-]{22,60})(?:['"\x60\s;\\]|$)'''
+regex = '''\b((?:EAAA|sq0atp-)[\w-]{22,60})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "sq0atp-",
@@ -2861,13 +2861,13 @@ keywords = [
 [[rules]]
 id = "squarespace-access-token"
 description = "Identified a Squarespace Access Token, which may compromise website management and content control on Squarespace."
-regex = '''(?i)[\w.-]{0,50}?(?:squarespace)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:squarespace)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["squarespace"]
 
 [[rules]]
 id = "stripe-access-token"
 description = "Found a Stripe Access Token, posing a risk to payment processing services and sensitive financial data."
-regex = '''\b((?:sk|rk)_(?:test|live|prod)_[a-zA-Z0-9]{10,99})(?:['"\x60\s;\\]|$)'''
+regex = '''\b((?:sk|rk)_(?:test|live|prod)_[a-zA-Z0-9]{10,99})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 2
 keywords = [
     "sk_test",
@@ -2881,27 +2881,27 @@ keywords = [
 [[rules]]
 id = "sumologic-access-id"
 description = "Discovered a SumoLogic Access ID, potentially compromising log management services and data analytics integrity."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(su[a-zA-Z0-9]{12})(?:['"\x60\s;\\]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5})(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(su[a-zA-Z0-9]{12})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["sumo"]
 
 [[rules]]
 id = "sumologic-access-token"
 description = "Uncovered a SumoLogic Access Token, which could lead to unauthorized access to log data and analytics insights."
-regex = '''(?i)[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{64})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3
 keywords = ["sumo"]
 
 [[rules]]
 id = "telegram-bot-api-token"
 description = "Detected a Telegram Bot API Token, risking unauthorized bot operations and message interception on Telegram."
-regex = '''(?i)[\w.-]{0,50}?(?:telegr)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9]{5,16}:(?-i:A)[a-z0-9_\-]{34})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:telegr)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9]{5,16}:(?-i:A)[a-z0-9_\-]{34})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["telegr"]
 
 [[rules]]
 id = "travisci-access-token"
 description = "Identified a Travis CI Access Token, potentially compromising continuous integration services and codebase security."
-regex = '''(?i)[\w.-]{0,50}?(?:travis)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{22})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:travis)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{22})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["travis"]
 
 [[rules]]
@@ -2914,56 +2914,56 @@ keywords = ["sk"]
 [[rules]]
 id = "twitch-api-token"
 description = "Discovered a Twitch API token, which could compromise streaming services and account integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:twitch)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{30})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitch)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{30})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["twitch"]
 
 [[rules]]
 id = "twitter-access-secret"
 description = "Uncovered a Twitter Access Secret, potentially risking unauthorized Twitter integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{45})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{45})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-access-token"
 description = "Detected a Twitter Access Token, posing a risk of unauthorized account operations and social media data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9]{15,25}-[a-zA-Z0-9]{20,40})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([0-9]{15,25}-[a-zA-Z0-9]{20,40})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-api-key"
 description = "Identified a Twitter API Key, which may compromise Twitter application integrations and user data security."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{25})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{25})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-api-secret"
 description = "Found a Twitter API Secret, risking the security of Twitter app integrations and sensitive data access."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{50})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{50})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-bearer-token"
 description = "Discovered a Twitter Bearer Token, potentially compromising API access and data retrieval from Twitter."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(A{22}[a-zA-Z0-9%]{80,100})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(A{22}[a-zA-Z0-9%]{80,100})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "typeform-api-token"
 description = "Uncovered a Typeform API token, which could lead to unauthorized survey management and data collection."
-regex = '''(?i)[\w.-]{0,50}?(?:typeform)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(tfp_[a-z0-9\-_\.=]{59})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:typeform)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(tfp_[a-z0-9\-_\.=]{59})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["tfp_"]
 
 [[rules]]
 id = "vault-batch-token"
 description = "Detected a Vault Batch Token, risking unauthorized access to secret management services and sensitive data."
-regex = '''\b(hvb\.[\w-]{138,300})(?:['"\x60\s;\\]|$)'''
+regex = '''\b(hvb\.[\w-]{138,300})(?:['"\x60\s;\\<,)]|$)'''
 entropy = 4
 keywords = ["hvb."]
 
 [[rules]]
 id = "vault-service-token"
 description = "Identified a Vault Service Token, potentially compromising infrastructure security and access to sensitive credentials."
-regex = '''\b((?:hvs\.[\w-]{90,120}|s\.(?i:[a-z0-9]{24})))(?:['"\x60\s;\\]|$)'''
+regex = '''\b((?:hvs\.[\w-]{90,120}|s\.(?i:[a-z0-9]{24})))(?:['"\x60\s;\\<,)]|$)'''
 entropy = 3.5
 keywords = [
     "hvs.",
@@ -2978,24 +2978,24 @@ regexes = [
 [[rules]]
 id = "yandex-access-token"
 description = "Found a Yandex Access Token, posing a risk to Yandex service integrations and user data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "yandex-api-key"
 description = "Discovered a Yandex API Key, which could lead to unauthorized access to Yandex services and data manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(AQVN[A-Za-z0-9_\-]{35,38})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(AQVN[A-Za-z0-9_\-]{35,38})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "yandex-aws-access-token"
 description = "Uncovered a Yandex AWS Access Token, potentially compromising cloud resource access and data security on Yandex Cloud."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}(YC[a-zA-Z0-9_\-]{38})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}(YC[a-zA-Z0-9_\-]{38})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "zendesk-secret-key"
 description = "Detected a Zendesk Secret Key, risking unauthorized access to customer support services and sensitive ticketing data."
-regex = '''(?i)[\w.-]{0,50}?(?:zendesk)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\()(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{40})(?:['"\x60\s;\\]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:zendesk)(?:[\w \t.-]{0,20})(?:\\*['"]{0,3})?[ \t]{0,5}(?:[<>?+]?=|:{1,3}=|>|=>|:|\(|,)(?:\\*(?:'|")|[\x60\s=]){0,5}([a-z0-9]{40})(?:['"\x60\s;\\<,)]|$)'''
 keywords = ["zendesk"]
 


### PR DESCRIPTION
### Description:

The goal of this change is to identify common valid formats for secrets and generate a suite of examples per rule. I have created a set of baseline patterns based on #1222, however, it is by no means exhaustive.

Some examples are intentionally left disabled so that we're aware of the blind-spots. More examples and tweaks will need to be made in the future.

This fixes #1222.

**New Patterns**

I've tweaked the regex to support secrets in the following situations:

- Make `?=` operator
- Make `+=` operator
- Escaped JSON `\"secret\"`
- XML element `<value>secret</value>`
- Multiline YAML `password: |\n    secret` and `password: >\n    secret`

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
