### PR TITLE
Add Onfido API Token detector to recognize this type of secrets.

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -140,6 +140,7 @@ func main() {
 		rules.NPM(),
 		rules.NytimesAccessToken(),
 		rules.OktaAccessToken(),
+		rules.OnfidoAPIToken(),
 		rules.OpenAI(),
 		rules.OpenshiftUserToken(),
 		rules.PlaidAccessID(),

--- a/cmd/generate/config/rules/onfido.go
+++ b/cmd/generate/config/rules/onfido.go
@@ -1,0 +1,26 @@
+package rules
+
+import (
+    "github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+    "github.com/zricethezav/gitleaks/v8/config"
+)
+
+func OnfidoAPIToken() *config.Rule {
+    // define rule
+    r := config.Rule{
+        RuleID:      "onfido-live-api-token",
+        Description: "Found an Onfido live API Token posing a risk of unauthorized access to identity verification services data, potentially leading to misuse of PII.",
+        Regex:       utils.GenerateUniqueTokenRegex(`(?:api_live(?:_[a-zA-Z]{2})?\.[a-zA-Z0-9-_]{11}\.[-_a-zA-Z0-9]{32})`, true),
+
+        Keywords: []string{
+            "onfido",
+            "api_live",
+            "api_live_ca",
+            "api_live_us",
+        },
+    }
+
+// validate
+    tps := []string{utils.GenerateSampleSecret("onfido-live-api-token", "api_live.abc123ABC-_.abc123ABC-_abc123ABC-_abc123ABC-")}
+    return utils.Validate(r, tps, nil)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2446,6 +2446,14 @@ keywords = [
 ]
 
 [[rules]]
+id = "onfido-live-api-token"
+description = "Found an Onfido live API Token posing a risk of unauthorized access to identity verification services data, potentially leading to misuse of PII."
+regex = '''(?i)\b((?:api_live(?:_[a-zA-Z]{2})?\.[a-zA-Z0-9-_]{11}\.[-_a-zA-Z0-9]{32}))(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+keywords = [
+    "onfido","api_live","api_live_ca","api_live_us",
+]
+
+[[rules]]
 id = "openai-api-key"
 description = "Found an OpenAI API Key, posing a risk of unauthorized access to AI services and data manipulation."
 regex = '''(?i)\b(sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:['|\"|\n|\r|\s|\x60|;]|$)'''


### PR DESCRIPTION
Add [Onfido](https://onfido.com/) API Token detector to recognize this type of secrets. Documentation on API token can be found here: https://documentation.onfido.com/api/latest/#api-tokens.

Note that Onfido is a GitHub [secret scanning partner](https://docs.github.com/en/code-security/secret-scanning/introduction/supported-secret-scanning-patterns) and those tokens are currently detected by the built-in GitHub scanner.