### PR TITLE
Define multiple allowlists per rule

### DIFF
--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -43,23 +43,21 @@ keywords = [{{ range $j, $keyword := . }}"{{ $keyword }}"{{ end }}]{{end}}{{ end
 tags = [
     {{ range $j, $tag := . }}"{{ $tag }}",{{ end }}
 ]{{ end }}
-{{ if or $rule.Allowlist.Regexes $rule.Allowlist.Paths $rule.Allowlist.Commits $rule.Allowlist.StopWords }}
-[rules.allowlist]
-{{- with $rule.Allowlist.RegexTarget }}
-regexTarget = "{{ . }}"{{ end -}}
-{{- with $rule.Allowlist.Regexes }}
-regexes = [{{ range $i, $regex := . }}
+{{ with $rule.Allowlists }}{{ range $i, $allowlist := . }}{{ if or $allowlist.Regexes $allowlist.Paths $allowlist.Commits $allowlist.StopWords }}
+[[rules.allowlist]]
+{{ with $allowlist.RegexTarget }}regexTarget = "{{ . }}"
+{{ end -}}
+{{- with $allowlist.Regexes }}regexes = [{{ range $i, $regex := . }}
     '''{{ $regex }}''',{{ end }}
 ]{{ end }}
-{{- with $rule.Allowlist.Paths }}paths = [
+{{- with $allowlist.Paths }}paths = [
     {{ range $j, $path := . }}'''{{ $path }}''',{{ end }}
 ]{{ end }}
-{{- with $rule.Allowlist.Commits }}commits = [
+{{- with $allowlist.Commits }}commits = [
     {{ range $j, $commit := . }}"{{ $commit }}",{{ end }}
 ]{{ end }}
-{{- with $rule.Allowlist.StopWords }}
-stopwords = [{{ range $j, $stopword := . }}
+{{- with $allowlist.StopWords }}stopwords = [{{ range $j, $stopword := . }}
     "{{ $stopword }}",{{ end }}
-]{{ end }}
+]{{ end }}{{ end }}{{ end }}
 {{ end }}
 {{ end -}}

--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -44,17 +44,19 @@ tags = [
     {{ range $j, $tag := . }}"{{ $tag }}",{{ end }}
 ]{{ end }}
 {{ with $rule.Allowlists }}{{ range $i, $allowlist := . }}{{ if or $allowlist.Regexes $allowlist.Paths $allowlist.Commits $allowlist.StopWords }}
-[[rules.allowlist]]
-{{ with $allowlist.RegexTarget }}regexTarget = "{{ . }}"
+[[rules.allowlists]]
+{{ with $allowlist.MatchCondition }}condition = "{{ . }}"
 {{ end -}}
-{{- with $allowlist.Regexes }}regexes = [{{ range $i, $regex := . }}
-    '''{{ $regex }}''',{{ end }}
+{{- with $allowlist.Commits }}commits = [
+    {{ range $j, $commit := . }}"{{ $commit }}",{{ end }}
 ]{{ end }}
 {{- with $allowlist.Paths }}paths = [
     {{ range $j, $path := . }}'''{{ $path }}''',{{ end }}
 ]{{ end }}
-{{- with $allowlist.Commits }}commits = [
-    {{ range $j, $commit := . }}"{{ $commit }}",{{ end }}
+{{- with $allowlist.RegexTarget }}regexTarget = "{{ . }}"
+{{ end -}}
+{{- with $allowlist.Regexes }}regexes = [{{ range $i, $regex := . }}
+    '''{{ $regex }}''',{{ end }}
 ]{{ end }}
 {{- with $allowlist.StopWords }}stopwords = [{{ range $j, $stopword := . }}
     "{{ $stopword }}",{{ end }}

--- a/cmd/generate/config/rules/generic.go
+++ b/cmd/generate/config/rules/generic.go
@@ -33,8 +33,10 @@ func GenericCredential() *config.Rule {
 			"access",
 		},
 		Entropy: 3.5,
-		Allowlist: config.Allowlist{
-			StopWords: DefaultStopWords,
+		Allowlists: []config.Allowlist{
+			{
+				StopWords: DefaultStopWords,
+			},
 		},
 	}
 

--- a/cmd/generate/config/rules/hashicorp_vault.go
+++ b/cmd/generate/config/rules/hashicorp_vault.go
@@ -15,10 +15,12 @@ func VaultServiceToken() *config.Rule {
 		Regex:       utils.GenerateUniqueTokenRegex(`(?:hvs\.[\w-]{90,120}|s\.(?i:[a-z0-9]{24}))`, false),
 		Entropy:     3.5,
 		Keywords:    []string{"hvs", "s."},
-		Allowlist: config.Allowlist{
-			Regexes: []*regexp.Regexp{
-				// https://github.com/gitleaks/gitleaks/issues/1490#issuecomment-2334166357
-				regexp.MustCompile(`s\.[A-Za-z]{24}`),
+		Allowlists: []config.Allowlist{
+			{
+				Regexes: []*regexp.Regexp{
+					// https://github.com/gitleaks/gitleaks/issues/1490#issuecomment-2334166357
+					regexp.MustCompile(`s\.[A-Za-z]{24}`),
+				},
 			},
 		},
 	}

--- a/cmd/generate/config/rules/kubernetes.go
+++ b/cmd/generate/config/rules/kubernetes.go
@@ -31,13 +31,15 @@ func KubernetesSecret() *config.Rule {
 		},
 		// Kubernetes secrets are usually yaml files.
 		Path: regexp.MustCompile(`(?i)\.ya?ml$`),
-		Allowlist: config.Allowlist{
-			Regexes: []*regexp.Regexp{
-				// Ignore empty or placeholder values.
-				// variable: {{ .Values.Example }} (https://helm.sh/docs/chart_template_guide/variables/)
-				// variable: ""
-				// variable: ''
-				regexp.MustCompile(`[\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:\{\{[ \t\w"|$:=,.-]+}}|""|'')`),
+		Allowlists: []config.Allowlist{
+			{
+				Regexes: []*regexp.Regexp{
+					// Ignore empty or placeholder values.
+					// variable: {{ .Values.Example }} (https://helm.sh/docs/chart_template_guide/variables/)
+					// variable: ""
+					// variable: ''
+					regexp.MustCompile(`[\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:\{\{[ \t\w"|$:=,.-]+}}|""|'')`),
+				},
 			},
 		},
 	}

--- a/cmd/generate/config/rules/nuget.go
+++ b/cmd/generate/config/rules/nuget.go
@@ -16,13 +16,15 @@ func NugetConfigPassword() *config.Rule {
 		Path:        regexp.MustCompile(`(?i)nuget\.config$`),
 		Keywords:    []string{"<add key="},
 		Entropy:     1,
-		Allowlist: config.Allowlist{
-			Regexes: []*regexp.Regexp{
-				// samples from https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file
-				regexp.MustCompile(`33f!!lloppa`),
-				regexp.MustCompile(`hal\+9ooo_da!sY`),
-				// exclude environment variables
-				regexp.MustCompile(`^\%\S.*\%$`),
+		Allowlists: []config.Allowlist{
+			{
+				Regexes: []*regexp.Regexp{
+					// samples from https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file
+					regexp.MustCompile(`33f!!lloppa`),
+					regexp.MustCompile(`hal\+9ooo_da!sY`),
+					// exclude environment variables
+					regexp.MustCompile(`^\%\S.*\%$`),
+				},
 			},
 		},
 	}

--- a/cmd/generate/config/rules/sumologic.go
+++ b/cmd/generate/config/rules/sumologic.go
@@ -24,14 +24,10 @@ func SumoLogicAccessID() *config.Rule {
 		Allowlists: []config.Allowlist{
 			{
 				RegexTarget: "line",
-				Regexes: []*regexp.Regexp{
-					regexp.MustCompile(`sumOf`),
-				},
+				Regexes:     []*regexp.Regexp{regexp.MustCompile(`sumOf`)},
 			},
 			{
-				Paths: []*regexp.Regexp{
-					regexp.MustCompile(`tests/.+$`),
-				},
+				Paths: []*regexp.Regexp{regexp.MustCompile(`tests/.+$`)},
 			},
 		},
 	}

--- a/cmd/generate/config/rules/sumologic.go
+++ b/cmd/generate/config/rules/sumologic.go
@@ -21,10 +21,17 @@ func SumoLogicAccessID() *config.Rule {
 		Keywords: []string{
 			"sumo",
 		},
-		Allowlist: config.Allowlist{
-			RegexTarget: "line",
-			Regexes: []*regexp.Regexp{
-				regexp.MustCompile(`sumOf`),
+		Allowlists: []config.Allowlist{
+			{
+				RegexTarget: "line",
+				Regexes: []*regexp.Regexp{
+					regexp.MustCompile(`sumOf`),
+				},
+			},
+			{
+				Paths: []*regexp.Regexp{
+					regexp.MustCompile(`tests/.+$`),
+				},
 			},
 		},
 	}

--- a/config/allowlist.go
+++ b/config/allowlist.go
@@ -1,8 +1,16 @@
 package config
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
+)
+
+type AllowlistMatchCondition string
+
+const (
+	AllowlistMatchOr  AllowlistMatchCondition = "OR"
+	AllowlistMatchAnd                         = "AND"
 )
 
 // Allowlist allows a rule to be ignored for specific
@@ -10,6 +18,15 @@ import (
 type Allowlist struct {
 	// Short human readable description of the allowlist.
 	Description string
+
+	// MatchCondition determines whether all criteria must match.
+	MatchCondition AllowlistMatchCondition
+
+	// Commits is a slice of commit SHAs that are allowed to be ignored. Defaults to "OR".
+	Commits []string
+
+	// Paths is a slice of path regular expressions that are allowed to be ignored.
+	Paths []*regexp.Regexp
 
 	// Regexes is slice of content regular expressions that are allowed to be ignored.
 	Regexes []*regexp.Regexp
@@ -22,12 +39,6 @@ type Allowlist struct {
 	//
 	// If RegexTarget is empty, it will be tested against the found secret.
 	RegexTarget string
-
-	// Paths is a slice of path regular expressions that are allowed to be ignored.
-	Paths []*regexp.Regexp
-
-	// Commits is a slice of commit SHAs that are allowed to be ignored.
-	Commits []string
 
 	// StopWords is a slice of stop words that are allowed to be ignored.
 	// This targets the _secret_, not the content of the regex match like the
@@ -50,18 +61,11 @@ func (a *Allowlist) CommitAllowed(c string) bool {
 
 // PathAllowed returns true if the path is allowed to be ignored.
 func (a *Allowlist) PathAllowed(path string) bool {
-	// If |Regexes| are defined, this should be handled by |RegexAllowed|.
-	if len(a.Regexes) > 0 {
-		return false
-	}
 	return anyRegexMatch(path, a.Paths)
 }
 
 // RegexAllowed returns true if the regex is allowed to be ignored.
-func (a *Allowlist) RegexAllowed(secret string, path string) bool {
-	if path != "" && len(a.Paths) > 0 {
-		return anyRegexMatch(secret, a.Regexes) && anyRegexMatch(path, a.Paths)
-	}
+func (a *Allowlist) RegexAllowed(secret string) bool {
 	return anyRegexMatch(secret, a.Regexes)
 }
 
@@ -73,4 +77,16 @@ func (a *Allowlist) ContainsStopWord(s string) bool {
 		}
 	}
 	return false
+}
+
+func (a *Allowlist) Validate() error {
+	// Disallow empty allowlists.
+	if len(a.Commits) == 0 &&
+		len(a.Paths) == 0 &&
+		len(a.Regexes) == 0 &&
+		len(a.StopWords) == 0 {
+		return fmt.Errorf("[[rules.allowlists]] must contain at least one check for: commits, paths, regexes, or stopwords")
+	}
+
+	return nil
 }

--- a/config/allowlist.go
+++ b/config/allowlist.go
@@ -50,12 +50,19 @@ func (a *Allowlist) CommitAllowed(c string) bool {
 
 // PathAllowed returns true if the path is allowed to be ignored.
 func (a *Allowlist) PathAllowed(path string) bool {
+	// If |Regexes| are defined, this should be handled by |RegexAllowed|.
+	if len(a.Regexes) > 0 {
+		return false
+	}
 	return anyRegexMatch(path, a.Paths)
 }
 
 // RegexAllowed returns true if the regex is allowed to be ignored.
-func (a *Allowlist) RegexAllowed(s string) bool {
-	return anyRegexMatch(s, a.Regexes)
+func (a *Allowlist) RegexAllowed(secret string, path string) bool {
+	if path != "" && len(a.Paths) > 0 {
+		return anyRegexMatch(secret, a.Regexes) && anyRegexMatch(path, a.Paths)
+	}
+	return anyRegexMatch(secret, a.Regexes)
 }
 
 func (a *Allowlist) ContainsStopWord(s string) bool {

--- a/config/allowlist_test.go
+++ b/config/allowlist_test.go
@@ -62,7 +62,7 @@ func TestRegexAllowed(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		assert.Equal(t, tt.regexAllowed, tt.allowlist.RegexAllowed(tt.secret, ""))
+		assert.Equal(t, tt.regexAllowed, tt.allowlist.RegexAllowed(tt.secret))
 	}
 }
 

--- a/config/allowlist_test.go
+++ b/config/allowlist_test.go
@@ -62,7 +62,7 @@ func TestRegexAllowed(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		assert.Equal(t, tt.regexAllowed, tt.allowlist.RegexAllowed(tt.secret))
+		assert.Equal(t, tt.regexAllowed, tt.allowlist.RegexAllowed(tt.secret, ""))
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,9 +33,11 @@ func TestTranslate(t *testing.T) {
 					Tags:        []string{"key", "AWS"},
 					Keywords:    []string{},
 					RuleID:      "aws-access-key",
-					Allowlist: Allowlist{
-						Regexes: []*regexp.Regexp{
-							regexp.MustCompile("AKIALALEMEL33243OLIA"),
+					Allowlists: []Allowlist{
+						{
+							Regexes: []*regexp.Regexp{
+								regexp.MustCompile("AKIALALEMEL33243OLIA"),
+							},
 						},
 					},
 				},
@@ -51,8 +53,10 @@ func TestTranslate(t *testing.T) {
 					Tags:        []string{"key", "AWS"},
 					Keywords:    []string{},
 					RuleID:      "aws-access-key",
-					Allowlist: Allowlist{
-						Commits: []string{"allowthiscommit"},
+					Allowlists: []Allowlist{
+						{
+							Commits: []string{"allowthiscommit"},
+						},
 					},
 				},
 				},
@@ -67,9 +71,11 @@ func TestTranslate(t *testing.T) {
 					Tags:        []string{"key", "AWS"},
 					Keywords:    []string{},
 					RuleID:      "aws-access-key",
-					Allowlist: Allowlist{
-						Paths: []*regexp.Regexp{
-							regexp.MustCompile(".go"),
+					Allowlists: []Allowlist{
+						{
+							Paths: []*regexp.Regexp{
+								regexp.MustCompile(".go"),
+							},
 						},
 					},
 				},
@@ -83,7 +89,7 @@ func TestTranslate(t *testing.T) {
 					Description: "Discord API key",
 					Regex:       regexp.MustCompile(`(?i)(discord[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-h0-9]{64})['\"]`),
 					RuleID:      "discord-api-key",
-					Allowlist:   Allowlist{},
+					Allowlists:  []Allowlist{},
 					Entropy:     3.5,
 					SecretGroup: 3,
 					Tags:        []string{},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,19 +25,51 @@ func TestTranslate(t *testing.T) {
 		wantError error
 	}{
 		{
+			cfgName: "allowlist_old_compat",
+			cfg: Config{
+				Rules: map[string]Rule{"example": {
+					RuleID:   "example",
+					Regex:    regexp.MustCompile(`example\d+`),
+					Tags:     []string{},
+					Keywords: []string{},
+					Allowlists: []Allowlist{
+						{
+							MatchCondition: "OR",
+							Regexes:        []*regexp.Regexp{regexp.MustCompile("123")},
+						},
+					},
+				},
+				},
+			},
+		},
+		{
+			cfgName:   "allowlist_invalid_empty",
+			cfg:       Config{},
+			wantError: fmt.Errorf("example: [[rules.allowlists]] must contain at least one check for: commits, paths, regexes, or stopwords"),
+		},
+		{
+			cfgName:   "allowlist_invalid_old_and_new",
+			cfg:       Config{},
+			wantError: fmt.Errorf("example: [rules.allowlist] is deprecated, it cannot be used alongside [[rules.allowlist]]"),
+		},
+		{
+			cfgName:   "allowlist_invalid_regextarget",
+			cfg:       Config{},
+			wantError: fmt.Errorf("example: unknown allowlist |regexTarget| 'mtach' (expected 'match', 'line')"),
+		},
+		{
 			cfgName: "allow_aws_re",
 			cfg: Config{
 				Rules: map[string]Rule{"aws-access-key": {
+					RuleID:      "aws-access-key",
 					Description: "AWS Access Key",
 					Regex:       regexp.MustCompile("(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}"),
-					Tags:        []string{"key", "AWS"},
 					Keywords:    []string{},
-					RuleID:      "aws-access-key",
+					Tags:        []string{"key", "AWS"},
 					Allowlists: []Allowlist{
 						{
-							Regexes: []*regexp.Regexp{
-								regexp.MustCompile("AKIALALEMEL33243OLIA"),
-							},
+							MatchCondition: "OR",
+							Regexes:        []*regexp.Regexp{regexp.MustCompile("AKIALALEMEL33243OLIA")},
 						},
 					},
 				},
@@ -48,14 +80,15 @@ func TestTranslate(t *testing.T) {
 			cfgName: "allow_commit",
 			cfg: Config{
 				Rules: map[string]Rule{"aws-access-key": {
+					RuleID:      "aws-access-key",
 					Description: "AWS Access Key",
 					Regex:       regexp.MustCompile("(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}"),
-					Tags:        []string{"key", "AWS"},
 					Keywords:    []string{},
-					RuleID:      "aws-access-key",
+					Tags:        []string{"key", "AWS"},
 					Allowlists: []Allowlist{
 						{
-							Commits: []string{"allowthiscommit"},
+							MatchCondition: "OR",
+							Commits:        []string{"allowthiscommit"},
 						},
 					},
 				},
@@ -66,16 +99,15 @@ func TestTranslate(t *testing.T) {
 			cfgName: "allow_path",
 			cfg: Config{
 				Rules: map[string]Rule{"aws-access-key": {
+					RuleID:      "aws-access-key",
 					Description: "AWS Access Key",
 					Regex:       regexp.MustCompile("(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}"),
-					Tags:        []string{"key", "AWS"},
 					Keywords:    []string{},
-					RuleID:      "aws-access-key",
+					Tags:        []string{"key", "AWS"},
 					Allowlists: []Allowlist{
 						{
-							Paths: []*regexp.Regexp{
-								regexp.MustCompile(".go"),
-							},
+							MatchCondition: "OR",
+							Paths:          []*regexp.Regexp{regexp.MustCompile(".go")},
 						},
 					},
 				},
@@ -86,14 +118,13 @@ func TestTranslate(t *testing.T) {
 			cfgName: "entropy_group",
 			cfg: Config{
 				Rules: map[string]Rule{"discord-api-key": {
+					RuleID:      "discord-api-key",
 					Description: "Discord API key",
 					Regex:       regexp.MustCompile(`(?i)(discord[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-h0-9]{64})['\"]`),
-					RuleID:      "discord-api-key",
-					Allowlists:  []Allowlist{},
+					Keywords:    []string{},
 					Entropy:     3.5,
 					SecretGroup: 3,
 					Tags:        []string{},
-					Keywords:    []string{},
 				},
 				},
 			},
@@ -118,49 +149,80 @@ func TestTranslate(t *testing.T) {
 			cfg: Config{
 				Rules: map[string]Rule{
 					"aws-access-key": {
+						RuleID:      "aws-access-key",
 						Description: "AWS Access Key",
 						Regex:       regexp.MustCompile("(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}"),
-						Tags:        []string{"key", "AWS"},
 						Keywords:    []string{},
-						RuleID:      "aws-access-key",
+						Tags:        []string{"key", "AWS"},
 					},
 					"aws-secret-key": {
+						RuleID:      "aws-secret-key",
 						Description: "AWS Secret Key",
 						Regex:       regexp.MustCompile(`(?i)aws_(.{0,20})?=?.[\'\"0-9a-zA-Z\/+]{40}`),
-						Tags:        []string{"key", "AWS"},
 						Keywords:    []string{},
-						RuleID:      "aws-secret-key",
+						Tags:        []string{"key", "AWS"},
 					},
 					"aws-secret-key-again": {
+						RuleID:      "aws-secret-key-again",
 						Description: "AWS Secret Key",
 						Regex:       regexp.MustCompile(`(?i)aws_(.{0,20})?=?.[\'\"0-9a-zA-Z\/+]{40}`),
-						Tags:        []string{"key", "AWS"},
 						Keywords:    []string{},
-						RuleID:      "aws-secret-key-again",
+						Tags:        []string{"key", "AWS"},
 					},
 				},
 			},
 		},
 		{
-			cfgName: "extend_rule_allowlist",
+			cfgName: "extend_rule_allowlist_or",
 			cfg: Config{
 				Rules: map[string]Rule{
 					"aws-secret-key-again-again": {
 						RuleID:      "aws-secret-key-again-again",
 						Description: "AWS Secret Key",
 						Regex:       regexp.MustCompile(`(?i)aws_(.{0,20})?=?.[\'\"0-9a-zA-Z\/+]{40}`),
-						Tags:        []string{"key", "AWS"},
 						Keywords:    []string{},
-						Allowlist: Allowlist{
-							Commits: []string{"abcdefg1"},
-							Regexes: []*regexp.Regexp{
-								regexp.MustCompile(`foo.+bar`),
+						Tags:        []string{"key", "AWS"},
+						Allowlists: []Allowlist{
+							{
+								MatchCondition: "OR",
+								StopWords:      []string{"fake"},
 							},
-							RegexTarget: "line",
-							Paths: []*regexp.Regexp{
-								regexp.MustCompile(`ignore\.xaml`),
+							{
+								MatchCondition: "OR",
+								Commits:        []string{"abcdefg1"},
+								Paths:          []*regexp.Regexp{regexp.MustCompile(`ignore\.xaml`)},
+								Regexes:        []*regexp.Regexp{regexp.MustCompile(`foo.+bar`)},
+								RegexTarget:    "line",
+								StopWords:      []string{"example"},
 							},
-							StopWords: []string{"example"},
+						},
+					},
+				},
+			},
+		},
+		{
+			cfgName: "extend_rule_allowlist_and",
+			cfg: Config{
+				Rules: map[string]Rule{
+					"aws-secret-key-again-again": {
+						RuleID:      "aws-secret-key-again-again",
+						Description: "AWS Secret Key",
+						Regex:       regexp.MustCompile(`(?i)aws_(.{0,20})?=?.[\'\"0-9a-zA-Z\/+]{40}`),
+						Keywords:    []string{},
+						Tags:        []string{"key", "AWS"},
+						Allowlists: []Allowlist{
+							{
+								MatchCondition: "OR",
+								StopWords:      []string{"fake"},
+							},
+							{
+								MatchCondition: "AND",
+								Commits:        []string{"abcdefg1"},
+								Paths:          []*regexp.Regexp{regexp.MustCompile(`ignore\.xaml`)},
+								Regexes:        []*regexp.Regexp{regexp.MustCompile(`foo.+bar`)},
+								RegexTarget:    "line",
+								StopWords:      []string{"example"},
+							},
 						},
 					},
 				},
@@ -174,11 +236,12 @@ func TestTranslate(t *testing.T) {
 						RuleID:      "aws-secret-key-again-again",
 						Description: "AWS Secret Key",
 						Regex:       regexp.MustCompile(`(?i)aws_(.{0,20})?=?.[\'\"0-9a-zA-Z\/+]{40}`),
-						Tags:        []string{"key", "AWS"},
 						Keywords:    []string{},
-						Allowlist: Allowlist{
-							Paths: []*regexp.Regexp{
-								regexp.MustCompile(`something.py`),
+						Tags:        []string{"key", "AWS"},
+						Allowlists: []Allowlist{
+							{
+								MatchCondition: "OR",
+								Paths:          []*regexp.Regexp{regexp.MustCompile(`something.py`)},
 							},
 						},
 					},
@@ -206,8 +269,8 @@ func TestTranslate(t *testing.T) {
 				Rules: map[string]Rule{"aws-access-key": {
 					RuleID:      "aws-access-key",
 					Description: "AWS Access Key",
-					Entropy:     999.0,
 					Regex:       regexp.MustCompile("(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}"),
+					Entropy:     999.0,
 					Keywords:    []string{},
 					Tags:        []string{"key", "AWS"},
 				},
@@ -305,7 +368,7 @@ func TestTranslate(t *testing.T) {
 			err = viper.Unmarshal(&vc)
 			require.NoError(t, err)
 			cfg, err := vc.Translate()
-			if !assert.Equal(t, tt.wantError, err) {
+			if err != nil && !assert.EqualError(t, tt.wantError, err.Error()) {
 				return
 			}
 

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -481,7 +481,7 @@ keywords = [
     "access",
 ]
 
-[rules.allowlist]
+[[rules.allowlist]]
 stopwords = [
     "000000",
     "aaaaaa",
@@ -2169,7 +2169,7 @@ regex = '''(?i)(?:\bkind:[ \t]*["']?secret["']?(?:.|\s){0,200}?\bdata:(?:.|\s){0
 path = '''(?i)\.ya?ml$'''
 keywords = ["secret"]
 
-[rules.allowlist]
+[[rules.allowlist]]
 regexes = [
     '''[\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:\{\{[ \t\w"|$:=,.-]+}}|""|'')''',
 ]
@@ -2355,7 +2355,7 @@ path = '''(?i)nuget\.config$'''
 entropy = 1
 keywords = ["<add key="]
 
-[rules.allowlist]
+[[rules.allowlist]]
 regexes = [
     '''33f!!lloppa''',
     '''hal\+9ooo_da!sY''',
@@ -2685,10 +2685,14 @@ regex = '''(?i:(?:sumo)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3})(?:=|>|:{
 entropy = 3
 keywords = ["sumo"]
 
-[rules.allowlist]
+[[rules.allowlist]]
 regexTarget = "line"
 regexes = [
     '''sumOf''',
+]
+[[rules.allowlist]]
+paths = [
+    '''tests/.+$''',
 ]
 
 [[rules]]
@@ -2774,7 +2778,7 @@ keywords = [
     "s.",
 ]
 
-[rules.allowlist]
+[[rules.allowlist]]
 regexes = [
     '''s\.[A-Za-z]{24}''',
 ]

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -481,7 +481,7 @@ keywords = [
     "access",
 ]
 
-[[rules.allowlist]]
+[[rules.allowlists]]
 stopwords = [
     "000000",
     "aaaaaa",
@@ -2169,7 +2169,7 @@ regex = '''(?i)(?:\bkind:[ \t]*["']?secret["']?(?:.|\s){0,200}?\bdata:(?:.|\s){0
 path = '''(?i)\.ya?ml$'''
 keywords = ["secret"]
 
-[[rules.allowlist]]
+[[rules.allowlists]]
 regexes = [
     '''[\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:\{\{[ \t\w"|$:=,.-]+}}|""|'')''',
 ]
@@ -2355,7 +2355,7 @@ path = '''(?i)nuget\.config$'''
 entropy = 1
 keywords = ["<add key="]
 
-[[rules.allowlist]]
+[[rules.allowlists]]
 regexes = [
     '''33f!!lloppa''',
     '''hal\+9ooo_da!sY''',
@@ -2685,12 +2685,12 @@ regex = '''(?i:(?:sumo)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3})(?:=|>|:{
 entropy = 3
 keywords = ["sumo"]
 
-[[rules.allowlist]]
+[[rules.allowlists]]
 regexTarget = "line"
 regexes = [
     '''sumOf''',
 ]
-[[rules.allowlist]]
+[[rules.allowlists]]
 paths = [
     '''tests/.+$''',
 ]
@@ -2778,7 +2778,7 @@ keywords = [
     "s.",
 ]
 
-[[rules.allowlist]]
+[[rules.allowlists]]
 regexes = [
     '''s\.[A-Za-z]{24}''',
 ]

--- a/config/rule.go
+++ b/config/rule.go
@@ -41,7 +41,7 @@ type Rule struct {
 
 	// Allowlist allows a rule to be ignored for specific
 	// regexes, paths, and/or commits
-	Allowlist Allowlist
+	Allowlists []Allowlist
 }
 
 // Validate guards against common misconfigurations.

--- a/config/rule.go
+++ b/config/rule.go
@@ -39,8 +39,7 @@ type Rule struct {
 	// keyword(s) are in the content being scanned.
 	Keywords []string
 
-	// Allowlist allows a rule to be ignored for specific
-	// regexes, paths, and/or commits
+	// Allowlists allows a rule to be ignored for specific commits, paths, regexes, and/or stopwords.
 	Allowlists []Allowlist
 }
 

--- a/detect/baseline_test.go
+++ b/detect/baseline_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/zricethezav/gitleaks/v8/report"
 )
@@ -128,7 +129,8 @@ func TestIgnoreIssuesInBaseline(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		d, _ := NewDetectorDefaultConfig()
+		d, err := NewDetectorDefaultConfig()
+		require.NoError(t, err)
 		d.baseline = test.baseline
 		for _, finding := range test.findings {
 			d.addFinding(finding)

--- a/testdata/config/allow_aws_re.toml
+++ b/testdata/config/allow_aws_re.toml
@@ -5,5 +5,5 @@ title = "simple config with allowlist for aws"
     id = "aws-access-key"
     regex = '''(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}'''
     tags = ["key", "AWS"]
-    [rules.allowlist]
+    [[rules.allowlists]]
         regexes = ['''AKIALALEMEL33243OLIA''']

--- a/testdata/config/allow_commit.toml
+++ b/testdata/config/allow_commit.toml
@@ -5,5 +5,5 @@ title = "simple config with allowlist for a specific commit"
     id = "aws-access-key"
     regex = '''(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}'''
     tags = ["key", "AWS"]
-    [rules.allowlist]
+    [[rules.allowlists]]
         commits = ['''allowthiscommit''']

--- a/testdata/config/allow_path.toml
+++ b/testdata/config/allow_path.toml
@@ -5,5 +5,5 @@ title = "simple config with allowlist for .go files"
     id = "aws-access-key"
     regex = '''(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}'''
     tags = ["key", "AWS"]
-    [rules.allowlist]
+    [[rules.allowlists]]
         paths = ['''.go''']

--- a/testdata/config/allowlist_invalid_empty.toml
+++ b/testdata/config/allowlist_invalid_empty.toml
@@ -1,0 +1,6 @@
+title = "simple config with allowlist for aws"
+
+[[rules]]
+id = "example"
+regex = '''example\d+'''
+    [[rules.allowlists]]

--- a/testdata/config/allowlist_invalid_old_and_new.toml
+++ b/testdata/config/allowlist_invalid_old_and_new.toml
@@ -1,0 +1,9 @@
+title = "simple config with allowlist for aws"
+
+[[rules]]
+id = "example"
+regex = '''example\d+'''
+    [rules.allowlist]
+    regexes = ['''123''']
+    [[rules.allowlists]]
+    regexes = ['''456''']

--- a/testdata/config/allowlist_invalid_regextarget.toml
+++ b/testdata/config/allowlist_invalid_regextarget.toml
@@ -1,0 +1,8 @@
+title = "simple config with allowlist for aws"
+
+[[rules]]
+id = "example"
+regex = '''example\d+'''
+    [[rules.allowlists]]
+    regexTarget = "mtach"
+    regexes = ['''456''']

--- a/testdata/config/allowlist_old_compat.toml
+++ b/testdata/config/allowlist_old_compat.toml
@@ -1,0 +1,7 @@
+title = "simple config with allowlist for aws"
+
+[[rules]]
+    id = "example"
+    regex = '''example\d+'''
+    [rules.allowlist]
+        regexes = ['''123''']

--- a/testdata/config/extend_empty_regexpath.toml
+++ b/testdata/config/extend_empty_regexpath.toml
@@ -3,6 +3,6 @@ path="../testdata/config/extend_3.toml"
 
 [[rules]]
 id = "aws-secret-key-again-again"
-[rules.allowlist]
+[[rules.allowlists]]
 description = "False positive. Keys used for colors match the rule, and should be excluded."
 paths = ['''something.py''']

--- a/testdata/config/extend_rule_allowlist_and.toml
+++ b/testdata/config/extend_rule_allowlist_and.toml
@@ -1,11 +1,12 @@
 title = "gitleaks extended 3"
 
 [extend]
-path="../testdata/config/extend_3.toml"
+path="../testdata/config/extend_rule_allowlist_base.toml"
 
 [[rules]]
     id = "aws-secret-key-again-again"
-[rules.allowlist]
+[[rules.allowlists]]
+    condition = "AND"
     commits = ['''abcdefg1''']
     regexes = ['''foo.+bar''']
     regexTarget = "line"

--- a/testdata/config/extend_rule_allowlist_base.toml
+++ b/testdata/config/extend_rule_allowlist_base.toml
@@ -1,0 +1,11 @@
+title = "gitleaks extended 3"
+
+## This should not be loaded since we can only extend configs to a depth of 3
+
+[[rules]]
+    id = "aws-secret-key-again-again"
+    description = "AWS Secret Key"
+    regex = '''(?i)aws_(.{0,20})?=?.[\'\"0-9a-zA-Z\/+]{40}'''
+    tags = ["key", "AWS"]
+[[rules.allowlists]]
+    stopwords = ["fake"]

--- a/testdata/config/extend_rule_allowlist_or.toml
+++ b/testdata/config/extend_rule_allowlist_or.toml
@@ -1,0 +1,13 @@
+title = "gitleaks extended 3"
+
+[extend]
+path="../testdata/config/extend_rule_allowlist_base.toml"
+
+[[rules]]
+    id = "aws-secret-key-again-again"
+[[rules.allowlists]]
+    commits = ['''abcdefg1''']
+    regexes = ['''foo.+bar''']
+    regexTarget = "line"
+    paths = ['''ignore\.xaml''']
+    stopwords = ['''example''']


### PR DESCRIPTION
### Description:
This is an experimental implementation of two things I described [here](https://github.com/gitleaks/gitleaks/issues/1274#issuecomment-1806391187):

> * **Support Multiple Allowlist Targets**
>   Right now you can only chose a single `regexTarget` per allowlist (global or rule). This makes it awkward when you want to ignore multiple patterns, where one is the secret (e.g., `{{ secrets.MY_SECRET}}`) and another is the match or line (e.g., `passwordFile: ...` or `token_id: ...`). The ability to definite separate regexes for `secret` and `match` or `line` would be a nice quality-of-life improvement.
> 
> * **Support Allowlist matching `path && regex`**
>   Presently, `rule.path` + `rule.regex` and `rule.allowlist.paths` + `rule.allowlist.regexes` behave differently. Unlike `rule` which matches `path && regex`, the `allowlist` will match `path || regex` which can lead to unexpected results.

With this change, a rule can have broad regexes AND ones specific to a certain path. This is a bit of a pain point for more complex configurations, at least in my experience.

A contrived example for the sake of demonstration:
```toml
[[rules]]
id = "sumologic-access-id"
description = "Discovered a SumoLogic Access ID, potentially compromising log management services and data analytics integrity."
regex = '''(?i:(?:sumo)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(su[a-zA-Z0-9]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
entropy = 3
keywords = [
    "sumo",
]
# Allow `sumOf` anywhere
[[rules.allowlists]]
regexTarget = "line"
regexes = [
    "sumOf",
]
# Allow `abcdefg` when found under `node_modules/@sumologic/opentelemetry-node`
[[rules.allowlists]]
condition = "AND" # default condition is "OR".
regexes = [ 
 '''abcdefg''',
]
paths = [
    "node_modules/@sumologic/opentelemetry-node/.+$",
]
```

This closes https://github.com/gitleaks/gitleaks/issues/1512.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
