### PR TITLE
Add support in .gitleaksignore file comment strings  (#1425)

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -149,7 +149,13 @@ func (d *Detector) AddGitleaksIgnore(gitleaksIgnorePath string) error {
 	scanner := bufio.NewScanner(file)
 
 	for scanner.Scan() {
-		d.gitleaksIgnore[scanner.Text()] = true
+		line := scanner.Text()
+		// Trim leading and trailing whitespace
+		line = strings.TrimSpace(line)
+		// Skip lines that start with a comment
+		if line != "" && !strings.HasPrefix(line, "#") {
+			d.gitleaksIgnore[line] = true
+		}
 	}
 	return nil
 }

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -149,9 +149,7 @@ func (d *Detector) AddGitleaksIgnore(gitleaksIgnorePath string) error {
 	scanner := bufio.NewScanner(file)
 
 	for scanner.Scan() {
-		line := scanner.Text()
-		// Trim leading and trailing whitespace
-		line = strings.TrimSpace(line)
+		line := strings.TrimSpace(scanner.Text())
 		// Skip lines that start with a comment
 		if line != "" && !strings.HasPrefix(line, "#") {
 			d.gitleaksIgnore[line] = true

--- a/testdata/repos/small/.gitleaksignore
+++ b/testdata/repos/small/.gitleaksignore
@@ -1,2 +1,3 @@
 api/ignoreGlobal.go:aws-access-key:20
+# test comment
 53cd7a3c6eb4937f413e3c25e4a9f39289afa69e:api/ignoreCommit.go:aws-access-key:20


### PR DESCRIPTION
### Description:
This pull request introduces a modification to the `AddGitleaksIgnore` function to properly handle comments in the `.gitleaksignore` file. Specifically, it ensures that lines starting with a comment (`#`) are skipped and not added to the `d.gitleaksIgnore map`.

#1425 

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?


