### PR TITLE
Update Harness rules to add _ and - in the account ID part.

### DIFF
--- a/cmd/generate/config/rules/harness.go
+++ b/cmd/generate/config/rules/harness.go
@@ -1,8 +1,9 @@
 package rules
 
 import (
-	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
 	"regexp"
+
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
 
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
 	"github.com/zricethezav/gitleaks/v8/config"
@@ -13,7 +14,7 @@ func HarnessApiKey() *config.Rule {
 	r := config.Rule{
 		Description: "Identified a Harness Access Token (PAT or SAT), risking unauthorized access to a Harness account.",
 		RuleID:      "harness-api-key",
-		Regex:       regexp.MustCompile(`(?:pat|sat)\.[a-zA-Z0-9]{22}\.[a-zA-Z0-9]{24}\.[a-zA-Z0-9]{20}`),
+		Regex:       regexp.MustCompile(`(?:pat|sat)\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9]{24}\.[a-zA-Z0-9]{20}`),
 		Keywords:    []string{"pat.", "sat."},
 	}
 

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2098,7 +2098,7 @@ keywords = [
 [[rules]]
 id = "harness-api-key"
 description = "Identified a Harness Access Token (PAT or SAT), risking unauthorized access to a Harness account."
-regex = '''(?:pat|sat)\.[a-zA-Z0-9]{22}\.[a-zA-Z0-9]{24}\.[a-zA-Z0-9]{20}'''
+regex = '''(?:pat|sat)\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9]{24}\.[a-zA-Z0-9]{20}'''
 keywords = [
     "pat.","sat.",
 ]


### PR DESCRIPTION
### Description:

This PR adds the Harness rule to add `_` and `-` in the account ID part since Harness account ID supports these characters. Without this change, a secret containing `_` or `-` will not be detected by gitleaks.

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
