### PR TITLE
Disable rule regex & path validation

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -91,11 +91,11 @@ func TestTranslate(t *testing.T) {
 			cfg:       Config{},
 			wantError: fmt.Errorf("rule |id| is missing or empty, regex: (?i)(discord[a-z0-9_ .\\-,]{0,25})(=|>|:=|\\|\\|:|<=|=>|:).{0,5}['\\\"]([a-h0-9]{64})['\\\"]"),
 		},
-		{
-			cfgName:   "no_regex_or_path",
-			cfg:       Config{},
-			wantError: fmt.Errorf("discord-api-key: both |regex| and |path| are empty, this rule will have no effect"),
-		},
+		//{
+		//	cfgName:   "no_regex_or_path",
+		//	cfg:       Config{},
+		//	wantError: fmt.Errorf("discord-api-key: both |regex| and |path| are empty, this rule will have no effect"),
+		//},
 		{
 			cfgName:   "bad_entropy_group",
 			cfg:       Config{},

--- a/config/rule.go
+++ b/config/rule.go
@@ -60,10 +60,12 @@ func (r Rule) Validate() error {
 		return fmt.Errorf("rule |id| is missing or empty" + context)
 	}
 
+	// TODO: uncomment this once it works with |extend|.
+	// See: https://github.com/gitleaks/gitleaks/issues/1507#issuecomment-2352559213
 	// Ensure the rule actually matches something.
-	if r.Regex == nil && r.Path == nil {
-		return fmt.Errorf("%s: both |regex| and |path| are empty, this rule will have no effect", r.RuleID)
-	}
+	//if r.Regex == nil && r.Path == nil {
+	//	return fmt.Errorf("%s: both |regex| and |path| are empty, this rule will have no effect", r.RuleID)
+	//}
 
 	// Ensure |secretGroup| works.
 	if r.Regex != nil && r.SecretGroup > r.Regex.NumSubexp() {


### PR DESCRIPTION
### Description:
This disables the check that |regex| and |path| aren't both nil.

As pointed out in https://github.com/gitleaks/gitleaks/issues/1507#issuecomment-2352550208, it does not seem to work with extended configs.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
