### PR TITLE
fix: to many false-positive for gltf files, add gltf suffix to allowlist

### DIFF
--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -14,7 +14,7 @@ title = "gitleaks config"
 description = "global allow lists"
 paths = [
     '''gitleaks.toml''',
-    '''(.*?)(jpg|gif|doc|docx|zip|xls|pdf|bin|svg|socket|vsidx|v2|suo|wsuo|.dll|pdb|exe)$''',
+    '''(.*?)(jpg|gif|doc|docx|zip|xls|pdf|bin|svg|socket|vsidx|v2|suo|wsuo|.dll|pdb|exe|gltf)$''',
     '''(go.mod|go.sum|go.work|go.work.sum)$''',
     '''gradle.lockfile''',
     '''verification-metadata.xml''',

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -14,7 +14,7 @@ title = "gitleaks config"
 description = "global allow lists"
 paths = [
     '''gitleaks.toml''',
-    '''(.*?)(jpg|gif|doc|docx|zip|xls|pdf|bin|svg|socket|vsidx|v2|suo|wsuo|.dll|pdb|exe)$''',
+    '''(.*?)(jpg|gif|doc|docx|zip|xls|pdf|bin|svg|socket|vsidx|v2|suo|wsuo|.dll|pdb|exe|gltf)$''',
     '''(go.mod|go.sum|go.work|go.work.sum)$''',
     '''gradle.lockfile''',
     '''verification-metadata.xml''',


### PR DESCRIPTION
Closes #1526

### Description:

glTF files (image/graphical mesh) produce a lot of false positives

Steps to reproduce the behavior:

- `git clone clone https://github.com/KhronosGroup/glTF-Sample-Assets && cd glTF-Sample-Assets`
- `gitleaks detect -r gltf.json`
- review `gltf.json`

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
