### PR TITLE
Ignore leading newlines

### DIFF
--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -2,6 +2,7 @@ package detect
 
 import (
 	"fmt"
+	"github.com/google/go-cmp/cmp"
 	"os"
 	"path/filepath"
 	"testing"
@@ -563,11 +564,11 @@ func TestFromFiles(t *testing.T) {
 					Description: "AWS Access Key",
 					StartLine:   20,
 					EndLine:     20,
-					StartColumn: 16,
-					EndColumn:   35,
+					StartColumn: 15,
+					EndColumn:   34,
 					Match:       "AKIALALEMEL33243OLIA",
 					Secret:      "AKIALALEMEL33243OLIA",
-					Line:        "\n\tawsToken := \"AKIALALEMEL33243OLIA\"",
+					Line:        "\tawsToken := \"AKIALALEMEL33243OLIA\"",
 					File:        "../testdata/repos/nogit/main.go",
 					SymlinkFile: "",
 					RuleID:      "aws-access-key",
@@ -585,11 +586,11 @@ func TestFromFiles(t *testing.T) {
 					Description: "AWS Access Key",
 					StartLine:   20,
 					EndLine:     20,
-					StartColumn: 16,
-					EndColumn:   35,
+					StartColumn: 15,
+					EndColumn:   34,
 					Match:       "AKIALALEMEL33243OLIA",
 					Secret:      "AKIALALEMEL33243OLIA",
-					Line:        "\n\tawsToken := \"AKIALALEMEL33243OLIA\"",
+					Line:        "\tawsToken := \"AKIALALEMEL33243OLIA\"",
 					File:        "../testdata/repos/nogit/main.go",
 					RuleID:      "aws-access-key",
 					Tags:        []string{"key", "AWS"},
@@ -611,11 +612,11 @@ func TestFromFiles(t *testing.T) {
 					Description: "Generic API Key",
 					StartLine:   4,
 					EndLine:     4,
-					StartColumn: 5,
-					EndColumn:   35,
+					StartColumn: 4,
+					EndColumn:   34,
 					Match:       "PASSWORD=8ae31cacf141669ddfb5da",
 					Secret:      "8ae31cacf141669ddfb5da",
-					Line:        "\nDB_PASSWORD=8ae31cacf141669ddfb5da",
+					Line:        "DB_PASSWORD=8ae31cacf141669ddfb5da",
 					File:        "../testdata/repos/nogit/.env.prod",
 					RuleID:      "generic-api-key",
 					Tags:        []string{},
@@ -655,7 +656,9 @@ func TestFromFiles(t *testing.T) {
 		require.NoError(t, err)
 		findings, err := detector.DetectFiles(paths)
 		require.NoError(t, err)
-		assert.ElementsMatch(t, tt.expectedFindings, findings)
+		if diff := cmp.Diff(tt.expectedFindings, findings); diff != "" {
+			t.Errorf("diff: (-got +want)\n%s", diff)
+		}
 	}
 }
 

--- a/detect/location.go
+++ b/detect/location.go
@@ -42,7 +42,7 @@ func location(fragment Fragment, matchIndex []int) Location {
 			location.startLine = lineNum
 			location.endLine = lineNum
 			location.startColumn = (start - prevNewLine) + 1 // +1 because counting starts at 1
-			location.startLineIndex = prevNewLine
+			location.startLineIndex = prevNewLine + 1        // start after the newline.
 			location.endLineIndex = newLineByteIndex
 		}
 		if prevNewLine < end && end <= newLineByteIndex {


### PR DESCRIPTION
This is a trivial implementation that increments 'startLineIndex' by 1, assuming that skips the newline. It may not be comprehensive.'

### Description:
This was mentioned in https://github.com/gitleaks/gitleaks/pull/1501. I don't know if we want to strip leading newlines.

I could imagine them causing issues for any allowlist regexes that target `line`.

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
