### PR TITLE
Disable inherited rule from extended config

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ useDefault = true
 # or you can supply a path to a configuration. Path is relative to where gitleaks
 # was invoked, not the location of the base config.
 path = "common_config.toml"
+# If there are any rules you don't want to inherit, they can be specified here.
+disabledRules = [ "generic-api-key"]
 
 # An array of tables that contain information that define instructions
 # on how to detect secrets

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -39,8 +39,7 @@ func TestTranslate(t *testing.T) {
 							Regexes:        []*regexp.Regexp{regexp.MustCompile("123")},
 						},
 					},
-				},
-				},
+				}},
 			},
 		},
 		{
@@ -73,8 +72,7 @@ func TestTranslate(t *testing.T) {
 							Regexes:        []*regexp.Regexp{regexp.MustCompile("AKIALALEMEL33243OLIA")},
 						},
 					},
-				},
-				},
+				}},
 			},
 		},
 		{
@@ -92,8 +90,7 @@ func TestTranslate(t *testing.T) {
 							Commits:        []string{"allowthiscommit"},
 						},
 					},
-				},
-				},
+				}},
 			},
 		},
 		{
@@ -111,8 +108,7 @@ func TestTranslate(t *testing.T) {
 							Paths:          []*regexp.Regexp{regexp.MustCompile(".go")},
 						},
 					},
-				},
-				},
+				}},
 			},
 		},
 		{
@@ -122,12 +118,11 @@ func TestTranslate(t *testing.T) {
 					RuleID:      "discord-api-key",
 					Description: "Discord API key",
 					Regex:       regexp.MustCompile(`(?i)(discord[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-h0-9]{64})['\"]`),
-					Keywords:    []string{},
 					Entropy:     3.5,
 					SecretGroup: 3,
+					Keywords:    []string{},
 					Tags:        []string{},
-				},
-				},
+				}},
 			},
 		},
 		{
@@ -347,6 +342,25 @@ func TestTranslate(t *testing.T) {
 					Keywords:    []string{"puppy"},
 					Tags:        []string{"key", "AWS"},
 				},
+				},
+			},
+		},
+		{
+			cfgName: "extend_disabled",
+			cfg: Config{
+				Rules: map[string]Rule{
+					"aws-secret-key": {
+						RuleID:   "aws-secret-key",
+						Regex:    regexp.MustCompile(`(?i)aws_(.{0,20})?=?.[\'\"0-9a-zA-Z\/+]{40}`),
+						Tags:     []string{"key", "AWS"},
+						Keywords: []string{},
+					},
+					"pypi-upload-token": {
+						RuleID:   "pypi-upload-token",
+						Regex:    regexp.MustCompile(`pypi-AgEIcHlwaS5vcmc[A-Za-z0-9\-_]{50,1000}`),
+						Tags:     []string{},
+						Keywords: []string{},
+					},
 				},
 			},
 		},

--- a/testdata/config/extend_disabled.toml
+++ b/testdata/config/extend_disabled.toml
@@ -1,0 +1,11 @@
+title = "gitleaks extend disable"
+
+[extend]
+path = "../testdata/config/extend_disabled_base.toml"
+disabledRules = [
+    'custom-rule1'
+]
+
+[[rules]]
+id = "pypi-upload-token"
+regex = '''pypi-AgEIcHlwaS5vcmc[A-Za-z0-9\-_]{50,1000}'''

--- a/testdata/config/extend_disabled_base.toml
+++ b/testdata/config/extend_disabled_base.toml
@@ -1,0 +1,11 @@
+title = "gitleaks extended 3"
+
+
+[[rules]]
+id = "aws-secret-key"
+regex = '''(?i)aws_(.{0,20})?=?.[\'\"0-9a-zA-Z\/+]{40}'''
+tags = ["key", "AWS"]
+
+[[rules]]
+id = "custom-rule1"
+regex = '''[Cc]ustom!'''


### PR DESCRIPTION
### Description:
This fixes #1531.

It allows you to specify ~`ignoredRules`~ `disabledRules` under `[extend]` and exclude them from your config. (I'm amenable to changing the name.)

Edit: I switched back to `disabled` because I think it's consistent with the `--enable-rule` flag.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
