### PR TITLE
fix: use regexTarget for extend config

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,17 @@ stopwords = [
   '''endpoint''',
 ]
 
+# You can extend a particular rule from the default config. e.g., gitlab-pat
+# if you have defined a custom token prefix on your GitLab instance
+[[rules]]
+id = "gitlab-pat"
+# all the other attributes from the default rule are inherited
+
+[rules.allowlist]
+regexTarget = "line"
+regexes = [
+    '''MY-glpat-''',
+]
 
 # This is a global allowlist which has a higher order of precedence than rule-specific allowlists.
 # If a commit listed in the `commits` field below is encountered then that commit will be skipped and no

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@
 
 <p align="left">
   <p align="left">
-	  <a href="https://github.com/zricethezav/gitleaks/actions/workflows/test.yml">
-		  <img alt="Github Test" src="https://github.com/zricethezav/gitleaks/actions/workflows/test.yml/badge.svg">
+	  <a href="https://github.com/gitleaks/gitleaks/actions/workflows/test.yml">
+		  <img alt="Github Test" src="https://github.com/gitleaks/gitleaks/actions/workflows/test.yml/badge.svg">
 	  </a>
 	  <a href="https://hub.docker.com/r/zricethezav/gitleaks">
 		  <img src="https://img.shields.io/docker/pulls/zricethezav/gitleaks.svg" />
 	  </a>
-	  <a href="https://github.com/zricethezav/gitleaks-action">
+	  <a href="https://github.com/gitleaks/gitleaks-action">
         	<img alt="gitleaks badge" src="https://img.shields.io/badge/protected%20by-gitleaks-blue">
     	 </a>
 	  <a href="https://twitter.com/intent/follow?screen_name=zricethezav">
@@ -54,7 +54,7 @@ Fingerprint: cd5226711335c68be1e720b318b7bc3135a30eb2:cmd/generate/config/rules/
 
 ## Getting Started
 
-Gitleaks can be installed using Homebrew, Docker, or Go. Gitleaks is also available in binary form for many popular platforms and OS types on the [releases page](https://github.com/zricethezav/gitleaks/releases). In addition, Gitleaks can be implemented as a pre-commit hook directly in your repo or as a GitHub action using [Gitleaks-Action](https://github.com/gitleaks/gitleaks-action).
+Gitleaks can be installed using Homebrew, Docker, or Go. Gitleaks is also available in binary form for many popular platforms and OS types on the [releases page](https://github.com/gitleaks/gitleaks/releases). In addition, Gitleaks can be implemented as a pre-commit hook directly in your repo or as a GitHub action using [Gitleaks-Action](https://github.com/gitleaks/gitleaks-action).
 
 ### Installing
 
@@ -110,7 +110,7 @@ jobs:
          - id: gitleaks
    ```
 
-   for a [native execution of GitLeaks](https://github.com/zricethezav/gitleaks/releases) or use the [`gitleaks-docker` pre-commit ID](https://github.com/zricethezav/gitleaks/blob/master/.pre-commit-hooks.yaml) for executing GitLeaks using the [official Docker images](#docker)
+   for a [native execution of GitLeaks](https://github.com/gitleaks/gitleaks/releases) or use the [`gitleaks-docker` pre-commit ID](https://github.com/gitleaks/gitleaks/blob/master/.pre-commit-hooks.yaml) for executing GitLeaks using the [official Docker images](#docker)
 
 3. Auto-update the config to the latest repos' versions by executing `pre-commit autoupdate`
 4. Install with `pre-commit install`
@@ -231,7 +231,7 @@ title = "Gitleaks title"
 # useDefault and path can NOT be used at the same time. Choose one.
 [extend]
 # useDefault will extend the base configuration with the default gitleaks config:
-# https://github.com/zricethezav/gitleaks/blob/master/config/gitleaks.toml
+# https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml
 useDefault = true
 # or you can supply a path to a configuration. Path is relative to where gitleaks
 # was invoked, not the location of the base config.
@@ -341,7 +341,7 @@ stopwords = [
 ]
 ```
 
-Refer to the default [gitleaks config](https://github.com/zricethezav/gitleaks/blob/master/config/gitleaks.toml) for examples or follow the [contributing guidelines](https://github.com/gitleaks/gitleaks/blob/master/CONTRIBUTING.md) if you would like to contribute to the default configuration. Additionally, you can check out [this gitleaks blog post](https://blog.gitleaks.io/stop-leaking-secrets-configuration-2-3-aeed293b1fbf) which covers advanced configuration setups.
+Refer to the default [gitleaks config](https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml) for examples or follow the [contributing guidelines](https://github.com/gitleaks/gitleaks/blob/master/CONTRIBUTING.md) if you would like to contribute to the default configuration. Additionally, you can check out [this gitleaks blog post](https://blog.gitleaks.io/stop-leaking-secrets-configuration-2-3-aeed293b1fbf) which covers advanced configuration setups.
 
 ### Additional Configuration
 
@@ -358,7 +358,7 @@ class CustomClass:
 
 #### .gitleaksignore
 
-You can ignore specific findings by creating a `.gitleaksignore` file at the root of your repo. In release v8.10.0 Gitleaks added a `Fingerprint` value to the Gitleaks report. Each leak, or finding, has a Fingerprint that uniquely identifies a secret. Add this fingerprint to the `.gitleaksignore` file to ignore that specific secret. See Gitleaks' [.gitleaksignore](https://github.com/zricethezav/gitleaks/blob/master/.gitleaksignore) for an example. Note: this feature is experimental and is subject to change in the future.
+You can ignore specific findings by creating a `.gitleaksignore` file at the root of your repo. In release v8.10.0 Gitleaks added a `Fingerprint` value to the Gitleaks report. Each leak, or finding, has a Fingerprint that uniquely identifies a secret. Add this fingerprint to the `.gitleaksignore` file to ignore that specific secret. See Gitleaks' [.gitleaksignore](https://github.com/gitleaks/gitleaks/blob/master/.gitleaksignore) for an example. Note: this feature is experimental and is subject to change in the future.
 
 ## Sponsorships
 <p align="left">

--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -1,7 +1,7 @@
 # This file has been auto-generated. Do not edit manually.
 # If you would like to contribute new rules, please use
 # cmd/generate/config/main.go and follow the contributing guidelines
-# at https://github.com/zricethezav/gitleaks/blob/master/CONTRIBUTING.md
+# at https://github.com/gitleaks/gitleaks/blob/master/CONTRIBUTING.md
 
 # This is the default gitleaks configuration file.
 # Rules and allowlists are defined within this file.

--- a/config/config.go
+++ b/config/config.go
@@ -254,6 +254,9 @@ func (c *Config) extend(extensionConfig Config) {
 			baseRule.Allowlist.Regexes = append(baseRule.Allowlist.Regexes, currentRule.Allowlist.Regexes...)
 			baseRule.Allowlist.RegexTarget = currentRule.Allowlist.RegexTarget
 			baseRule.Allowlist.StopWords = append(baseRule.Allowlist.StopWords, currentRule.Allowlist.StopWords...)
+			// The keywords from the base rule and the extended rule must be merged into the global keywords list
+			c.Keywords = append(c.Keywords, baseRule.Keywords...)
+			c.Keywords = append(c.Keywords, currentRule.Keywords...)
 
 			delete(c.Rules, ruleID)
 			c.Rules[ruleID] = baseRule

--- a/config/config.go
+++ b/config/config.go
@@ -252,6 +252,7 @@ func (c *Config) extend(extensionConfig Config) {
 			baseRule.Allowlist.Commits = append(baseRule.Allowlist.Commits, currentRule.Allowlist.Commits...)
 			baseRule.Allowlist.Paths = append(baseRule.Allowlist.Paths, currentRule.Allowlist.Paths...)
 			baseRule.Allowlist.Regexes = append(baseRule.Allowlist.Regexes, currentRule.Allowlist.Regexes...)
+			baseRule.Allowlist.RegexTarget = currentRule.Allowlist.RegexTarget
 			baseRule.Allowlist.StopWords = append(baseRule.Allowlist.StopWords, currentRule.Allowlist.StopWords...)
 
 			delete(c.Rules, ruleID)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -145,6 +145,7 @@ func TestTranslate(t *testing.T) {
 							Regexes: []*regexp.Regexp{
 								regexp.MustCompile(`foo.+bar`),
 							},
+							RegexTarget: "line",
 							Paths: []*regexp.Regexp{
 								regexp.MustCompile(`ignore\.xaml`),
 							},

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -1,7 +1,7 @@
 # This file has been auto-generated. Do not edit manually.
 # If you would like to contribute new rules, please use
 # cmd/generate/config/main.go and follow the contributing guidelines
-# at https://github.com/zricethezav/gitleaks/blob/master/CONTRIBUTING.md
+# at https://github.com/gitleaks/gitleaks/blob/master/CONTRIBUTING.md
 
 # This is the default gitleaks configuration file.
 # Rules and allowlists are defined within this file.

--- a/testdata/config/extend_rule_allowlist.toml
+++ b/testdata/config/extend_rule_allowlist.toml
@@ -8,5 +8,6 @@ path="../testdata/config/extend_3.toml"
 [rules.allowlist]
     commits = ['''abcdefg1''']
     regexes = ['''foo.+bar''']
+    regexTarget = "line"
     paths = ['''ignore\.xaml''']
     stopwords = ['''example''']


### PR DESCRIPTION
### Description:

Extend config is super useful, but if you have `regexTarget = "line"` within `[rules.allowlist]`, extend does not work.
The basic functionality works thanks to https://github.com/gitleaks/gitleaks/pull/1524 but `regexTarget` was missing.
Beside of this the adding keywords from base and extended rule into global keywords list is required to extend rules.
In addition some documentation to extend a rule has been added.

This should also solve:

- https://github.com/gitleaks/gitleaks/issues/999
- https://github.com/gitleaks/gitleaks/issues/1027
- https://github.com/gitleaks/gitleaks/issues/1384

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
