### PR TITLE
Warn when a file cannot be scanned due to Git LFS

### DIFF
--- a/detect/git.go
+++ b/detect/git.go
@@ -5,6 +5,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/zricethezav/gitleaks/v8/report"
 	"github.com/zricethezav/gitleaks/v8/sources"
+	"strings"
 )
 
 func (d *Detector) DetectGit(gitCmd *sources.GitCmd) ([]report.Finding, error) {
@@ -46,6 +47,16 @@ func (d *Detector) DetectGit(gitCmd *sources.GitCmd) ([]report.Finding, error) {
 						Raw:       textFragment.Raw(gitdiff.OpAdd),
 						CommitSHA: commitSHA,
 						FilePath:  gitdiffFile.NewName,
+					}
+
+					// Warn if the file is hosted with Git LFS. It can't be scanned (for now).
+					if strings.Contains(fragment.Raw, "version https://git-lfs.github.com/spec/v") ||
+						(strings.Contains(fragment.Raw, "oid sha256:") && strings.Contains(fragment.Raw, "size ")) {
+						log.Warn().
+							Str("commit", fragment.CommitSHA).
+							Str("path", fragment.FilePath).
+							Msg("File is hosted with Git LFS and cannot be scanned.")
+						break
 					}
 
 					for _, finding := range d.Detect(fragment) {


### PR DESCRIPTION
### Description:

Gitleaks currently doesn't scan files hosted with Git LFS. I think it would be useful to explicitly log a warning saying "hey, we can't scan this file", as right now they are silently skipped.

Git LFS inserts 'fake' files with metadata in the following form. This implementation is a POC, merely searching for these strings is naive and error-prone.

```diff
diff --git a/credentials.xml b/credentials.xml
index 448b22e..3e67baf 100644
--- a/credentials.xml
+++ b/credentials.xml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:91953836428ae751a52f47d7f622ac9db9a1c5eb9f5b3c1604ba74e2b995fa43
-size 171
+oid sha256:3d078c9c53bd7119d8b56a7a8bf28ac6cf6e0693d1d4f3b374f61dbc3db0418c
+size 178

diff --git a/credentials.xml b/credentials.xml
new file mode 100644
index 0000000..448b22e
--- /dev/null
+++ b/credentials.xml
@@ -0,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91953836428ae751a52f47d7f622ac9db9a1c5eb9f5b3c1604ba74e2b995fa43
+size 171
```

**Example**
```sh
$ ./gitleaks git ../lfs-test --verbose

    ○
    │╲
    │ ○
    ○ ░
    ░    gitleaks

10:20PM WRN Skipping file: it is hosted with Git LFS. commit=992a3cd5339607071f89be0a90a963c1fd968979 path=credentials.xml
10:20PM WRN Skipping file: it is hosted with Git LFS. commit=5433f8d391496faf59943db9a4bc36b59cef2fce path=credentials.xml
10:20PM INF 3 commits scanned.
10:20PM INF scan completed in 5.91ms
10:20PM INF no leaks found
```

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
