### PR TITLE
Update base config allowlist

### DIFF
--- a/cmd/generate/config/base/config.go
+++ b/cmd/generate/config/base/config.go
@@ -13,6 +13,12 @@ func CreateGlobalConfig() config.Config {
 			Regexes: []*regexp.Regexp{
 				// ----------- General placeholders -----------
 				regexp.MustCompile(`(?i)^true|false|null$`),
+
+				// ----------- Environment Variables -----------
+				regexp.MustCompile(`^\$(\d+|{\d+})$`),
+				regexp.MustCompile(`^\$([A-Z_]+|[a-z_]+)$`),
+				regexp.MustCompile(`^\${([A-Z_]+|[a-z_]+)}$`),
+
 				// ----------- Interpolated Variables -----------
 				// Ansible (https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html)
 				regexp.MustCompile(`^\{\{[ \t]*[\w ().|]+[ \t]*}}$`),
@@ -22,13 +28,11 @@ func CreateGlobalConfig() config.Config {
 				regexp.MustCompile(`^\$\{\{[ \t]*((env|github|secrets|vars)(\.[A-Za-z]\w+)+[\w "'&./=|]*)[ \t]*}}$`),
 				// NuGet (https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file#using-environment-variables)
 				regexp.MustCompile(`^%([A-Z_]+|[a-z_]+)%$`),
+				// String formatting.
+				regexp.MustCompile(`^%[+\-# 0]?[bcdeEfFgGoOpqstTUvxX]$`), // Golang (https://pkg.go.dev/fmt)
+				regexp.MustCompile(`^\{\d{0,2}}$`),                       // Python (https://docs.python.org/3/tutorial/inputoutput.html)
 				// Urban Code Deploy (https://www.ibm.com/support/pages/replace-token-step-replaces-replacement-values-windows-variables)
 				regexp.MustCompile(`^@([A-Z_]+|[a-z_]+)@$`),
-
-				// ----------- Environment Variables -----------
-				regexp.MustCompile(`^\$(\d+|{\d+})$`),
-				regexp.MustCompile(`^\$([A-Z_]+|[a-z_]+)$`),
-				regexp.MustCompile(`^\${([A-Z_]+|[a-z_]+)}$`),
 			},
 			Paths: []*regexp.Regexp{
 				regexp.MustCompile(`gitleaks\.toml`),

--- a/cmd/generate/config/base/config.go
+++ b/cmd/generate/config/base/config.go
@@ -38,7 +38,8 @@ func CreateGlobalConfig() config.Config {
 				regexp.MustCompile(`gitleaks\.toml`),
 
 				// ----------- Documents and media -----------
-				regexp.MustCompile(`(?i)\.(bmp|gif|jpe?g|svg|tiff?)$`),
+				regexp.MustCompile(`(?i)\.(bmp|gif|jpe?g|svg|tiff?)$`), // Images
+				regexp.MustCompile(`\.(eot|[ot]tf|woff2?)$`),           // Fonts
 				regexp.MustCompile(`(.*?)(doc|docx|zip|xls|pdf|bin|socket|vsidx|v2|suo|wsuo|.dll|pdb|exe|gltf)$`),
 
 				// ----------- Golang files -----------

--- a/cmd/generate/config/base/config.go
+++ b/cmd/generate/config/base/config.go
@@ -1,8 +1,10 @@
 package base
 
 import (
+	"fmt"
 	"github.com/zricethezav/gitleaks/v8/config"
 	"regexp"
+	"strings"
 )
 
 func CreateGlobalConfig() config.Config {
@@ -13,6 +15,21 @@ func CreateGlobalConfig() config.Config {
 			Regexes: []*regexp.Regexp{
 				// ----------- General placeholders -----------
 				regexp.MustCompile(`(?i)^true|false|null$`),
+				// Awkward workaround to detect repeated characters.
+				func() *regexp.Regexp {
+					var (
+						letters  = "abcdefghijklmnopqrstuvwxyz*."
+						patterns []string
+					)
+					for _, char := range letters {
+						if char == '*' || char == '.' {
+							patterns = append(patterns, fmt.Sprintf("\\%c+", char))
+						} else {
+							patterns = append(patterns, fmt.Sprintf("%c+", char))
+						}
+					}
+					return regexp.MustCompile("^(?i:" + strings.Join(patterns, "|") + ")$")
+				}(),
 
 				// ----------- Environment Variables -----------
 				regexp.MustCompile(`^\$(\d+|{\d+})$`),

--- a/cmd/generate/config/base/config_test.go
+++ b/cmd/generate/config/base/config_test.go
@@ -39,6 +39,16 @@ func TestConfigAllowlistRegexes(t *testing.T) {
 				`%MY_PASSWORD%`, `%password%`,
 			},
 		},
+		"interpolated variables - string fmt - golang": {
+			invalid: []string{
+				`%b`, `%c`, `%d`, `% d`, `%e`, `%E`, `%f`, `%F`, `%g`, `%G`, `%o`, `%O`, `%p`, `%q`, `%-s`, `%s`, `%t`, `%T`, `%U`, `%#U`, `%+v`, `%#v`, `%v`, `%x`, `%X`,
+			},
+		},
+		"interpolated variables - string fmt - python": {
+			invalid: []string{
+				`{}`, `{0}`, `{10}`,
+			},
+		},
 		"interpolated variables - ucd": {
 			invalid: []string{`@password@`, `@LDAP_PASS@`},
 			valid:   []string{`@username@mastodon.example`},

--- a/cmd/generate/config/base/config_test.go
+++ b/cmd/generate/config/base/config_test.go
@@ -14,6 +14,16 @@ func TestConfigAllowlistRegexes(t *testing.T) {
 				`true`, `True`, `false`, `False`, `null`, `NULL`,
 			},
 		},
+		"general placeholders - repeated characters": {
+			invalid: []string{
+				`aaaaaaaaaaaaaaaaa`, `BBBBBBBBBBbBBBBBBBbBB`, `********************`,
+			},
+			valid: []string{`aaaaaaaaaaaaaaaaaaabaa`, `pas*************d`},
+		},
+		"environment variables": {
+			invalid: []string{`$2`, `$GIT_PASSWORD`, `${GIT_PASSWORD}`, `$password`},
+			valid:   []string{`$yP@R.@=ibxI`, `$2a6WCust9aE`, `${not_complete1`},
+		},
 		"interpolated variables - ansible": {
 			invalid: []string{
 				`{{ x }}`, `{{ password }}`, `{{password}}`, `{{ data.proxy_password }}`,
@@ -52,10 +62,6 @@ func TestConfigAllowlistRegexes(t *testing.T) {
 		"interpolated variables - ucd": {
 			invalid: []string{`@password@`, `@LDAP_PASS@`},
 			valid:   []string{`@username@mastodon.example`},
-		},
-		"environment variables": {
-			invalid: []string{`$2`, `$GIT_PASSWORD`, `${GIT_PASSWORD}`, `$password`},
-			valid:   []string{`$yP@R.@=ibxI`, `$2a6WCust9aE`, `${not_complete1`},
 		},
 	}
 

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -14,13 +14,15 @@ title = "gitleaks config"
 description = "global allow lists"
 regexes = [
     '''(?i)^true|false|null$''',
-    '''^\{\{[ \t]*[\w ().|]+[ \t]*}}$''',
-    '''^\$\{\{[ \t]*((env|github|secrets|vars)(\.[A-Za-z]\w+)+[\w "'&./=|]*)[ \t]*}}$''',
-    '''^%([A-Z_]+|[a-z_]+)%$''',
-    '''^@([A-Z_]+|[a-z_]+)@$''',
     '''^\$(\d+|{\d+})$''',
     '''^\$([A-Z_]+|[a-z_]+)$''',
     '''^\${([A-Z_]+|[a-z_]+)}$''',
+    '''^\{\{[ \t]*[\w ().|]+[ \t]*}}$''',
+    '''^\$\{\{[ \t]*((env|github|secrets|vars)(\.[A-Za-z]\w+)+[\w "'&./=|]*)[ \t]*}}$''',
+    '''^%([A-Z_]+|[a-z_]+)%$''',
+    '''^%[+\-# 0]?[bcdeEfFgGoOpqstTUvxX]$''',
+    '''^\{\d{0,2}}$''',
+    '''^@([A-Z_]+|[a-z_]+)@$''',
 ]
 paths = [
     '''gitleaks\.toml''',

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -27,6 +27,7 @@ regexes = [
 paths = [
     '''gitleaks\.toml''',
     '''(?i)\.(bmp|gif|jpe?g|svg|tiff?)$''',
+    '''\.(eot|[ot]tf|woff2?)$''',
     '''(.*?)(doc|docx|zip|xls|pdf|bin|socket|vsidx|v2|suo|wsuo|.dll|pdb|exe|gltf)$''',
     '''go\.(mod|sum|work(\.sum)?)$''',
     '''(^|/)vendor/modules\.txt$''',

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -14,6 +14,7 @@ title = "gitleaks config"
 description = "global allow lists"
 regexes = [
     '''(?i)^true|false|null$''',
+    '''^(?i:a+|b+|c+|d+|e+|f+|g+|h+|i+|j+|k+|l+|m+|n+|o+|p+|q+|r+|s+|t+|u+|v+|w+|x+|y+|z+|\*+|\.+)$''',
     '''^\$(\d+|{\d+})$''',
     '''^\$([A-Z_]+|[a-z_]+)$''',
     '''^\${([A-Z_]+|[a-z_]+)}$''',


### PR DESCRIPTION
### Description:
This updates the config allowlist to ignore the following:

- String fmt placeholders (e.g., `%s`, `{0}`)
- Font file extensions
- Repeated characters (e.g., `*******`, `aaaaaaaaaaaaaaaaaaaa`)

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
