### PR TITLE
Fix rule extension

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -252,6 +252,27 @@ func (c *Config) extend(extensionConfig Config) {
 			c.OrderedRules = append(c.OrderedRules, ruleID)
 		} else {
 			// Rule exists, merge our changes into the base.
+			if currentRule.Description != "" {
+				baseRule.Description = currentRule.Description
+			}
+			if currentRule.Entropy != 0 {
+				baseRule.Entropy = currentRule.Entropy
+			}
+			if currentRule.SecretGroup != 0 {
+				baseRule.SecretGroup = currentRule.SecretGroup
+			}
+			if currentRule.Regex != nil {
+				baseRule.Regex = currentRule.Regex
+			}
+			if currentRule.Path != nil {
+				baseRule.Path = currentRule.Path
+			}
+			if len(currentRule.Tags) > 0 {
+				baseRule.Tags = currentRule.Tags
+			}
+			if len(currentRule.Keywords) > 0 {
+				baseRule.Keywords = currentRule.Keywords
+			}
 			baseRule.Allowlist.Commits = append(baseRule.Allowlist.Commits, currentRule.Allowlist.Commits...)
 			baseRule.Allowlist.Paths = append(baseRule.Allowlist.Paths, currentRule.Allowlist.Paths...)
 			baseRule.Allowlist.Regexes = append(baseRule.Allowlist.Regexes, currentRule.Allowlist.Regexes...)

--- a/config/config.go
+++ b/config/config.go
@@ -267,12 +267,8 @@ func (c *Config) extend(extensionConfig Config) {
 			if currentRule.Path != nil {
 				baseRule.Path = currentRule.Path
 			}
-			if len(currentRule.Tags) > 0 {
-				baseRule.Tags = currentRule.Tags
-			}
-			if len(currentRule.Keywords) > 0 {
-				baseRule.Keywords = currentRule.Keywords
-			}
+			baseRule.Tags = append(baseRule.Tags, currentRule.Tags...)
+			baseRule.Keywords = append(baseRule.Keywords, currentRule.Keywords...)
 			baseRule.Allowlist.Commits = append(baseRule.Allowlist.Commits, currentRule.Allowlist.Commits...)
 			baseRule.Allowlist.Paths = append(baseRule.Allowlist.Paths, currentRule.Allowlist.Paths...)
 			baseRule.Allowlist.Regexes = append(baseRule.Allowlist.Regexes, currentRule.Allowlist.Regexes...)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -261,7 +261,7 @@ func TestTranslate(t *testing.T) {
 					Description: "AWS Access Key",
 					Regex:       regexp.MustCompile("(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}"),
 					Keywords:    []string{},
-					Tags:        []string{"puppy"},
+					Tags:        []string{"key", "AWS", "puppy"},
 				},
 				},
 			},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,8 +15,13 @@ const configPath = "../testdata/config/"
 
 func TestTranslate(t *testing.T) {
 	tests := []struct {
-		cfgName   string
-		cfg       Config
+		// Configuration file basename to load, from `../testdata/config/`.
+		cfgName string
+		// Expected result.
+		cfg Config
+		// Rules to compare.
+		rules []string
+		// Error to expect.
 		wantError error
 	}{
 		{
@@ -174,6 +179,107 @@ func TestTranslate(t *testing.T) {
 				},
 			},
 		},
+		{
+			cfgName: "override_description",
+			rules:   []string{"aws-access-key"},
+			cfg: Config{
+				Rules: map[string]Rule{"aws-access-key": {
+					RuleID:      "aws-access-key",
+					Description: "Puppy Doggy",
+					Regex:       regexp.MustCompile("(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}"),
+					Keywords:    []string{},
+					Tags:        []string{"key", "AWS"},
+				},
+				},
+			},
+		},
+		{
+			cfgName: "override_entropy",
+			rules:   []string{"aws-access-key"},
+			cfg: Config{
+				Rules: map[string]Rule{"aws-access-key": {
+					RuleID:      "aws-access-key",
+					Description: "AWS Access Key",
+					Entropy:     999.0,
+					Regex:       regexp.MustCompile("(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}"),
+					Keywords:    []string{},
+					Tags:        []string{"key", "AWS"},
+				},
+				},
+			},
+		},
+		{
+			cfgName: "override_secret_group",
+			rules:   []string{"aws-access-key"},
+			cfg: Config{
+				Rules: map[string]Rule{"aws-access-key": {
+					RuleID:      "aws-access-key",
+					Description: "AWS Access Key",
+					Regex:       regexp.MustCompile("(?:a)(?:a)"),
+					SecretGroup: 2,
+					Keywords:    []string{},
+					Tags:        []string{"key", "AWS"},
+				},
+				},
+			},
+		},
+		{
+			cfgName: "override_regex",
+			rules:   []string{"aws-access-key"},
+			cfg: Config{
+				Rules: map[string]Rule{"aws-access-key": {
+					RuleID:      "aws-access-key",
+					Description: "AWS Access Key",
+					Regex:       regexp.MustCompile("(?:a)"),
+					Keywords:    []string{},
+					Tags:        []string{"key", "AWS"},
+				},
+				},
+			},
+		},
+		{
+			cfgName: "override_path",
+			rules:   []string{"aws-access-key"},
+			cfg: Config{
+				Rules: map[string]Rule{"aws-access-key": {
+					RuleID:      "aws-access-key",
+					Description: "AWS Access Key",
+					Regex:       regexp.MustCompile("(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}"),
+					Path:        regexp.MustCompile("(?:puppy)"),
+					Keywords:    []string{},
+					Tags:        []string{"key", "AWS"},
+				},
+				},
+			},
+		},
+		{
+			cfgName: "override_tags",
+			rules:   []string{"aws-access-key"},
+			cfg: Config{
+				Rules: map[string]Rule{"aws-access-key": {
+					RuleID:      "aws-access-key",
+					Description: "AWS Access Key",
+					Regex:       regexp.MustCompile("(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}"),
+					Keywords:    []string{},
+					Tags:        []string{"puppy"},
+				},
+				},
+			},
+		},
+		{
+			cfgName: "override_keywords",
+			rules:   []string{"aws-access-key"},
+			cfg: Config{
+				Rules: map[string]Rule{"aws-access-key": {
+					RuleID:      "aws-access-key",
+					Description: "AWS Access Key",
+					Regex:       regexp.MustCompile("(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}"),
+					Keywords:    []string{"puppy"},
+					Tags:        []string{"key", "AWS"},
+				},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -195,6 +301,14 @@ func TestTranslate(t *testing.T) {
 			cfg, err := vc.Translate()
 			if !assert.Equal(t, tt.wantError, err) {
 				return
+			}
+
+			if len(tt.rules) > 0 {
+				rules := make(map[string]Rule)
+				for _, name := range tt.rules {
+					rules[name] = cfg.Rules[name]
+				}
+				cfg.Rules = rules
 			}
 
 			var regexComparer = func(x, y *regexp.Regexp) bool {

--- a/testdata/config/override_description.toml
+++ b/testdata/config/override_description.toml
@@ -1,0 +1,8 @@
+title = "override a built-in rule's description"
+
+[extend]
+path = "../testdata/config/simple.toml"
+
+[[rules]]
+id = "aws-access-key"
+description = "Puppy Doggy"

--- a/testdata/config/override_entropy.toml
+++ b/testdata/config/override_entropy.toml
@@ -1,0 +1,8 @@
+title = "override a built-in rule's entropy"
+
+[extend]
+path = "../testdata/config/simple.toml"
+
+[[rules]]
+id = "aws-access-key"
+entropy = 999

--- a/testdata/config/override_keywords.toml
+++ b/testdata/config/override_keywords.toml
@@ -1,0 +1,8 @@
+title = "override a built-in rule's keywords"
+
+[extend]
+path = "../testdata/config/simple.toml"
+
+[[rules]]
+id = "aws-access-key"
+keywords = ["puppy"]

--- a/testdata/config/override_path.toml
+++ b/testdata/config/override_path.toml
@@ -1,0 +1,8 @@
+title = "override a built-in rule's path"
+
+[extend]
+path = "../testdata/config/simple.toml"
+
+[[rules]]
+id = "aws-access-key"
+path = '''(?:puppy)'''

--- a/testdata/config/override_regex.toml
+++ b/testdata/config/override_regex.toml
@@ -1,0 +1,8 @@
+title = "override a built-in rule's regex"
+
+[extend]
+path = "../testdata/config/simple.toml"
+
+[[rules]]
+id = "aws-access-key"
+regex = '''(?:a)'''

--- a/testdata/config/override_secret_group.toml
+++ b/testdata/config/override_secret_group.toml
@@ -1,0 +1,9 @@
+title = "override a built-in rule's secretGroup"
+
+[extend]
+path = "../testdata/config/simple.toml"
+
+[[rules]]
+id = "aws-access-key"
+regex = '''(?:a)(?:a)'''
+secretGroup = 2

--- a/testdata/config/override_tags.toml
+++ b/testdata/config/override_tags.toml
@@ -1,0 +1,8 @@
+title = "override a built-in rule's tags"
+
+[extend]
+path = "../testdata/config/simple.toml"
+
+[[rules]]
+id = "aws-access-key"
+tags = ["puppy"]


### PR DESCRIPTION
### Description:
PR #1524 broke the ability to specify a `[[rules]]` with the same ID as a built-in rule in order to extend the default configuration.

This PR restores this ability, but merges the provided configuration with the default rule instead of overwriting the default rule wholesale.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
