### PR TITLE
Use iota for Allowlist condition

### DIFF
--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -45,7 +45,7 @@ tags = [
 ]{{ end }}
 {{ with $rule.Allowlists }}{{ range $i, $allowlist := . }}{{ if or $allowlist.Regexes $allowlist.Paths $allowlist.Commits $allowlist.StopWords }}
 [[rules.allowlists]]
-{{ with $allowlist.MatchCondition }}condition = "{{ . }}"
+{{ with $allowlist.MatchCondition }}condition = "{{ .String }}"
 {{ end -}}
 {{- with $allowlist.Commits }}commits = [
     {{ range $j, $commit := . }}"{{ $commit }}",{{ end }}

--- a/config/allowlist.go
+++ b/config/allowlist.go
@@ -6,12 +6,19 @@ import (
 	"strings"
 )
 
-type AllowlistMatchCondition string
+type AllowlistMatchCondition int
 
 const (
-	AllowlistMatchOr  AllowlistMatchCondition = "OR"
-	AllowlistMatchAnd                         = "AND"
+	AllowlistMatchOr AllowlistMatchCondition = iota
+	AllowlistMatchAnd
 )
+
+func (a AllowlistMatchCondition) String() string {
+	return [...]string{
+		"OR",
+		"AND",
+	}[a]
+}
 
 // Allowlist allows a rule to be ignored for specific
 // regexes, paths, and/or commits

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,7 +34,7 @@ func TestTranslate(t *testing.T) {
 					Keywords: []string{},
 					Allowlists: []Allowlist{
 						{
-							MatchCondition: "OR",
+							MatchCondition: AllowlistMatchOr,
 							Regexes:        []*regexp.Regexp{regexp.MustCompile("123")},
 						},
 					},
@@ -68,7 +68,7 @@ func TestTranslate(t *testing.T) {
 					Tags:        []string{"key", "AWS"},
 					Allowlists: []Allowlist{
 						{
-							MatchCondition: "OR",
+							MatchCondition: AllowlistMatchOr,
 							Regexes:        []*regexp.Regexp{regexp.MustCompile("AKIALALEMEL33243OLIA")},
 						},
 					},
@@ -87,7 +87,7 @@ func TestTranslate(t *testing.T) {
 					Tags:        []string{"key", "AWS"},
 					Allowlists: []Allowlist{
 						{
-							MatchCondition: "OR",
+							MatchCondition: AllowlistMatchOr,
 							Commits:        []string{"allowthiscommit"},
 						},
 					},
@@ -106,7 +106,7 @@ func TestTranslate(t *testing.T) {
 					Tags:        []string{"key", "AWS"},
 					Allowlists: []Allowlist{
 						{
-							MatchCondition: "OR",
+							MatchCondition: AllowlistMatchOr,
 							Paths:          []*regexp.Regexp{regexp.MustCompile(".go")},
 						},
 					},
@@ -184,11 +184,11 @@ func TestTranslate(t *testing.T) {
 						Tags:        []string{"key", "AWS"},
 						Allowlists: []Allowlist{
 							{
-								MatchCondition: "OR",
+								MatchCondition: AllowlistMatchOr,
 								StopWords:      []string{"fake"},
 							},
 							{
-								MatchCondition: "OR",
+								MatchCondition: AllowlistMatchOr,
 								Commits:        []string{"abcdefg1"},
 								Paths:          []*regexp.Regexp{regexp.MustCompile(`ignore\.xaml`)},
 								Regexes:        []*regexp.Regexp{regexp.MustCompile(`foo.+bar`)},
@@ -212,11 +212,11 @@ func TestTranslate(t *testing.T) {
 						Tags:        []string{"key", "AWS"},
 						Allowlists: []Allowlist{
 							{
-								MatchCondition: "OR",
+								MatchCondition: AllowlistMatchOr,
 								StopWords:      []string{"fake"},
 							},
 							{
-								MatchCondition: "AND",
+								MatchCondition: AllowlistMatchAnd,
 								Commits:        []string{"abcdefg1"},
 								Paths:          []*regexp.Regexp{regexp.MustCompile(`ignore\.xaml`)},
 								Regexes:        []*regexp.Regexp{regexp.MustCompile(`foo.+bar`)},
@@ -240,7 +240,7 @@ func TestTranslate(t *testing.T) {
 						Tags:        []string{"key", "AWS"},
 						Allowlists: []Allowlist{
 							{
-								MatchCondition: "OR",
+								MatchCondition: AllowlistMatchOr,
 								Paths:          []*regexp.Regexp{regexp.MustCompile(`something.py`)},
 							},
 						},

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -282,7 +282,7 @@ func (d *Detector) detectRule(fragment Fragment, currentRaw string, rule config.
 		}
 		if isAllowed {
 			logger.Trace().
-				Str("condition", string(a.MatchCondition)).
+				Str("condition", a.MatchCondition.String()).
 				Bool("commit-allowed", commitAllowed).
 				Bool("path-allowed", commitAllowed).
 				Msg("Skipping fragment due to rule allowlist")
@@ -474,7 +474,7 @@ MatchLoop:
 			if isAllowed {
 				logger.Trace().
 					Str("finding", finding.Secret).
-					Str("condition", string(a.MatchCondition)).
+					Str("condition", a.MatchCondition.String()).
 					Bool("regex-allowed", regexAllowed).
 					Bool("contains-stopword", containsStopword).
 					Msg("Skipping finding due to rule allowlist")


### PR DESCRIPTION
### Description:
This is a follow-up to #1496.

It makes `AllowlistMatchCondition` an int/iota "enum" to ensure that the default value is always `AllowlistMatchOr`. There are were some strange edge cases where `AllowlistMatchCondition` was "".

I don't think this was a problem in practice because the logic explicitly checked for `AllowlistMatchAnd`. Better safe than sorry!

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
