### PR TITLE
Temporarily switch back to `[rules.allowlist]` 

### DIFF
--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -43,6 +43,32 @@ keywords = [{{ range $j, $keyword := . }}"{{ $keyword }}"{{ end }}]{{end}}{{ end
 tags = [
     {{ range $j, $tag := . }}"{{ $tag }}",{{ end }}
 ]{{ end }}
+
+{{- /*
+    * Use [rules.allowlist] for a while, allow people to catch up with the new syntax.
+    * TODO: Remove this a few major versions after 8.21.0
+    * https://github.com/gitleaks/gitleaks/issues/1571
+    */}}
+{{- if eq (len $rule.Allowlists) 1 }}{{ with index $rule.Allowlists 0}}{{ if or .Regexes .Paths .Commits .StopWords }}
+# NOTE: Gitleaks >= v8.21.0 should use [[rules.allowlists] instead.
+[rules.allowlist]
+{{ with .MatchCondition }}condition = "{{ . }}"
+{{ end -}}
+{{- with .Commits }}commits = [
+    {{ range $j, $commit := . }}"{{ $commit }}",{{ end }}
+]{{ end }}
+{{- with .Paths }}paths = [
+    {{ range $j, $path := . }}'''{{ $path }}''',{{ end }}
+]{{ end }}
+{{- with .RegexTarget }}regexTarget = "{{ . }}"
+{{ end -}}
+{{- with .Regexes }}regexes = [{{ range $i, $regex := . }}
+    '''{{ $regex }}''',{{ end }}
+]{{ end }}
+{{- with .StopWords }}stopwords = [{{ range $j, $stopword := . }}
+    "{{ $stopword }}",{{ end }}
+]{{ end }}{{ end }}{{ end }}
+{{ else }}
 {{ with $rule.Allowlists }}{{ range $i, $allowlist := . }}{{ if or $allowlist.Regexes $allowlist.Paths $allowlist.Commits $allowlist.StopWords }}
 [[rules.allowlists]]
 {{ with $allowlist.MatchCondition }}condition = "{{ . }}"
@@ -61,5 +87,5 @@ tags = [
 {{- with $allowlist.StopWords }}stopwords = [{{ range $j, $stopword := . }}
     "{{ $stopword }}",{{ end }}
 ]{{ end }}{{ end }}{{ end }}
-{{ end }}
+{{ end }}{{ end }}
 {{ end -}}

--- a/cmd/generate/config/rules/sumologic.go
+++ b/cmd/generate/config/rules/sumologic.go
@@ -26,9 +26,6 @@ func SumoLogicAccessID() *config.Rule {
 				RegexTarget: "line",
 				Regexes:     []*regexp.Regexp{regexp.MustCompile(`sumOf`)},
 			},
-			{
-				Paths: []*regexp.Regexp{regexp.MustCompile(`tests/.+$`)},
-			},
 		},
 	}
 

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -480,8 +480,8 @@ keywords = [
     "auth",
     "access",
 ]
-
-[[rules.allowlists]]
+# NOTE: Gitleaks >= v8.21.0 should use [[rules.allowlists] instead.
+[rules.allowlist]
 stopwords = [
     "000000",
     "aaaaaa",
@@ -2168,8 +2168,8 @@ description = "Possible Kubernetes Secret detected, posing a risk of leaking cre
 regex = '''(?i)(?:\bkind:[ \t]*["']?secret["']?(?:.|\s){0,200}?\bdata:(?:.|\s){0,100}?\s+([\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:["']?[a-z0-9]{10,}={0,3}["']?|\{\{[ \t\w"|$:=,.-]+}}|""|''))|\bdata:(?:.|\s){0,100}?\s+([\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:["']?[a-z0-9]{10,}={0,3}["']?|\{\{[ \t\w"|$:=,.-]+}}|""|''))(?:.|\s){0,200}?\bkind:[ \t]*["']?secret["']?)'''
 path = '''(?i)\.ya?ml$'''
 keywords = ["secret"]
-
-[[rules.allowlists]]
+# NOTE: Gitleaks >= v8.21.0 should use [[rules.allowlists] instead.
+[rules.allowlist]
 regexes = [
     '''[\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:\{\{[ \t\w"|$:=,.-]+}}|""|'')''',
 ]
@@ -2354,8 +2354,8 @@ regex = '''(?i)<add key=\"(?:(?:ClearText)?Password)\"\s*value=\"(.{8,})\"\s*/>'
 path = '''(?i)nuget\.config$'''
 entropy = 1
 keywords = ["<add key="]
-
-[[rules.allowlists]]
+# NOTE: Gitleaks >= v8.21.0 should use [[rules.allowlists] instead.
+[rules.allowlist]
 regexes = [
     '''33f!!lloppa''',
     '''hal\+9ooo_da!sY''',
@@ -2684,15 +2684,11 @@ description = "Discovered a SumoLogic Access ID, potentially compromising log ma
 regex = '''(?i:(?:sumo)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(su[a-zA-Z0-9]{12})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["sumo"]
-
-[[rules.allowlists]]
+# NOTE: Gitleaks >= v8.21.0 should use [[rules.allowlists] instead.
+[rules.allowlist]
 regexTarget = "line"
 regexes = [
     '''sumOf''',
-]
-[[rules.allowlists]]
-paths = [
-    '''tests/.+$''',
 ]
 
 [[rules]]
@@ -2777,8 +2773,8 @@ keywords = [
     "hvs",
     "s.",
 ]
-
-[[rules.allowlists]]
+# NOTE: Gitleaks >= v8.21.0 should use [[rules.allowlists] instead.
+[rules.allowlist]
 regexes = [
     '''s\.[A-Za-z]{24}''',
 ]


### PR DESCRIPTION
### Description:
This should fix #1571, per https://github.com/gitleaks/gitleaks/issues/1571#issuecomment-2417659688. No rules were using multiple allowlists yet (the sumologic one was a leftover test), so this should be fine.

We should switch back after a few months or major versions.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
