### PR TITLE
Log skipped symlinks

### DIFF
--- a/sources/directory.go
+++ b/sources/directory.go
@@ -1,12 +1,12 @@
 package sources
 
 import (
+	"github.com/rs/zerolog/log"
 	"io/fs"
 	"os"
 	"path/filepath"
 
 	"github.com/fatih/semgroup"
-	"github.com/rs/zerolog/log"
 )
 
 type ScanTarget struct {
@@ -35,7 +35,12 @@ func DirectoryTargets(source string, s *semgroup.Group, followSymlinks bool) (<-
 						Symlink: "",
 					}
 				}
-				if fInfo.Mode().Type() == fs.ModeSymlink && followSymlinks {
+				if fInfo.Mode().Type() == fs.ModeSymlink {
+					if !followSymlinks {
+						log.Debug().Str("path", path).Msg("Skipping symlink")
+						return nil
+					}
+
 					realPath, err := filepath.EvalSymlinks(path)
 					if err != nil {
 						return err


### PR DESCRIPTION
### Description:

I encountered a bit of confusion when I accidentally specified `/tmp` instead of `/tmp/`, with no feedback. This adds a debug log when a symlink is skipped.

**Example output from before**

*No symlink*
```sh
$ ./gitleaks dir /tmp --config /tmp/g.toml --log-level debug

9:17AM DBG using gitleaks config /tmp/g.toml from `--config`
9:17AM DBG extending config with default config
9:17AM DBG found .gitleaksignore file: .gitleaksignore
9:17AM INF scan completed in 1.75ms
9:17AM INF no leaks found
```

*Symlink*
```sh
$ ./gitleaks dir /tmp/ --config /tmp/g.toml --log-level debug

9:18AM DBG using gitleaks config /tmp/g.toml from `--config`
9:18AM DBG extending config with default config
9:18AM DBG found .gitleaksignore file: .gitleaksignore
9:18AM ERR failed scan directory error="1 error(s) occurred:\n* open /tmp/tmp-mount-c7Lws7: permission denied"
9:18AM WRN partial scan completed in 1.84ms
9:18AM WRN 1 leaks found in partial scan
```

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
