### PR TITLE
Fix config validate rules when [extend] is used

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -199,7 +199,8 @@ func (vc *ViperConfig) Translate() (Config, error) {
 		OrderedRules: orderedRules,
 	}
 
-	if maxExtendDepth != extendDepth {
+	currentExtendDepth := extendDepth
+	if maxExtendDepth != currentExtendDepth {
 		// disallow both usedefault and path from being set
 		if c.Extend.Path != "" && c.Extend.UseDefault {
 			log.Fatal().Msg("unable to load config due to extend.path and extend.useDefault being set")
@@ -212,8 +213,8 @@ func (vc *ViperConfig) Translate() (Config, error) {
 	}
 
 	// Validate the rules after everything has been assembled (including extended configs).
-	if extendDepth == 0 {
-		for _, rule := range rulesMap {
+	if currentExtendDepth == 0 {
+		for _, rule := range c.Rules {
 			if err := rule.Validate(); err != nil {
 				return Config{}, err
 			}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,13 +1,14 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"regexp"
 	"testing"
 
 	"github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -132,7 +133,7 @@ func TestTranslate(t *testing.T) {
 		{
 			cfgName:   "missing_id",
 			cfg:       Config{},
-			wantError: fmt.Errorf("rule |id| is missing or empty, regex: (?i)(discord[a-z0-9_ .\\-,]{0,25})(=|>|:=|\\|\\|:|<=|=>|:).{0,5}['\\\"]([a-h0-9]{64})['\\\"]"),
+			wantError: fmt.Errorf("rule |id| is missing or empty, description: Discord API key, regex: (?i)(discord[a-z0-9_ .\\-,]{0,25})(=|>|:=|\\|\\|:|<=|=>|:).{0,5}['\\\"]([a-h0-9]{64})['\\\"]"),
 		},
 		{
 			cfgName:   "no_regex_or_path",
@@ -284,7 +285,7 @@ func TestTranslate(t *testing.T) {
 				Rules: map[string]Rule{"aws-access-key": {
 					RuleID:      "aws-access-key",
 					Description: "AWS Access Key",
-					Regex:       regexp.MustCompile("(?:a)(?:a)"),
+					Regex:       regexp.MustCompile("(a)(a)"),
 					SecretGroup: 2,
 					Keywords:    []string{},
 					Tags:        []string{"key", "AWS"},
@@ -349,6 +350,10 @@ func TestTranslate(t *testing.T) {
 				},
 			},
 		},
+		{
+			cfgName:   "extend_invalid_ruleid",
+			wantError: errors.New("rule |id| is missing or empty"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -368,8 +373,17 @@ func TestTranslate(t *testing.T) {
 			err = viper.Unmarshal(&vc)
 			require.NoError(t, err)
 			cfg, err := vc.Translate()
-			if err != nil && !assert.EqualError(t, tt.wantError, err.Error()) {
-				return
+			if err != nil {
+				if tt.wantError != nil {
+					assert.EqualError(t, tt.wantError, err.Error())
+				} else {
+					require.NoError(t, err)
+				}
+			} else {
+				if tt.wantError != nil {
+					t.Fatalf("expected error but got none: %v", tt.wantError)
+					return
+				}
 			}
 
 			if len(tt.rules) > 0 {

--- a/config/rule.go
+++ b/config/rule.go
@@ -48,15 +48,17 @@ func (r Rule) Validate() error {
 	// Ensure |id| is present.
 	if strings.TrimSpace(r.RuleID) == "" {
 		// Try to provide helpful context, since |id| is empty.
-		var context string
-		if r.Regex != nil {
-			context = ", regex: " + r.Regex.String()
-		} else if r.Path != nil {
-			context = ", path: " + r.Path.String()
-		} else if r.Description != "" {
-			context = ", description: " + r.Description
+		var sb strings.Builder
+		if r.Description != "" {
+			sb.WriteString(", description: " + r.Description)
 		}
-		return fmt.Errorf("rule |id| is missing or empty" + context)
+		if r.Regex != nil {
+			sb.WriteString(", regex: " + r.Regex.String())
+		}
+		if r.Path != nil {
+			sb.WriteString(", path: " + r.Path.String())
+		}
+		return fmt.Errorf("rule |id| is missing or empty" + sb.String())
 	}
 
 	// Ensure the rule actually matches something.

--- a/testdata/config/extend_invalid_ruleid.toml
+++ b/testdata/config/extend_invalid_ruleid.toml
@@ -1,0 +1,7 @@
+[extend]
+useDefault = true
+
+[[rules]]
+
+[[rules.allowlists]]
+paths = ['^.*\.(xml|log|json)$']

--- a/testdata/config/override_secret_group.toml
+++ b/testdata/config/override_secret_group.toml
@@ -5,5 +5,5 @@ path = "../testdata/config/simple.toml"
 
 [[rules]]
 id = "aws-access-key"
-regex = '''(?:a)(?:a)'''
+regex = '''(a)(a)'''
 secretGroup = 2


### PR DESCRIPTION
### Description:
This fixes an issue where rules were not being validated when the config contained `[extend]`.

Because `extendDepth` is globally mutable, `if extendDepth == 0 {` was never true.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
