### PR TITLE
slightly flaky build - adjust entropy, tps, for sumologic-access-id, plaidAccessId, vault-service-token

### DIFF
--- a/cmd/generate/config/rules/hashicorp_vault.go
+++ b/cmd/generate/config/rules/hashicorp_vault.go
@@ -28,10 +28,10 @@ func VaultServiceToken() *config.Rule {
 	// validate
 	tps := []string{
 		// Old
-		utils.GenerateSampleSecret("vault", "s."+secrets.NewSecret(utils.AlphaNumeric("24"))),
+		utils.GenerateSampleSecret("vault", secrets.NewSecret(`s\.[a-zA-Z0-9]{24}`)),
 		`token: s.ZC9Ecf4M5g9o34Q6RkzGsj0z`,
 		// New
-		utils.GenerateSampleSecret("vault", "hvs."+secrets.NewSecret(utils.AlphaNumericExtendedShort("90"))),
+		utils.GenerateSampleSecret("vault", secrets.NewSecret(`hvs\.[\w\-]{90}`)),
 		`-vaultToken hvs.CAESIP2jTxc9S2K7Z6CtcFWQv7-044m_oSsxnPE1H3nF89l3GiYKHGh2cy5sQmlIZVNyTWJNcDRsYWJpQjlhYjVlb1cQh6PL8wEYAg"`, // longer than 100 chars
 	}
 	fps := []string{

--- a/cmd/generate/config/rules/plaid.go
+++ b/cmd/generate/config/rules/plaid.go
@@ -23,7 +23,7 @@ func PlaidAccessID() *config.Rule {
 
 	// validate
 	tps := []string{
-		utils.GenerateSampleSecret("plaid", secrets.NewSecret(utils.AlphaNumeric("24"))),
+		utils.GenerateSampleSecret("plaid", secrets.NewSecret(`[a-zA-Z0-9]{24}`)),
 	}
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/sumologic.go
+++ b/cmd/generate/config/rules/sumologic.go
@@ -25,7 +25,7 @@ func SumoLogicAccessID() *config.Rule {
 		`sumologic_access_id = "sug5XpdpaoxtOH"`,     // gitleaks:allow
 		`export SUMOLOGIC_ACCESSID="suDbJw97o9WVo0"`, // gitleaks:allow
 		`SUMO_ACCESS_ID = "suGyI5imvADdvU"`,          // gitleaks:allow
-		utils.GenerateSampleSecret("sumo", "su"+secrets.NewSecret(utils.AlphaNumeric("12"))),
+		utils.GenerateSampleSecret("sumo", secrets.NewSecret(`su[a-zA-Z0-9]{12}`)),
 	}
 	fps := []string{
 		`- (NSNumber *)sumOfProperty:(NSString *)property;`,


### PR DESCRIPTION
### Description:
`go generate` was slightly flaky, failing sometimes for the rules "sumologic-access-id", "plaid-client-id", "vault-service-token"

There was a small but significant chance that the true positive samples generated with `secrets.NewSecret()` would not match the minimum entropy.

I calculated a reasonably minimum threshold for the entropy, so that ~99.999% of random strings should have higher entropy.

#### changes:
- plaid-client-id: entropy 3.5 -> 3.4
- sumologic-access-id: entropy 3 -> 2.5
- hashicorp: entropy kept at 3.5, only adjusted the tps sample to include uppercase

The entropy of the generated true positives was also slightly lower than expected, since `secrets.NewSecret()` will only generate uppercase letters if they are explicitely included in the regex, so no uppercase for e.g. `secrets.NewSecret(utils.AlphaNumeric("24")`

I explicitely added the uppercase letters to the NewSecret calls for now. Not sure if there is a more elegant solution:
```diff
- utils.GenerateSampleSecret("vault", "s."+secrets.NewSecret(utils.AlphaNumeric("24"))),
+ utils.GenerateSampleSecret("vault", secrets.NewSecret(`s\.[a-zA-Z0-9]{24}`)),
```

Here are my calculated entropy thresholds:

| rule | regex | min entropy (matching 99.999% of strings) |
|------|-------|-------------|
|sumologic-access-id           | `su[a-zA-Z0-9]{12}`      | 2.638460          |
|                                        | `su[a-z0-9]{12}`      | 2.403677          |
| plaidAccessId                   | `[a-zA-Z0-9]{24}`    |  3.516151          |
|                                       | `[a-z0-9]{24}`    |  3.184561         |
| vault-service-token            | `s\.[a-zA-Z0-9]{24}`    |  3.642371       |
|                                       | `s\.[a-z0-9]{24}`  |  3.348084      |
|                                       | `hvs\.[\w-]{90}`  |  5.055993      |
|                                       | `hvs\.[a-z0-9_\-]{90}`  |  4.586675      |

I calculated these values with this code (not commited):
```golang
g, err := reggen.NewGenerator(regex)
if err != nil {
	panic(err)
}

entropy_samples := []float64{}
for i := 0; i < 1000000; i++ {
	secret := g.Generate(1)
	entropy := shannonEntropy(secret)
	entropy_samples = append(entropy_samples, entropy)
}
sort.Float64s(entropy_samples)
return entropy_samples[10]
```



### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
