### PR TITLE
Detect base64 secrets with generic-api-key

### DIFF
--- a/cmd/generate/config/rules/generic.go
+++ b/cmd/generate/config/rules/generic.go
@@ -19,11 +19,10 @@ func GenericCredential() *config.Rule {
 			"credential",
 			"creds",
 			"key",
-			"passwd",
-			"password",
+			"passw(?:or)?d",
 			"secret",
 			"token",
-		}, `[\w.=-]{10,150}`, true),
+		}, `[\w.=-]{10,150}|[a-z0-9][a-z0-9+/]{11,}={0,3}`, true),
 		Keywords: []string{
 			"access",
 			"api",
@@ -114,6 +113,8 @@ func GenericCredential() *config.Rule {
 		`some_api_token_123 = "`+newPlausibleSecret(`[a-zA-Z0-9]{60}`)+`"`,
 
 		// Auth
+		`"user_auth": "am9obmRvZTpkMDY5NGIxYi1jMTcxLTQ4ODYt+TMyYS0wMmUwOWQ1/mIwNjc="`,
+
 		// Credentials
 		`"credentials" : "0afae57f3ccfd9d7f5767067bc48b30f719e271ba470488056e37ab35d4b6506"`,
 		`creds = `+newPlausibleSecret(`[a-zA-Z0-9]{30}`),

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -564,7 +564,7 @@ regexes = [
 [[rules]]
 id = "generic-api-key"
 description = "Detected a Generic API Key, potentially exposing access to various services and sensitive operations."
-regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passwd|password|secret|token)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([\w.=-]{10,150})(?:[\x60'"\s;]|\\[nr]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passw(?:or)?d|secret|token)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([\w.=-]{10,150}|[a-z0-9][a-z0-9+/]{11,}={0,3})(?:[\x60'"\s;]|\\[nr]|$)'''
 entropy = 3.5
 keywords = [
     "access",


### PR DESCRIPTION
### Description:
This fixes an inconsistency where a baes64 encoded secret value (such as `abdcefg==`) would be detected, but other ones with valid characters `+` and `/` weren't.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
