### PR TITLE
Update Okta Access Token Rule

### DIFF
--- a/cmd/generate/config/rules/okta.go
+++ b/cmd/generate/config/rules/okta.go
@@ -11,8 +11,8 @@ func OktaAccessToken() *config.Rule {
 	r := config.Rule{
 		RuleID:      "okta-access-token",
 		Description: "Identified an Okta Access Token, which may compromise identity management services and user authentication data.",
-		Regex:       utils.GenerateSemiGenericRegex([]string{"okta"}, utils.AlphaNumericExtended("42"), true),
-		Entropy:     3,
+		Regex:       utils.GenerateSemiGenericRegex([]string{`(?-i:[Oo]kta|OKTA)`}, `00[\w=\-]{40}`, false),
+		Entropy:     4,
 		Keywords: []string{
 			"okta",
 		},
@@ -20,10 +20,15 @@ func OktaAccessToken() *config.Rule {
 
 	// validate
 	tps := []string{
-		utils.GenerateSampleSecret("okta", secrets.NewSecret(utils.AlphaNumeric("42"))),
+		utils.GenerateSampleSecret("okta", secrets.NewSecret(`00[\w=\-]{40}`)),
+		`"oktaApiToken": "00ebObu4zSNkyc6dimLvUwq4KpTEop-PCEnnfSTpD3",`,       // gitleaks:allow
+		`			var OktaApiToken = "00fWkOjwwL9xiFd-Vfgm_ePATIRxVj852Iblbb1DS_";`, // gitleaks:allow
 	}
 	fps := []string{
-		"00000000000000000000000000000000000TUVWXYZ",
+		`oktaKey = 00000000000000000000000000000000000TUVWXYZ`,   // low entropy
+		`rookTable = 0023452Lllk2KqjLBvaxANWEgTd7bqjsxjo8aZj0wd`, // wrong case
 	}
 	return utils.Validate(r, tps, fps)
 }
+
+// TODO: Okta client secret?

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2461,8 +2461,8 @@ keywords = [
 [[rules]]
 id = "okta-access-token"
 description = "Identified an Okta Access Token, which may compromise identity management services and user authentication data."
-regex = '''(?i)[\w.-]{0,10}?(?:okta)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([a-z0-9=_\-]{42})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
-entropy = 3
+regex = '''[\w.-]{0,10}?(?i:[\w.-]{0,10}?(?:(?-i:[Oo]kta|OKTA))(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}(00[\w=\-]{40})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+entropy = 4
 keywords = ["okta"]
 
 [[rules]]


### PR DESCRIPTION
### Description:
This improves the Okta access token pattern.

1. All the tokens I've found start with `00`.
2. All the tokens I've found have entropy >4.5
3. Short prefixes like `okta` or `etsy` can trigger false positives, this limits the keywords to "realistic" casing (`okta`, `Okta`, and `OKTA`). 

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
