### PR TITLE
Remove hard-coded 'magic' from the `generic-api-key` rule

### DIFF
--- a/cmd/generate/config/rules/generic.go
+++ b/cmd/generate/config/rules/generic.go
@@ -40,6 +40,13 @@ func GenericCredential() *config.Rule {
 		Entropy: 3.5,
 		Allowlists: []config.Allowlist{
 			{
+				// NOTE: this is a goofy hack to get around the fact there golang's regex engine does not support positive lookaheads.
+				// Ideally we would want to ensure the secret contains both numbers and alphabetical characters, not just alphabetical characters.
+				Regexes: []*regexp.Regexp{
+					regexp.MustCompile(`^[a-zA-Z_.-]+$`),
+				},
+			},
+			{
 				Description:    "Allowlist for Generic API Keys",
 				MatchCondition: config.AllowlistMatchOr,
 				RegexTarget:    "match",

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -551,6 +551,10 @@ keywords = [
     "token",
 ]
 [[rules.allowlists]]
+regexes = [
+    '''^[a-zA-Z_.-]+$''',
+]
+[[rules.allowlists]]
 regexTarget = "match"
 regexes = [
     '''(?i)(accessor|access[_.-]?id|api[_.-]?(version|id)|rapid|capital|[a-z0-9-]*?api[a-z0-9-]*?:jar:|author|X-MS-Exchange-Organization-Auth|Authentication-Results|(credentials?[_.-]?id|withCredentials)|(bucket|foreign|hot|natural|primary|schema|sequence)[_.-]?key|key[_.-]?(alias|board|code|ring|selector|size|stone|storetype|word|up|down|left|right)|key(store|tab)[_.-]?(file|path)|issuerkeyhash|(?-i:[DdMm]onkey|[DM]ONKEY)|keying|(secret)[_.-]?name|UserSecretsId|(api|credentials|token)[_.-]?(endpoint|ur[il])|public[_.-]?(key|token)|(key|token)[_.-]?file)''',

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -431,18 +431,6 @@ MatchLoop:
 				// entropy is too low, skip this finding
 				continue
 			}
-			// NOTE: this is a goofy hack to get around the fact there golang's regex engine
-			// does not support positive lookaheads. Ideally we would want to add a
-			// restriction on generic rules regex that requires the secret match group
-			// contains both numbers and alphabetical characters, not just alphabetical characters.
-			// What this bit of code does is check if the ruleid is prepended with "generic" and enforces the
-			// secret contains both digits and alphabetical characters.
-			// TODO: this should be replaced with stop words
-			if strings.HasPrefix(r.RuleID, "generic") {
-				if !containsDigit(finding.Secret) {
-					continue
-				}
-			}
 		}
 		// check if the regexTarget is defined in the allowlist "regexes" entry
 		// or if the secret is in the list of stopwords

--- a/detect/utils.go
+++ b/detect/utils.go
@@ -180,17 +180,6 @@ func printFinding(f report.Finding, noColor bool) {
 	fmt.Println("")
 }
 
-func containsDigit(s string) bool {
-	for _, c := range s {
-		switch c {
-		case '1', '2', '3', '4', '5', '6', '7', '8', '9':
-			return true
-		}
-
-	}
-	return false
-}
-
 func isWhitespace(ch byte) bool {
 	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r'
 }


### PR DESCRIPTION
### Description:
This replaces the hardcoded logic in `detect.go` with a regex. In testing across 3,000 repositories, there was virtually no difference between these implementations.

The benefit is that the constraints are explicit (not hidden in code), and people can take the config and tweak to be as they desire.

This should be merged after #1691.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
