### PR TITLE
fix(vault-service-token): ensure that TPS contains digits

### DIFF
--- a/cmd/generate/config/rules/hashicorp_vault.go
+++ b/cmd/generate/config/rules/hashicorp_vault.go
@@ -28,10 +28,10 @@ func VaultServiceToken() *config.Rule {
 	// validate
 	tps := []string{
 		// Old
-		utils.GenerateSampleSecret("vault", secrets.NewSecret(`s\.[a-zA-Z0-9]{24}`)),
+		utils.GenerateSampleSecret("vault", secrets.NewSecret(`s\.[0-9][a-zA-Z0-9]{23}`)),
 		`token: s.ZC9Ecf4M5g9o34Q6RkzGsj0z`,
 		// New
-		utils.GenerateSampleSecret("vault", secrets.NewSecret(`hvs\.[\w\-]{90}`)),
+		utils.GenerateSampleSecret("vault", secrets.NewSecret(`hvs\.[0-9][\w\-]{89}`)),
 		`-vaultToken hvs.CAESIP2jTxc9S2K7Z6CtcFWQv7-044m_oSsxnPE1H3nF89l3GiYKHGh2cy5sQmlIZVNyTWJNcDRsYWJpQjlhYjVlb1cQh6PL8wEYAg"`, // longer than 100 chars
 	}
 	fps := []string{


### PR DESCRIPTION
closes #1613

### Description:
Ensures that the true positives for both the old and the new hashicorp token formats contain a digit in the first 24 characters.

Chances of randomly generating a 24 letter string without digits: P = ( (26+26) / (26+26+10) ) ^ 24 = 1.46 %

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you lint your code locally prior to submission?
