### PR TITLE
fix(aws): detect token in url

### DIFF
--- a/cmd/generate/config/rules/aws.go
+++ b/cmd/generate/config/rules/aws.go
@@ -13,7 +13,7 @@ func AWS() *config.Rule {
 	r := config.Rule{
 		Description: "Identified a pattern that may indicate AWS credentials, risking unauthorized cloud resource access and data breaches on AWS platforms.",
 		RuleID:      "aws-access-token",
-		Regex:       utils.GenerateUniqueTokenRegex("(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}", false),
+		Regex:       regexp.MustCompile(`\b((?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16})\b`),
 		Entropy:     3,
 		Keywords: []string{
 			// https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-unique-ids
@@ -35,6 +35,10 @@ func AWS() *config.Rule {
 	// validate
 	tps := []string{
 		utils.GenerateSampleSecret("AWS", "AKIALALEMEL33243OLIB"), // gitleaks:allow
+
+		// as part of a URL
+		`https://aws.example.com/test/abc?AWSAccessKeyId=AKIALALEMEL33243OLIB&Signature=test`, // gitleaks:allow
+
 		// current AWS tokens cannot contain [0,1,8,9], so their entropy is slightly lower than expected.
 		utils.GenerateSampleSecret("AWS", "AKIA"+secrets.NewSecret("[A-Z2-7]{16}")),
 		utils.GenerateSampleSecret("AWS", "ASIA"+secrets.NewSecret("[A-Z2-7]{16}")),

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -153,7 +153,7 @@ keywords = [
 [[rules]]
 id = "aws-access-token"
 description = "Identified a pattern that may indicate AWS credentials, risking unauthorized cloud resource access and data breaches on AWS platforms."
-regex = '''\b((?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+regex = '''\b((?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16})\b'''
 entropy = 3
 keywords = [
     "a3t",


### PR DESCRIPTION
closes #1612

### Description:
Changed the aws-access-token rule to find tokens ending with `\b` instead of only `(?:['|\"|\n|\r|\s|\x60|;]|$)`
Now tokens in urls should also be detected, e.g. `https://aws.example.com/test/abc?AWSAccessKeyId=AKIALALEMEL33243OLIB&Signature=test`

This pull request does not modify any other rules. Another way to fix this would be to add `&` to the suffix for all tokens generated by `GenerateUniqueTokenRegex` or `GenerateSemiGenericRegex`. 

That would allow other tokens to be detected in URLs, but I am not sure whether that would introduce other complications.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
