### PR TITLE
Add option to include `Line` field in JSON format report

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Flags:
       --no-banner                     suppress banner
       --no-color                      turn off color for verbose output
       --redact uint[=100]             redact secrets from logs and stdout. To redact only parts of the secret just apply a percent value from 0..100. For example --redact=20 (default 100%)
-  -f, --report-format string          output format (json, csv, junit, sarif) (default "json")
+  -f, --report-format string          output format (json, jsonextra, csv, junit, sarif) (default "json")
   -r, --report-path string            report file
   -v, --verbose                       show verbose output from scan
       --version                       version for gitleaks
@@ -278,7 +278,7 @@ keywords = [
 tags = ["tag","another tag"]
 
     # ⚠️ In v8.21.0 `[rules.allowlist]` was replaced with `[[rules.allowlists]]`.
-    # This change was backwards-compatible: instances of `[rules.allowlist]` still  work.  
+    # This change was backwards-compatible: instances of `[rules.allowlist]` still  work.
     #
     # You can define multiple allowlists for a rule to reduce false positives.
     # A finding will be ignored if _ANY_ `[[rules.allowlists]]` matches.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,7 +44,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("config", "c", "", configDescription)
 	rootCmd.PersistentFlags().Int("exit-code", 1, "exit code when leaks have been encountered")
 	rootCmd.PersistentFlags().StringP("report-path", "r", "", "report file")
-	rootCmd.PersistentFlags().StringP("report-format", "f", "json", "output format (json, csv, junit, sarif)")
+	rootCmd.PersistentFlags().StringP("report-format", "f", "json", "output format (json, jsonextra, csv, junit, sarif)")
 	rootCmd.PersistentFlags().StringP("baseline-path", "b", "", "path to baseline with issues that can be ignored")
 	rootCmd.PersistentFlags().StringP("log-level", "l", "info", "log level (trace, debug, info, warn, error, fatal)")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "show verbose output from scan")

--- a/report/finding.go
+++ b/report/finding.go
@@ -14,7 +14,7 @@ type Finding struct {
 	StartColumn int
 	EndColumn   int
 
-	Line string `json:"-"`
+	Line string `json:",omitempty"`
 
 	Match string
 

--- a/report/json.go
+++ b/report/json.go
@@ -9,6 +9,17 @@ func writeJson(findings []Finding, w io.WriteCloser) error {
 	if len(findings) == 0 {
 		findings = []Finding{}
 	}
+	for i := range findings {
+		// Remove `Line` from JSON output
+		findings[i].Line = ""
+	}
+	return writeJsonExtra(findings, w)
+}
+
+func writeJsonExtra(findings []Finding, w io.WriteCloser) error {
+	if len(findings) == 0 {
+		findings = []Finding{}
+	}
 	defer w.Close()
 
 	encoder := json.NewEncoder(w)

--- a/report/json_test.go
+++ b/report/json_test.go
@@ -9,6 +9,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var simpleFinding = Finding{
+	Description: "",
+	RuleID:      "test-rule",
+	Match:       "line containing secret",
+	Line:        "whole line containing secret",
+	Secret:      "a secret",
+	StartLine:   1,
+	EndLine:     2,
+	StartColumn: 1,
+	EndColumn:   2,
+	Message:     "opps",
+	File:        "auth.py",
+	SymlinkFile: "",
+	Commit:      "0000000000000000",
+	Author:      "John Doe",
+	Email:       "johndoe@gmail.com",
+	Date:        "10-19-2003",
+	Tags:        []string{},
+}
+
 func TestWriteJSON(t *testing.T) {
 	tests := []struct {
 		findings       []Finding
@@ -20,25 +40,7 @@ func TestWriteJSON(t *testing.T) {
 			testReportName: "simple",
 			expected:       filepath.Join(expectPath, "report", "json_simple.json"),
 			findings: []Finding{
-				{
-
-					Description: "",
-					RuleID:      "test-rule",
-					Match:       "line containing secret",
-					Secret:      "a secret",
-					StartLine:   1,
-					EndLine:     2,
-					StartColumn: 1,
-					EndColumn:   2,
-					Message:     "opps",
-					File:        "auth.py",
-					SymlinkFile: "",
-					Commit:      "0000000000000000",
-					Author:      "John Doe",
-					Email:       "johndoe@gmail.com",
-					Date:        "10-19-2003",
-					Tags:        []string{},
-				},
+				simpleFinding,
 			}},
 		{
 
@@ -65,4 +67,24 @@ func TestWriteJSON(t *testing.T) {
 			assert.Equal(t, want, got)
 		})
 	}
+}
+
+func TestWriteJSONExtra(t *testing.T) {
+	findings := []Finding{
+		simpleFinding,
+	}
+	expected := filepath.Join(expectPath, "report", "json_extra_simple.json")
+
+	tmpfile, err := os.Create(filepath.Join(t.TempDir(), "simple_extra.json"))
+	require.NoError(t, err)
+
+	err = writeJsonExtra(findings, tmpfile)
+	require.NoError(t, err)
+	assert.FileExists(t, tmpfile.Name())
+
+	got, err := os.ReadFile(tmpfile.Name())
+	require.NoError(t, err)
+	want, err := os.ReadFile(expected)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
 }

--- a/report/report.go
+++ b/report/report.go
@@ -22,6 +22,8 @@ func Write(findings []Finding, cfg config.Config, ext string, reportPath string)
 	switch ext {
 	case ".json", "json":
 		err = writeJson(findings, file)
+	case ".jsonextra", "jsonextra":
+		err = writeJsonExtra(findings, file)
 	case ".csv", "csv":
 		err = writeCsv(findings, file)
 	case ".xml", "junit":

--- a/testdata/expected/report/json_extra_simple.json
+++ b/testdata/expected/report/json_extra_simple.json
@@ -1,0 +1,23 @@
+[
+ {
+  "Description": "",
+  "StartLine": 1,
+  "EndLine": 2,
+  "StartColumn": 1,
+  "EndColumn": 2,
+  "Line": "whole line containing secret",
+  "Match": "line containing secret",
+  "Secret": "a secret",
+  "File": "auth.py",
+  "SymlinkFile": "",
+  "Commit": "0000000000000000",
+  "Entropy": 0,
+  "Author": "John Doe",
+  "Email": "johndoe@gmail.com",
+  "Date": "10-19-2003",
+  "Message": "opps",
+  "Tags": [],
+  "RuleID": "test-rule",
+  "Fingerprint": ""
+ }
+]


### PR DESCRIPTION
## Description
We propose adding an option to include the `Line` field in the JSON output of gitleaks.

Rather than simply adding a flag like `--include-line`, we suggest introducing a new `jsonextra` format that extends the standard `json` format. This approach ensures future extensibility, as we can easily add additional fields to `jsonextra` that are not part of the default output.

## Background
We are currently using gitleaks in conjunction with our custom "allowlist" extension: https://github.com/Finatext/gls

This extension supports multiple allow-rules for both global and per detection-rules. We developed this as separate tool because integrating such an extension into the upstream version of gitleaks seemed challenging without sufficient confidence.

We have been successfully running gitleaks with our extension on every GitHub PR in our organization for some time. While it may be difficult to incorporate our extension directly into the upstream version, we need to modify gitleaks to add the `Line` field to the JSON output to support this extension.

## Impact
No changes on the existing `json` format.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?