### PR TITLE
Make paths and fingerprints platform-agnostic

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -4,6 +4,7 @@ jobs:
   scan:
     name: gitleaks
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'gitleaks/gitleaks' }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,17 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ ubuntu-latest, windows-latest ]
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
 
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.22
+          go-version: 1.23
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,13 @@ jobs:
       - name: Build
         run: go build -v ./...
 
+      - name: Set up gotestsum
+        run: |
+          go install gotest.tools/gotestsum@latest
+
       - name: Test
-        run: make test
+        run: |
+          gotestsum --raw-command -- go test -json ./... --race
 
       - name: Validate Config
         run: go generate ./... && git diff --exit-code

--- a/report/csv_test.go
+++ b/report/csv_test.go
@@ -53,6 +53,7 @@ func TestWriteCSV(t *testing.T) {
 		t.Run(test.testReportName, func(t *testing.T) {
 			tmpfile, err := os.Create(filepath.Join(t.TempDir(), test.testReportName+".csv"))
 			require.NoError(t, err)
+			defer tmpfile.Close()
 
 			err = reporter.Write(tmpfile, test.findings)
 			require.NoError(t, err)
@@ -67,7 +68,10 @@ func TestWriteCSV(t *testing.T) {
 
 			want, err := os.ReadFile(test.expected)
 			require.NoError(t, err)
-			assert.Equal(t, string(want), string(got))
+
+			wantStr := lineEndingReplacer.Replace(string(want))
+			gotStr := lineEndingReplacer.Replace(string(got))
+			assert.Equal(t, wantStr, gotStr)
 		})
 	}
 }

--- a/report/json_test.go
+++ b/report/json_test.go
@@ -53,18 +53,25 @@ func TestWriteJSON(t *testing.T) {
 		t.Run(test.testReportName, func(t *testing.T) {
 			tmpfile, err := os.Create(filepath.Join(t.TempDir(), test.testReportName+".json"))
 			require.NoError(t, err)
+			defer tmpfile.Close()
+
 			err = reporter.Write(tmpfile, test.findings)
 			require.NoError(t, err)
 			assert.FileExists(t, tmpfile.Name())
+
 			got, err := os.ReadFile(tmpfile.Name())
 			require.NoError(t, err)
 			if test.wantEmpty {
 				assert.Empty(t, got)
 				return
 			}
+
 			want, err := os.ReadFile(test.expected)
 			require.NoError(t, err)
-			assert.Equal(t, string(want), string(got))
+
+			wantStr := lineEndingReplacer.Replace(string(want))
+			gotStr := lineEndingReplacer.Replace(string(got))
+			assert.Equal(t, wantStr, gotStr)
 		})
 	}
 }

--- a/report/junit_test.go
+++ b/report/junit_test.go
@@ -69,6 +69,7 @@ func TestWriteJunit(t *testing.T) {
 	for _, test := range tests {
 		tmpfile, err := os.Create(filepath.Join(t.TempDir(), test.testReportName+".xml"))
 		require.NoError(t, err)
+		defer tmpfile.Close()
 
 		err = reporter.Write(tmpfile, test.findings)
 		require.NoError(t, err)
@@ -83,6 +84,9 @@ func TestWriteJunit(t *testing.T) {
 
 		want, err := os.ReadFile(test.expected)
 		require.NoError(t, err)
-		assert.Equal(t, string(want), string(got))
+
+		wantStr := lineEndingReplacer.Replace(string(want))
+		gotStr := lineEndingReplacer.Replace(string(got))
+		assert.Equal(t, wantStr, gotStr)
 	}
 }

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -2,6 +2,7 @@ package report
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,7 +10,6 @@ import (
 )
 
 const expectPath = "../testdata/expected/"
-const configPath = "../testdata/config/"
 const templatePath = "../testdata/report/"
 
 func TestWriteStdout(t *testing.T) {
@@ -40,3 +40,10 @@ type testWriter struct {
 func (t testWriter) Close() error {
 	return nil
 }
+
+// lineEndingReplacer normalizes CRLF to LF so tests pass on Windows.
+var lineEndingReplacer = strings.NewReplacer(
+	"\\r\\n", "\\n",
+	"\r", "",
+	"\\r", "",
+)

--- a/report/sarif_test.go
+++ b/report/sarif_test.go
@@ -49,6 +49,7 @@ func TestWriteSarif(t *testing.T) {
 		t.Run(test.cfgName, func(t *testing.T) {
 			tmpfile, err := os.Create(filepath.Join(t.TempDir(), test.testReportName+".json"))
 			require.NoError(t, err)
+			defer tmpfile.Close()
 
 			reporter := SarifReporter{
 				OrderedRules: []config.Rule{
@@ -76,7 +77,10 @@ func TestWriteSarif(t *testing.T) {
 
 			want, err := os.ReadFile(test.expected)
 			require.NoError(t, err)
-			assert.Equal(t, string(want), string(got))
+
+			wantStr := lineEndingReplacer.Replace(string(want))
+			gotStr := lineEndingReplacer.Replace(string(got))
+			assert.Equal(t, wantStr, gotStr)
 		})
 	}
 }

--- a/report/template_test.go
+++ b/report/template_test.go
@@ -74,6 +74,7 @@ func TestWriteTemplate(t *testing.T) {
 
 			tmpfile, err := os.Create(filepath.Join(t.TempDir(), test.testReportName+filepath.Ext(test.expected)))
 			require.NoError(t, err)
+			defer tmpfile.Close()
 
 			err = reporter.Write(tmpfile, test.findings)
 			require.NoError(t, err)
@@ -88,7 +89,10 @@ func TestWriteTemplate(t *testing.T) {
 
 			want, err := os.ReadFile(test.expected)
 			require.NoError(t, err)
-			assert.Equal(t, string(want), string(got))
+
+			wantStr := lineEndingReplacer.Replace(string(want))
+			gotStr := lineEndingReplacer.Replace(string(got))
+			assert.Equal(t, wantStr, gotStr)
 		})
 	}
 }

--- a/testdata/gitleaksignore/.windowspaths
+++ b/testdata/gitleaksignore/.windowspaths
@@ -1,0 +1,4 @@
+foo\bar\gitleaks-false-positive.yaml:aws-access-token:4
+b55d88dc151f7022901cda41a03d43e0e508f2b7:test_data\test_local_repo_three_leaks.json:aws-access-token:73
+foo/bar/gitleaks-false-positive.yaml:aws-access-token:5
+# comment


### PR DESCRIPTION
### Description:
This fixes #1565.

~**Note:** the current 'fix' is technically a breaking change for `path`/`paths` regular expressions as mentioned [here](https://github.com/gitleaks/gitleaks/issues/1565#issuecomment-2411954236). I don't know if this is acceptable, or what the best way to handle this would be. (Test both styles of paths if `runtime.GOOS == 'Windows'`?)~

**TODO**

- [x] Normalize finding paths
- [x] Normalize fingerprint paths
- [x] Normalize gitleaksignore paths
- [x] Add tests
- [x] Test .gitleaksignore on Windows
- [x] Test `rule.path` and `rule.allowlist.paths` regexes on Windows 

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
