### PR TITLE
fix(easypost): only detect tokens of correct length

### DIFF
--- a/cmd/generate/config/rules/easypost.go
+++ b/cmd/generate/config/rules/easypost.go
@@ -13,14 +13,22 @@ func EasyPost() *config.Rule {
 	r := config.Rule{
 		RuleID:      "easypost-api-token",
 		Description: "Identified an EasyPost API token, which could lead to unauthorized postal and shipment service access and data exposure.",
-		Regex:       regexp.MustCompile(`\bEZAK(?i)[a-z0-9]{54}`),
+		Regex:       regexp.MustCompile(`\bEZAK(?i)[a-z0-9]{54}\b`),
 		Entropy:     2,
 		Keywords:    []string{"EZAK"},
 	}
 
 	// validate
-	tps := utils.GenerateSampleSecrets("EZAK", "EZAK"+secrets.NewSecret(utils.AlphaNumeric("54")))
-	return utils.Validate(r, tps, nil)
+	tps := utils.GenerateSampleSecrets("EZAK", "EZAK"+secrets.NewSecret(`[a-zA-Z0-9]{54}`))
+	tps = append(tps,
+		"EZAK"+secrets.NewSecret(`[a-zA-Z0-9]{54}`),
+		"example.com?t=EZAK"+secrets.NewSecret(`[a-zA-Z0-9]{54}`)+"&q=1",
+	)
+	fps := []string{
+		// random base64 encoded string
+		`...6wqX6fNUXA/rYqRvfQ+EZAKGqQRiRyqAFRQshGPWOIAwNWGORfKHSBnVNFtVmWYoW6PH23lkqbbDWep95C/3VmWq/edti6...`, // gitleaks:allow
+	}
+	return utils.Validate(r, tps, fps)
 }
 
 func EasyPostTestAPI() *config.Rule {
@@ -28,12 +36,21 @@ func EasyPostTestAPI() *config.Rule {
 	r := config.Rule{
 		RuleID:      "easypost-test-api-token",
 		Description: "Detected an EasyPost test API token, risking exposure of test environments and potentially sensitive shipment data.",
-		Regex:       regexp.MustCompile(`\bEZTK(?i)[a-z0-9]{54}`),
+		Regex:       regexp.MustCompile(`\bEZTK(?i)[a-z0-9]{54}\b`),
 		Entropy:     2,
 		Keywords:    []string{"EZTK"},
 	}
 
 	// validate
-	tps := utils.GenerateSampleSecrets("EZTK", "EZTK"+secrets.NewSecret(utils.AlphaNumeric("54")))
-	return utils.Validate(r, tps, nil)
+	tps := utils.GenerateSampleSecrets("EZTK", secrets.NewSecret(`EZTK[a-zA-Z0-9]{54}`))
+	tps = append(tps, secrets.NewSecret(`EZTK[a-zA-Z0-9]{54}`))
+	tps = append(tps,
+		"EZTK"+secrets.NewSecret(`[a-zA-Z0-9]{54}`),
+		"example.com?t=EZTK"+secrets.NewSecret(`[a-zA-Z0-9]{54}`)+"&q=1",
+	)
+	fps := []string{
+		// random base64 encoded string
+		`...6wqX6fNUXA/rYqRvfQ+EZTKGqQRiRyqAFRQshGPWOIAwNWGORfKHSBnVNFtVmWYoW6PH23lkqbbDWep95C/3VmWq/edti6...`, // gitleaks:allow
+	}
+	return utils.Validate(r, tps, fps)
 }

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -409,14 +409,14 @@ keywords = ["dt0c01"]
 [[rules]]
 id = "easypost-api-token"
 description = "Identified an EasyPost API token, which could lead to unauthorized postal and shipment service access and data exposure."
-regex = '''\bEZAK(?i)[a-z0-9]{54}'''
+regex = '''\bEZAK(?i)[a-z0-9]{54}\b'''
 entropy = 2
 keywords = ["ezak"]
 
 [[rules]]
 id = "easypost-test-api-token"
 description = "Detected an EasyPost test API token, risking exposure of test environments and potentially sensitive shipment data."
-regex = '''\bEZTK(?i)[a-z0-9]{54}'''
+regex = '''\bEZTK(?i)[a-z0-9]{54}\b'''
 entropy = 2
 keywords = ["eztk"]
 


### PR DESCRIPTION
### Description:
The rules easypost-api-token and easypost-test-api-token were not checking for word boundaries at the end of token.

This caused some false positives: given enough BASE64 encoded text, the string "+EZAK" or "/EZAK" is bound to occur at some point, e.g.
"...6wqX6fNUXA/rYqRvfQ+**EZAK**GqQRiRyqAFRQshGPWOIAwNWGORfKHSBnVNFtVmWYoW6PH23lkqbbDWep95C/3VmWq/edti6..."

The new regex also checks for word boundaries at the end of the token. 

(This is not perfect, a `+` or `/` could still randomly occur 54 characters after a `+EZAK` in a base64 string, but now the chances are 64 times lower. 
Long-term, I would like to migrate this to utils.GenerateUniqueTokenRegexp(), so I did not want to complicate this too much. Just wanted to avoid something like #1612 happening again)

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
