### PR TITLE
chore(gcp): add firebase example keys to the gcp-api-key allowlists

### DIFF
--- a/cmd/generate/config/rules/gcp.go
+++ b/cmd/generate/config/rules/gcp.go
@@ -36,6 +36,29 @@ func GCPAPIKey() *config.Rule {
 		Keywords: []string{
 			"AIza",
 		},
+		Allowlists: []config.Allowlist{
+			{
+				Regexes: []*regexp.Regexp{
+					// example keys from https://github.com/firebase/firebase-android-sdk
+					regexp.MustCompile(`AIzaSyabcdefghijklmnopqrstuvwxyz1234567`),
+					regexp.MustCompile(`AIzaSyAnLA7NfeLquW1tJFpx_eQCxoX-oo6YyIs`),
+					regexp.MustCompile(`AIzaSyCkEhVjf3pduRDt6d1yKOMitrUEke8agEM`),
+					regexp.MustCompile(`AIzaSyDMAScliyLx7F0NPDEJi1QmyCgHIAODrlU`),
+					regexp.MustCompile(`AIzaSyD3asb-2pEZVqMkmL6M9N6nHZRR_znhrh0`),
+					regexp.MustCompile(`AIzayDNSXIbFmlXbIE6mCzDLQAqITYefhixbX4A`),
+					regexp.MustCompile(`AIzaSyAdOS2zB6NCsk1pCdZ4-P6GBdi_UUPwX7c`),
+					regexp.MustCompile(`AIzaSyASWm6HmTMdYWpgMnjRBjxcQ9CKctWmLd4`),
+					regexp.MustCompile(`AIzaSyANUvH9H9BsUccjsu2pCmEkOPjjaXeDQgY`),
+					regexp.MustCompile(`AIzaSyA5_iVawFQ8ABuTZNUdcwERLJv_a_p4wtM`),
+					regexp.MustCompile(`AIzaSyA4UrcGxgwQFTfaI3no3t7Lt1sjmdnP5sQ`),
+					regexp.MustCompile(`AIzaSyDSb51JiIcB6OJpwwMicseKRhhrOq1cS7g`),
+					regexp.MustCompile(`AIzaSyBF2RrAIm4a0mO64EShQfqfd2AFnzAvvuU`),
+					regexp.MustCompile(`AIzaSyBcE-OOIbhjyR83gm4r2MFCu4MJmprNXsw`),
+					regexp.MustCompile(`AIzaSyB8qGxt4ec15vitgn44duC5ucxaOi4FmqE`),
+					regexp.MustCompile(`AIzaSyA8vmApnrHNFE0bApF4hoZ11srVL_n0nvY`),
+				},
+			},
+		},
 	}
 
 	// validate
@@ -49,6 +72,23 @@ func GCPAPIKey() *config.Rule {
 		`AIzaTesb6Tscfcni8vIpWZqNCXFDFslJtVSvFDqabcd123`,                                                                   // text boundary end
 		`apiKey: "AIzaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`,                                                                // not enough entropy
 		`AIZASYCO2CXRMC9ELSKLHLHRMBSWDEVEDZTLO2O`,                                                                          // incorrect case
+		// example keys from https://github.com/firebase/firebase-android-sdk
+		`AIzaSyabcdefghijklmnopqrstuvwxyz1234567`,
+		`AIzaSyAnLA7NfeLquW1tJFpx_eQCxoX-oo6YyIs`,
+		`AIzaSyCkEhVjf3pduRDt6d1yKOMitrUEke8agEM`,
+		`AIzaSyDMAScliyLx7F0NPDEJi1QmyCgHIAODrlU`,
+		`AIzaSyD3asb-2pEZVqMkmL6M9N6nHZRR_znhrh0`,
+		`AIzayDNSXIbFmlXbIE6mCzDLQAqITYefhixbX4A`,
+		`AIzaSyAdOS2zB6NCsk1pCdZ4-P6GBdi_UUPwX7c`,
+		`AIzaSyASWm6HmTMdYWpgMnjRBjxcQ9CKctWmLd4`,
+		`AIzaSyANUvH9H9BsUccjsu2pCmEkOPjjaXeDQgY`,
+		`AIzaSyA5_iVawFQ8ABuTZNUdcwERLJv_a_p4wtM`,
+		`AIzaSyA4UrcGxgwQFTfaI3no3t7Lt1sjmdnP5sQ`,
+		`AIzaSyDSb51JiIcB6OJpwwMicseKRhhrOq1cS7g`,
+		`AIzaSyBF2RrAIm4a0mO64EShQfqfd2AFnzAvvuU`,
+		`AIzaSyBcE-OOIbhjyR83gm4r2MFCu4MJmprNXsw`,
+		`AIzaSyB8qGxt4ec15vitgn44duC5ucxaOi4FmqE`,
+		`AIzaSyA8vmApnrHNFE0bApF4hoZ11srVL_n0nvY`,
 	}
 	return utils.Validate(r, tps, fps)
 }

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -532,6 +532,25 @@ description = "Uncovered a GCP API key, which could lead to unauthorized access 
 regex = '''\b(AIza[\w-]{35})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
 entropy = 3
 keywords = ["aiza"]
+[[rules.allowlists]]
+regexes = [
+    '''AIzaSyabcdefghijklmnopqrstuvwxyz1234567''',
+    '''AIzaSyAnLA7NfeLquW1tJFpx_eQCxoX-oo6YyIs''',
+    '''AIzaSyCkEhVjf3pduRDt6d1yKOMitrUEke8agEM''',
+    '''AIzaSyDMAScliyLx7F0NPDEJi1QmyCgHIAODrlU''',
+    '''AIzaSyD3asb-2pEZVqMkmL6M9N6nHZRR_znhrh0''',
+    '''AIzayDNSXIbFmlXbIE6mCzDLQAqITYefhixbX4A''',
+    '''AIzaSyAdOS2zB6NCsk1pCdZ4-P6GBdi_UUPwX7c''',
+    '''AIzaSyASWm6HmTMdYWpgMnjRBjxcQ9CKctWmLd4''',
+    '''AIzaSyANUvH9H9BsUccjsu2pCmEkOPjjaXeDQgY''',
+    '''AIzaSyA5_iVawFQ8ABuTZNUdcwERLJv_a_p4wtM''',
+    '''AIzaSyA4UrcGxgwQFTfaI3no3t7Lt1sjmdnP5sQ''',
+    '''AIzaSyDSb51JiIcB6OJpwwMicseKRhhrOq1cS7g''',
+    '''AIzaSyBF2RrAIm4a0mO64EShQfqfd2AFnzAvvuU''',
+    '''AIzaSyBcE-OOIbhjyR83gm4r2MFCu4MJmprNXsw''',
+    '''AIzaSyB8qGxt4ec15vitgn44duC5ucxaOi4FmqE''',
+    '''AIzaSyA8vmApnrHNFE0bApF4hoZ11srVL_n0nvY''',
+]
 
 [[rules]]
 id = "generic-api-key"


### PR DESCRIPTION
### Description:

The [firebase-android-sdk](https://github.com/firebase/firebase-android-sdk/) contains some example keys. This PR adds them to the allowlists for the gcp-api-key.

#### before

```
gitleaks git /tmp/firebase-android-sdk/ --enable-rule gcp-api-key

    ○
    │╲
    │ ○
    ○ ░
    ░    gitleaks

10:02AM INF Overriding enabled rules: gcp-api-key
10:03AM INF 5948 commits scanned.
10:03AM INF scan completed in 18.7s
10:03AM WRN leaks found: 91
```

#### after

```
./gitleaks git /tmp/firebase-android-sdk/ --enable-rule gcp-api-key

    ○
    │╲
    │ ○
    ○ ░
    ░    gitleaks

10:02AM INF Overriding enabled rules: gcp-api-key
10:03AM INF 5948 commits scanned.
10:03AM INF scanned ~93888297 bytes (93.89 MB) in 17.9s
10:03AM INF no leaks found
```


### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
