### PR TITLE
feat: use STDOUT when report file not specified

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -283,16 +283,19 @@ func findingSummaryAndExit(findings []report.Finding, cmd *cobra.Command, cfg co
 	// write report if desired
 	reportPath, _ := cmd.Flags().GetString("report-path")
 	ext, _ := cmd.Flags().GetString("report-format")
-	reportWriter := os.Stdout
-	if reportPath != "" && reportPath != "-" {
-		reportWriter, err = os.Create(reportPath)
-		if err != nil {
-			log.Fatal().Err(err).Msg("could not create report file")
-		}
-	}
 
-	if err = report.Write(findings, cfg, ext, reportWriter); err != nil {
-		log.Fatal().Err(err).Msg("could not write")
+	if reportPath != "" {
+		reportWriter := os.Stdout
+		if reportPath != "-" {
+			reportWriter, err = os.Create(reportPath)
+			if err != nil {
+				log.Fatal().Err(err).Msg("could not create report file")
+			}
+		}
+
+		if err = report.Write(findings, cfg, ext, reportWriter); err != nil {
+			log.Fatal().Err(err).Msg("could not write")
+		}
 	}
 
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -283,10 +283,16 @@ func findingSummaryAndExit(findings []report.Finding, cmd *cobra.Command, cfg co
 	// write report if desired
 	reportPath, _ := cmd.Flags().GetString("report-path")
 	ext, _ := cmd.Flags().GetString("report-format")
-	if reportPath != "" {
-		if err := report.Write(findings, cfg, ext, reportPath); err != nil {
-			log.Fatal().Err(err).Msg("could not write")
+	reportWriter := os.Stdout
+	if reportPath != "" && reportPath != "-" {
+		reportWriter, err = os.Create(reportPath)
+		if err != nil {
+			log.Fatal().Err(err).Msg("could not create report file")
 		}
+	}
+
+	if err = report.Write(findings, cfg, ext, reportWriter); err != nil {
+		log.Fatal().Err(err).Msg("could not write")
 	}
 
 	if err != nil {

--- a/report/report.go
+++ b/report/report.go
@@ -1,7 +1,7 @@
 package report
 
 import (
-	"os"
+	"io"
 	"strings"
 
 	"github.com/zricethezav/gitleaks/v8/config"
@@ -13,23 +13,20 @@ const (
 	CWE_DESCRIPTION = "Use of Hard-coded Credentials"
 )
 
-func Write(findings []Finding, cfg config.Config, ext string, reportPath string) error {
-	file, err := os.Create(reportPath)
-	if err != nil {
-		return err
-	}
+func Write(findings []Finding, cfg config.Config, ext string, report io.WriteCloser) error {
+	var err error
 	ext = strings.ToLower(ext)
 	switch ext {
 	case ".json", "json":
-		err = writeJson(findings, file)
+		err = writeJson(findings, report)
 	case ".jsonextra", "jsonextra":
-		err = writeJsonExtra(findings, file)
+		err = writeJsonExtra(findings, report)
 	case ".csv", "csv":
-		err = writeCsv(findings, file)
+		err = writeCsv(findings, report)
 	case ".xml", "junit":
-		err = writeJunit(findings, file)
+		err = writeJunit(findings, report)
 	case ".sarif", "sarif":
-		err = writeSarif(cfg, findings, file)
+		err = writeSarif(cfg, findings, report)
 	}
 
 	return err


### PR DESCRIPTION
### Description:

Addresses #1312 to write report to `/dev/stdout` when `report-path` is set to `""` or `"-"`.

### Checklist:

* [X] Does your PR pass tests?
* [X] Have you written new tests for your changes?
* [X] Have you lint your code locally prior to submission?
