### PR TITLE
Add support for GitLab routable tokens #1655

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -108,6 +108,7 @@ func main() {
 		rules.GitlabKubernetesAgentToken(),
 		rules.GitlabOauthAppSecret(),
 		rules.GitlabPat(),
+		rules.GitlabPatRoutable(),
 		rules.GitlabPipelineTriggerToken(),
 		rules.GitlabRunnerRegistrationToken(),
 		rules.GitlabRunnerAuthenticationToken(),

--- a/cmd/generate/config/rules/gitlab.go
+++ b/cmd/generate/config/rules/gitlab.go
@@ -115,6 +115,23 @@ func GitlabPat() *config.Rule {
 	return utils.Validate(r, tps, fps)
 }
 
+func GitlabPatRoutable() *config.Rule {
+	r := config.Rule{
+		RuleID:      "gitlab-pat-routable",
+		Description: "Identified a GitLab Personal Access Token (routable), risking unauthorized access to GitLab repositories and codebase exposure.",
+		Regex:       regexp.MustCompile(`glpat-[0-9a-zA-Z_-]{27,300}\.[0-9a-z]{2}[0-9a-z]{7}`),
+		Entropy:     3,
+		Keywords:    []string{"glpat-"},
+	}
+
+	// validate
+	tps := utils.GenerateSampleSecrets("gitlab", "glpat-"+secrets.NewSecret(utils.AlphaNumeric("27"))+"."+secrets.NewSecret(utils.AlphaNumeric("2"))+secrets.NewSecret(utils.AlphaNumeric("7")))
+	fps := []string{
+		"glpat-XXXXXXXXXXXXXXXXXXX",
+	}
+	return utils.Validate(r, tps, fps)
+}
+
 func GitlabPipelineTriggerToken() *config.Rule {
 	r := config.Rule{
 		RuleID:      "gitlab-ptt",

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2138,6 +2138,13 @@ entropy = 3
 keywords = ["glpat-"]
 
 [[rules]]
+id = "gitlab-pat-routable"
+description = "Identified a GitLab Personal Access Token (routable), risking unauthorized access to GitLab repositories and codebase exposure."
+regex = '''glpat-[0-9a-zA-Z_-]{27,300}\.[0-9a-z]{2}[0-9a-z]{7}'''
+entropy = 3
+keywords = ["glpat-"]
+
+[[rules]]
 id = "gitlab-ptt"
 description = "Found a GitLab Pipeline Trigger Token, potentially compromising continuous integration workflows and project security."
 regex = '''glptt-[0-9a-f]{40}'''


### PR DESCRIPTION
### Description:
This commit adds support for GitLab's routable tokens.

- [specification](https://handbook.gitlab.com/handbook/engineering/architecture/design-documents/cells/routable_tokens/#proposal)
- [regex](https://gitlab.com/gitlab-org/security-products/secret-detection/secret-detection-rules/-/blob/main/rules/mit/gitlab.toml?ref_type=heads#L19) the GitLab team uses for identification

Issue: https://github.com/gitleaks/gitleaks/issues/1655

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
