### PR TITLE
A better chunking algorithm?

### DIFF
--- a/detect/directory.go
+++ b/detect/directory.go
@@ -1,15 +1,19 @@
 package detect
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"strings"
 
 	"github.com/h2non/filetype"
 	"github.com/rs/zerolog/log"
+
 	"github.com/zricethezav/gitleaks/v8/report"
 	"github.com/zricethezav/gitleaks/v8/sources"
 )
+
+const maxPeekSize = 25 * 1_000 // 10kb
 
 func (d *Detector) DetectFiles(paths <-chan sources.ScanTarget) ([]report.Finding, error) {
 	for pa := range paths {
@@ -50,41 +54,87 @@ func (d *Detector) DetectFiles(paths <-chan sources.ScanTarget) ([]report.Findin
 			totalLines := 0
 			for {
 				n, err := f.Read(buf)
-				if err != nil && err != io.EOF {
-					return err
-				}
-				if n == 0 {
-					break
+				if n > 0 {
+					// TODO: optimization could be introduced here
+					if mimetype, err := filetype.Match(buf[:n]); err != nil {
+						return nil
+					} else if mimetype.MIME.Type == "application" {
+						return nil // skip binary files
+					}
+
+					// If the chunk doesn't end in a newline, peek |maxPeekSize| until we find one.
+					// This hopefully avoids splitting
+					// See: https://github.com/gitleaks/gitleaks/issues/1651
+					var (
+						peekBuf      = bytes.NewBuffer(buf[:n])
+						tempBuf      = make([]byte, 1)
+						newlineCount = 0 // Tracks consecutive newlines
+					)
+					for {
+						data := peekBuf.Bytes()
+						if len(data) == 0 {
+							break
+						}
+
+						// Check if the last character is a newline.
+						lastChar := data[len(data)-1]
+						if lastChar == '\n' || lastChar == '\r' {
+							newlineCount++
+
+							// Stop if two consecutive newlines are found
+							if newlineCount >= 2 {
+								break
+							}
+						} else {
+							newlineCount = 0 // Reset if a non-newline character is found
+						}
+
+						// Stop growing the buffer if it reaches maxSize
+						if (peekBuf.Len() - n) >= maxPeekSize {
+							break
+						}
+
+						// Read additional data into a temporary buffer
+						m, readErr := f.Read(tempBuf)
+						if m > 0 {
+							peekBuf.Write(tempBuf[:m])
+						}
+
+						// Stop if EOF is reached
+						if readErr != nil {
+							if readErr == io.EOF {
+								break
+							}
+							return readErr
+						}
+					}
+
+					// Count the number of newlines in this chunk
+					chunk := string(peekBuf.Bytes())
+					linesInChunk := strings.Count(chunk, "\n")
+					totalLines += linesInChunk
+					fragment := Fragment{
+						Raw:      chunk,
+						FilePath: pa.Path,
+					}
+					if pa.Symlink != "" {
+						fragment.SymlinkFile = pa.Symlink
+					}
+					for _, finding := range d.Detect(fragment) {
+						// need to add 1 since line counting starts at 1
+						finding.StartLine += (totalLines - linesInChunk) + 1
+						finding.EndLine += (totalLines - linesInChunk) + 1
+						d.addFinding(finding)
+					}
 				}
 
-				// TODO: optimization could be introduced here
-				mimetype, err := filetype.Match(buf[:n])
 				if err != nil {
+					if err == io.EOF {
+						return nil
+					}
 					return err
-				}
-				if mimetype.MIME.Type == "application" {
-					return nil // skip binary files
-				}
-
-				// Count the number of newlines in this chunk
-				linesInChunk := strings.Count(string(buf[:n]), "\n")
-				totalLines += linesInChunk
-				fragment := Fragment{
-					Raw:      string(buf[:n]),
-					FilePath: pa.Path,
-				}
-				if pa.Symlink != "" {
-					fragment.SymlinkFile = pa.Symlink
-				}
-				for _, finding := range d.Detect(fragment) {
-					// need to add 1 since line counting starts at 1
-					finding.StartLine += (totalLines - linesInChunk) + 1
-					finding.EndLine += (totalLines - linesInChunk) + 1
-					d.addFinding(finding)
 				}
 			}
-
-			return nil
 		})
 	}
 


### PR DESCRIPTION
### Description:
This is a follow-up to #1652.

It attempts to 'intelligently' chunk inputs on subsequent newlines `\n\n`, rather than indiscriminately breaking text apart. The assumption is that it's safe(r) for a chunk to end at (1), rather than (2) or (3). Of course, the buffer cannot grow indefinitely or the original issue would regress; it will only search for consecutive newlines up to a `maxPeekSize`.

```
  // TODO: optimization could be introduced here
  if mimetype, err := filetype.Match(buf[:n]); err != nil {
    return nil
  } else if mimetype.MIME.Type == "application" {
    return nil // skip binary files
  }

>>> (1) <<<  // If the chunk doesn't end in a newli>>> (2) <<<ne, peek|maxPeekSize| until we find one.
  // This hopefully avoids splitting
>>> (3) <<< // See: https://github.com/gitleaks/gitleaks/issues/1651
  var (
```

The original issue with 60 private keys is solved by this change:
```sh
$ ./gitleaks dir /tmp/60keys.txt --no-color

10:22PM INF scan completed in 88ms
10:22PM WRN leaks found: 60
```

### Thoughts

- Needs to be tested on Windows or files with CRLF.
- Reading one byte at a time might be slow (idk, seems pretty fast)
- It might make sense for whitespace not to reset the counter. That way empty lines can match the criteria.
  ```
    }
     
  // Foo
  ```

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
