### PR TITLE
Update golang docker image version to 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS build
+FROM golang:1.23 AS build
 WORKDIR /go/src/github.com/zricethezav/gitleaks
 COPY . .
 RUN VERSION=$(git describe --tags --abbrev=0) && \


### PR DESCRIPTION
### Description:
Docker release is broken (see https://github.com/gitleaks/gitleaks/actions/runs/12420417050) because go mod 1.23 has been updated, the golang image needs it too

### Checklist:

* [X] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [X] Have you lint your code locally prior to submission?

This PR will resolve #1671