### PR TITLE
fix: generate report file even if no findings

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -378,7 +378,7 @@ func findingSummaryAndExit(detector *detect.Detector, findings []report.Finding,
 	}
 
 	// write report if desired
-	if detector.Reporter != nil && len(findings) > 0 {
+	if detector.Reporter != nil {
 		var (
 			file      io.WriteCloser
 			reportErr error


### PR DESCRIPTION
### Description:

Fixes https://github.com/gitleaks/gitleaks-action/issues/169

Since https://github.com/gitleaks/gitleaks/releases/tag/v8.21.3, it does not generate report files if the findings are empty

Looks like related to https://github.com/gitleaks/gitleaks/pull/1650#issuecomment-2556474066

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
