### PR TITLE
Add test case for secret with `,` suffix

### DIFF
--- a/cmd/generate/config/utils/generate.go
+++ b/cmd/generate/config/utils/generate.go
@@ -131,6 +131,8 @@ func GenerateSampleSecrets(identifier string, secret string) []string {
 		// TODO: "comment - hashtag":     "#{s} is the password",
 		// TODO: "comment - semicolon":     ";{s} is the password",
 		// TODO: "csv - unquoted": `{i}Token,{s},`,
+		"misc - comma operator": `System.setProperty("{I}_TOKEN", "{s}")`,
+		// TODO: "misc - comma suffix": `environmentVariables = {PATH=/usr/local/bin, ENV=/etc/bashrc, {I}_PASSWORD={s}, LC_CTYPE=en_CA.UTF-8},`, // Spotted in `./Library/Logs/gradle-kotlin-dsl-resolver-xxxx.log`
 		"logstash": "  \"{i}Token\" => \"{s}\"",
 		// TODO: "sql - tabular":      "|{s}|",
 		// TODO: "sql":      "",
@@ -147,7 +149,11 @@ func GenerateSampleSecrets(identifier string, secret string) []string {
 		// "": "",
 	}
 
-	replacer := strings.NewReplacer("{i}", identifier, "{s}", secret)
+	replacer := strings.NewReplacer(
+		"{i}", identifier,
+		"{I}", strings.ToUpper(identifier),
+		"{s}", secret,
+	)
 	cases := make([]string, 0, len(samples))
 	for _, v := range samples {
 		cases = append(cases, replacer.Replace(v))


### PR DESCRIPTION
### Description:
This adds a latent test case for secrets with a `,` suffix, based on something discovered in the wild. I've also included a case for #1679.

To be uncommented, eventually.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
