### PR TITLE
Generate `gitleaks.toml` with multiple allowlists

### DIFF
--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -24,9 +24,9 @@ paths = [{{ range $i, $path := . }}
 ]{{ end }}
 {{- with .Allowlist.StopWords }}{{println}}stopwords = [{{ range $j, $stopword := . }}
     "{{ $stopword }}",{{ end }}
-]{{ end }}
+]{{ end }}{{println}}
 
-{{ range $i, $rule := .Rules }}[[rules]]
+{{- range $i, $rule := .Rules }}{{println}}[[rules]]
 id = "{{$rule.RuleID}}"
 description = "{{$rule.Description}}"
 regex = '''{{$rule.Regex}}'''
@@ -46,15 +46,7 @@ keywords = [{{ range $j, $keyword := . }}"{{ $keyword }}"{{ end }}]{{end}}{{ end
 tags = [
     {{ range $j, $tag := . }}"{{ $tag }}",{{ end }}
 ]{{ end }}
-
-{{- /*
-    * Use [rules.allowlist] for a while, allow people to catch up with the new syntax.
-    * TODO: Remove this a few major versions after 8.21.0
-    * https://github.com/gitleaks/gitleaks/issues/1571
-    */}}
-{{- if eq (len $rule.Allowlists) 1 }}{{ with index $rule.Allowlists 0}}{{ if or .Regexes .Paths .Commits .StopWords }}
-# NOTE: Gitleaks >= v8.21.0 should use [[rules.allowlists] instead.
-[rules.allowlist]
+{{- with $rule.Allowlists }}{{ range $i, $allowlist := . }}{{ if or $allowlist.Regexes $allowlist.Paths $allowlist.Commits $allowlist.StopWords }}{{println}}[[rules.allowlists]]
 {{- with .MatchCondition }}{{println}}condition = "{{ .MatchCondition.String }}"{{ end }}
 {{- with .Commits -}}{{println}}commits = [
     {{ range $j, $commit := . }}"{{ $commit }}",{{ end }}
@@ -68,25 +60,5 @@ tags = [
 ]{{ end }}
 {{- with .StopWords }}{{println}}stopwords = [{{ range $j, $stopword := . }}
     "{{ $stopword }}",{{ end }}
-]{{ end }}{{ end }}{{ end }}
-{{ else }}
-{{ with $rule.Allowlists }}{{ range $i, $allowlist := . }}{{ if or $allowlist.Regexes $allowlist.Paths $allowlist.Commits $allowlist.StopWords }}
-[[rules.allowlists]]
-{{ with $allowlist.MatchCondition }}condition = "{{ .String }}"
-{{ end -}}
-{{- with $allowlist.Commits }}commits = [
-    {{ range $j, $commit := . }}"{{ $commit }}",{{ end }}
-]{{ end }}
-{{- with $allowlist.Paths }}paths = [
-    {{ range $j, $path := . }}'''{{ $path }}''',{{ end }}
-]{{ end }}
-{{- with $allowlist.RegexTarget }}regexTarget = "{{ . }}"
-{{ end -}}
-{{- with $allowlist.Regexes }}regexes = [{{ range $i, $regex := . }}
-    '''{{ $regex }}''',{{ end }}
-]{{ end }}
-{{ with $allowlist.StopWords }}stopwords = [{{ range $j, $stopword := . }}
-    "{{ $stopword }}",{{ end }}
-]{{ end }}{{ end }}{{ end }}
-{{ end }}{{ end }}
-{{ end -}}
+]{{ end }}{{ end }}{{ end }}{{ end }}
+{{ end }}

--- a/cmd/generate/config/rules/kubernetes.go
+++ b/cmd/generate/config/rules/kubernetes.go
@@ -41,9 +41,13 @@ func KubernetesSecret() *config.Rule {
 					// variable: ""
 					// variable: ''
 					regexp.MustCompile(`[\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:\{\{[ \t\w"|$:=,.-]+}}|""|'')`),
-					// TODO: Requires multiple allowlists to target match.
-					// Avoid overreach between directives.
-					// regexp.MustCompile(`(kind:(.|\s)+\n---\n(.|\s)+\bdata:|data:(.|\s)+\n---\n(.|\s)+\bkind:)`),
+				},
+			},
+			{
+				// Avoid overreach between directives.
+				RegexTarget: "match",
+				Regexes: []*regexp.Regexp{
+					regexp.MustCompile(`(kind:(.|\s)+\n---\n(.|\s)+\bdata:|data:(.|\s)+\n---\n(.|\s)+\bkind:)`),
 				},
 			},
 		},
@@ -245,21 +249,20 @@ metadata:
   namespace: kubernetes-dashboard
 type: Opaque
 `,
-		// TODO: Requires multiple allowlists.
-		//		"overly-permissive3.yaml": ` kind: Secret
-		//  target:
-		//    name: mysecret
-		//    creationPolicy: Owner
-		//
-		// ---
-		//
-		// kind: ConfigMap
-		//  data:
-		//        conversionStrategy: Default
-		//        decodingStrategy: None
-		//        key: secret/mysecret
-		//        property: foo
-		//      secretKey: foo`,
+		"overly-permissive3.yaml": ` kind: Secret
+ target:
+   name: mysecret
+   creationPolicy: Owner
+
+---
+
+kind: ConfigMap
+ data:
+       conversionStrategy: Default
+       decodingStrategy: None
+       key: secret/mysecret
+       property: foo
+     secretKey: foo`,
 		// https://github.com/gitleaks/gitleaks/issues/1644
 		"wrong-kind.yaml": `apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -161,8 +161,7 @@ keywords = [
     "abia",
     "acca",
 ]
-# NOTE: Gitleaks >= v8.21.0 should use [[rules.allowlists] instead.
-[rules.allowlist]
+[[rules.allowlists]]
 regexes = [
     '''.+EXAMPLE$''',
 ]
@@ -288,8 +287,7 @@ description = "Discovered a potential basic authorization token provided in a cu
 regex = '''\bcurl\b(?:.*|.*(?:[\r\n]{1,2}.*){1,5})[ \t\n\r](?:-u|--user)(?:=|[ \t]{0,5})(?:"([^:"]{3,}:[^"]{3,})"|'([^:']{3,}:[^']{3,})'|((?:"[^"]{3,}"|'[^']{3,}'|[\w$@.-]+):(?:"[^"]{3,}"|'[^']{3,}'|[\w${}@.-]+)))(?:\s|\z)'''
 entropy = 2
 keywords = ["curl"]
-# NOTE: Gitleaks >= v8.21.0 should use [[rules.allowlists] instead.
-[rules.allowlist]
+[[rules.allowlists]]
 regexes = [
     '''[^:]+:(change(it|me)|pass(word)?|pwd|test|token|\*+|x+)''',
     '''['"]?<[^>]+>['"]?:['"]?<[^>]+>|<[^:]+:[^>]+>['"]?''',
@@ -552,8 +550,7 @@ keywords = [
     "secret",
     "token",
 ]
-# NOTE: Gitleaks >= v8.21.0 should use [[rules.allowlists] instead.
-[rules.allowlist]
+[[rules.allowlists]]
 regexTarget = "match"
 regexes = [
     '''(?i)(accessor|access[_.-]?id|api[_.-]?(version|id)|rapid|capital|[a-z0-9-]*?api[a-z0-9-]*?:jar:|author|X-MS-Exchange-Organization-Auth|Authentication-Results|(credentials?[_.-]?id|withCredentials)|(bucket|foreign|hot|natural|primary|schema|sequence)[_.-]?key|key[_.-]?(alias|board|code|ring|selector|size|stone|storetype|word|up|down|left|right)|key(store|tab)[_.-]?(file|path)|issuerkeyhash|(?-i:[DdMm]onkey|[DM]ONKEY)|keying|(secret)[_.-]?name|UserSecretsId|(api|credentials|token)[_.-]?(endpoint|ur[il])|public[_.-]?(key|token)|(key|token)[_.-]?file)''',
@@ -2046,8 +2043,7 @@ keywords = [
     "ghu_",
     "ghs_",
 ]
-# NOTE: Gitleaks >= v8.21.0 should use [[rules.allowlists] instead.
-[rules.allowlist]
+[[rules.allowlists]]
 paths = [
     '''(^|/)@octokit/auth-token/README\.md$''',
 ]
@@ -2072,8 +2068,7 @@ description = "Uncovered a GitHub Personal Access Token, potentially leading to 
 regex = '''ghp_[0-9a-zA-Z]{36}'''
 entropy = 3
 keywords = ["ghp_"]
-# NOTE: Gitleaks >= v8.21.0 should use [[rules.allowlists] instead.
-[rules.allowlist]
+[[rules.allowlists]]
 paths = [
     '''(^|/)@octokit/auth-token/README\.md$''',
 ]
@@ -2344,10 +2339,14 @@ description = "Possible Kubernetes Secret detected, posing a risk of leaking cre
 regex = '''(?i)(?:\bkind:[ \t]*["']?\bsecret\b["']?(?:.|\s){0,200}?\bdata:(?:.|\s){0,100}?\s+([\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:["']?[a-z0-9+/]{10,}={0,3}["']?|\{\{[ \t\w"|$:=,.-]+}}|""|''))|\bdata:(?:.|\s){0,100}?\s+([\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:["']?[a-z0-9+/]{10,}={0,3}["']?|\{\{[ \t\w"|$:=,.-]+}}|""|''))(?:.|\s){0,200}?\bkind:[ \t]*["']?\bsecret\b["']?)'''
 path = '''(?i)\.ya?ml$'''
 keywords = ["secret"]
-# NOTE: Gitleaks >= v8.21.0 should use [[rules.allowlists] instead.
-[rules.allowlist]
+[[rules.allowlists]]
 regexes = [
     '''[\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:\{\{[ \t\w"|$:=,.-]+}}|""|'')''',
+]
+[[rules.allowlists]]
+regexTarget = "match"
+regexes = [
+    '''(kind:(.|\s)+\n---\n(.|\s)+\bdata:|data:(.|\s)+\n---\n(.|\s)+\bkind:)''',
 ]
 
 [[rules]]
@@ -2537,8 +2536,7 @@ regex = '''(?i)<add key=\"(?:(?:ClearText)?Password)\"\s*value=\"(.{8,})\"\s*/>'
 path = '''(?i)nuget\.config$'''
 entropy = 1
 keywords = ["<add key="]
-# NOTE: Gitleaks >= v8.21.0 should use [[rules.allowlists] instead.
-[rules.allowlist]
+[[rules.allowlists]]
 regexes = [
     '''33f!!lloppa''',
     '''hal\+9ooo_da!sY''',
@@ -3018,8 +3016,7 @@ keywords = [
     "hvs.",
     "s.",
 ]
-# NOTE: Gitleaks >= v8.21.0 should use [[rules.allowlists] instead.
-[rules.allowlist]
+[[rules.allowlists]]
 regexes = [
     '''s\.[A-Za-z]{24}''',
 ]


### PR DESCRIPTION
### Description:
[GitLab has upgraded to Gitleaks v8.22](https://gitlab.com/gitlab-org/security-products/analyzers/secrets/-/releases/v6.14.0), which was the motivation for keeping the older syntax.


### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
