### PR TITLE
Use \x60 instead of literal ` in patterns

### DIFF
--- a/cmd/generate/config/utils/generate.go
+++ b/cmd/generate/config/utils/generate.go
@@ -27,8 +27,8 @@ const (
 
 	// boundaries for the secret
 	secretPrefixUnique = `\b(`
-	secretPrefix       = "[`" + `'"\s=]{0,5}(`
-	secretSuffix       = ")(?:[`" + `'"\s;]|$)`
+	secretPrefix       = `[\x60'"\s=]{0,5}(`
+	secretSuffix       = `)(?:[\x60'"\s;]|$)`
 )
 
 func GenerateSemiGenericRegex(identifiers []string, secretRegex string, isCaseInsensitive bool) *regexp.Regexp {

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -64,20 +64,20 @@ keywords = ["ops_"]
 [[rules]]
 id = "adafruit-api-key"
 description = "Identified a potential Adafruit API Key, which could lead to unauthorized access to Adafruit services and sensitive data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:adafruit)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9_-]{32})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:adafruit)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9_-]{32})(?:[\x60'"\s;]|$)'''
 keywords = ["adafruit"]
 
 [[rules]]
 id = "adobe-client-id"
 description = "Detected a pattern that resembles an Adobe OAuth Web Client ID, posing a risk of compromised Adobe integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:adobe)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-f0-9]{32})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:adobe)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-f0-9]{32})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = ["adobe"]
 
 [[rules]]
 id = "adobe-client-secret"
 description = "Discovered a potential Adobe Client Secret, which, if exposed, could allow unauthorized Adobe service access and data manipulation."
-regex = '''\b(p8e-(?i)[a-z0-9]{32})(?:[`'"\s;]|$)'''
+regex = '''\b(p8e-(?i)[a-z0-9]{32})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = ["p8e-"]
 
@@ -90,45 +90,45 @@ keywords = ["age-secret-key-1"]
 [[rules]]
 id = "airtable-api-key"
 description = "Uncovered a possible Airtable API Key, potentially compromising database access and leading to data leakage or alteration."
-regex = '''(?i)[\w.-]{0,50}?(?:airtable)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{17})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:airtable)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{17})(?:[\x60'"\s;]|$)'''
 keywords = ["airtable"]
 
 [[rules]]
 id = "algolia-api-key"
 description = "Identified an Algolia API Key, which could result in unauthorized search operations and data exposure on Algolia-managed platforms."
-regex = '''(?i)[\w.-]{0,50}?(?:algolia)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{32})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:algolia)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{32})(?:[\x60'"\s;]|$)'''
 keywords = ["algolia"]
 
 [[rules]]
 id = "alibaba-access-key-id"
 description = "Detected an Alibaba Cloud AccessKey ID, posing a risk of unauthorized cloud resource access and potential data compromise."
-regex = '''\b(LTAI(?i)[a-z0-9]{20})(?:[`'"\s;]|$)'''
+regex = '''\b(LTAI(?i)[a-z0-9]{20})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = ["ltai"]
 
 [[rules]]
 id = "alibaba-secret-key"
 description = "Discovered a potential Alibaba Cloud Secret Key, potentially allowing unauthorized operations and data access within Alibaba Cloud."
-regex = '''(?i)[\w.-]{0,50}?(?:alibaba)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{30})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:alibaba)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{30})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = ["alibaba"]
 
 [[rules]]
 id = "asana-client-id"
 description = "Discovered a potential Asana Client ID, risking unauthorized access to Asana projects and sensitive task information."
-regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([0-9]{16})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([0-9]{16})(?:[\x60'"\s;]|$)'''
 keywords = ["asana"]
 
 [[rules]]
 id = "asana-client-secret"
 description = "Identified an Asana Client Secret, which could lead to compromised project management integrity and unauthorized access."
-regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{32})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:asana)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{32})(?:[\x60'"\s;]|$)'''
 keywords = ["asana"]
 
 [[rules]]
 id = "atlassian-api-token"
 description = "Detected an Atlassian API token, posing a threat to project management and collaboration tool security and data confidentiality."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:atlassian|confluence|jira)(?:[ \t\w.-]{0,20})[\s'"|]{0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-zA-Z0-9]{24})(?:[`'"\s;]|$)|\b(ATATT3[A-Za-z0-9_\-=]{186})(?:[`'"\s;]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:atlassian|confluence|jira)(?:[ \t\w.-]{0,20})[\s'"|]{0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-zA-Z0-9]{24})(?:[\x60'"\s;]|$)|\b(ATATT3[A-Za-z0-9_\-=]{186})(?:[\x60'"\s;]|$)'''
 entropy = 3.5
 keywords = [
     "atlassian",
@@ -140,7 +140,7 @@ keywords = [
 [[rules]]
 id = "authress-service-client-access-key"
 description = "Uncovered a possible Authress Service Client Access Key, which may compromise access control services and sensitive data."
-regex = '''\b((?:sc|ext|scauth|authress)_(?i)[a-z0-9]{5,30}\.[a-z0-9]{4,6}\.(?-i:acc)[_-][a-z0-9-]{10,32}\.[a-z0-9+/_=-]{30,120})(?:[`'"\s;]|$)'''
+regex = '''\b((?:sc|ext|scauth|authress)_(?i)[a-z0-9]{5,30}\.[a-z0-9]{4,6}\.(?-i:acc)[_-][a-z0-9-]{10,32}\.[a-z0-9+/_=-]{30,120})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = [
     "sc_",
@@ -176,31 +176,31 @@ keywords = ["q~"]
 [[rules]]
 id = "beamer-api-token"
 description = "Detected a Beamer API token, potentially compromising content management and exposing sensitive notifications and updates."
-regex = '''(?i)[\w.-]{0,50}?(?:beamer)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}(b_[a-z0-9=_\-]{44})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:beamer)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}(b_[a-z0-9=_\-]{44})(?:[\x60'"\s;]|$)'''
 keywords = ["beamer"]
 
 [[rules]]
 id = "bitbucket-client-id"
 description = "Discovered a potential Bitbucket Client ID, risking unauthorized repository access and potential codebase exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{32})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{32})(?:[\x60'"\s;]|$)'''
 keywords = ["bitbucket"]
 
 [[rules]]
 id = "bitbucket-client-secret"
 description = "Discovered a potential Bitbucket Client Secret, posing a risk of compromised code repositories and unauthorized access."
-regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9=_\-]{64})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bitbucket)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9=_\-]{64})(?:[\x60'"\s;]|$)'''
 keywords = ["bitbucket"]
 
 [[rules]]
 id = "bittrex-access-key"
 description = "Identified a Bittrex Access Key, which could lead to unauthorized access to cryptocurrency trading accounts and financial loss."
-regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{32})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{32})(?:[\x60'"\s;]|$)'''
 keywords = ["bittrex"]
 
 [[rules]]
 id = "bittrex-secret-key"
 description = "Detected a Bittrex Secret Key, potentially compromising cryptocurrency transactions and financial security."
-regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{32})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:bittrex)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{32})(?:[\x60'"\s;]|$)'''
 keywords = ["bittrex"]
 
 [[rules]]
@@ -213,21 +213,21 @@ keywords = ["clojars_"]
 [[rules]]
 id = "cloudflare-api-key"
 description = "Detected a Cloudflare API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9_-]{40})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9_-]{40})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = ["cloudflare"]
 
 [[rules]]
 id = "cloudflare-global-api-key"
 description = "Detected a Cloudflare Global API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-f0-9]{37})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:cloudflare)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-f0-9]{37})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = ["cloudflare"]
 
 [[rules]]
 id = "cloudflare-origin-ca-key"
 description = "Detected a Cloudflare Origin CA Key, potentially compromising cloud application deployments and operational security."
-regex = '''\b(v1\.0-[a-f0-9]{24}-[a-f0-9]{146})(?:[`'"\s;]|$)'''
+regex = '''\b(v1\.0-[a-f0-9]{24}-[a-f0-9]{146})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = [
     "cloudflare",
@@ -237,13 +237,13 @@ keywords = [
 [[rules]]
 id = "codecov-access-token"
 description = "Found a pattern resembling a Codecov Access Token, posing a risk of unauthorized access to code coverage reports and sensitive data."
-regex = '''(?i)[\w.-]{0,50}?(?:codecov)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{32})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:codecov)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{32})(?:[\x60'"\s;]|$)'''
 keywords = ["codecov"]
 
 [[rules]]
 id = "cohere-api-token"
 description = "Identified a Cohere Token, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:cohere|CO_API_KEY)(?:[ \t\w.-]{0,20})[\s'"|]{0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-zA-Z0-9]{40})(?:[`'"\s;]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:cohere|CO_API_KEY)(?:[ \t\w.-]{0,20})[\s'"|]{0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-zA-Z0-9]{40})(?:[\x60'"\s;]|$)'''
 entropy = 4
 keywords = [
     "cohere",
@@ -253,25 +253,25 @@ keywords = [
 [[rules]]
 id = "coinbase-access-token"
 description = "Detected a Coinbase Access Token, posing a risk of unauthorized access to cryptocurrency accounts and financial transactions."
-regex = '''(?i)[\w.-]{0,50}?(?:coinbase)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9_-]{64})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:coinbase)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9_-]{64})(?:[\x60'"\s;]|$)'''
 keywords = ["coinbase"]
 
 [[rules]]
 id = "confluent-access-token"
 description = "Identified a Confluent Access Token, which could compromise access to streaming data platforms and sensitive data flow."
-regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{16})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{16})(?:[\x60'"\s;]|$)'''
 keywords = ["confluent"]
 
 [[rules]]
 id = "confluent-secret-key"
 description = "Found a Confluent Secret Key, potentially risking unauthorized operations and data access within Confluent services."
-regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{64})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:confluent)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{64})(?:[\x60'"\s;]|$)'''
 keywords = ["confluent"]
 
 [[rules]]
 id = "contentful-delivery-api-token"
 description = "Discovered a Contentful delivery API token, posing a risk to content management systems and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:contentful)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9=_\-]{43})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:contentful)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9=_\-]{43})(?:[\x60'"\s;]|$)'''
 keywords = ["contentful"]
 
 [[rules]]
@@ -300,59 +300,59 @@ regexes = [
 [[rules]]
 id = "databricks-api-token"
 description = "Uncovered a Databricks API token, which may compromise big data analytics platforms and sensitive data processing."
-regex = '''\b(dapi[a-f0-9]{32}(?:-\d)?)(?:[`'"\s;]|$)'''
+regex = '''\b(dapi[a-f0-9]{32}(?:-\d)?)(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["dapi"]
 
 [[rules]]
 id = "datadog-access-token"
 description = "Detected a Datadog Access Token, potentially risking monitoring and analytics data exposure and manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:datadog)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{40})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:datadog)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{40})(?:[\x60'"\s;]|$)'''
 keywords = ["datadog"]
 
 [[rules]]
 id = "defined-networking-api-token"
 description = "Identified a Defined Networking API token, which could lead to unauthorized network operations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:dnkey)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dnkey)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}(dnkey-[a-z0-9=_\-]{26}-[a-z0-9=_\-]{52})(?:[\x60'"\s;]|$)'''
 keywords = ["dnkey"]
 
 [[rules]]
 id = "digitalocean-access-token"
 description = "Found a DigitalOcean OAuth Access Token, risking unauthorized cloud resource access and data compromise."
-regex = '''\b(doo_v1_[a-f0-9]{64})(?:[`'"\s;]|$)'''
+regex = '''\b(doo_v1_[a-f0-9]{64})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["doo_v1_"]
 
 [[rules]]
 id = "digitalocean-pat"
 description = "Discovered a DigitalOcean Personal Access Token, posing a threat to cloud infrastructure security and data privacy."
-regex = '''\b(dop_v1_[a-f0-9]{64})(?:[`'"\s;]|$)'''
+regex = '''\b(dop_v1_[a-f0-9]{64})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["dop_v1_"]
 
 [[rules]]
 id = "digitalocean-refresh-token"
 description = "Uncovered a DigitalOcean OAuth Refresh Token, which could allow prolonged unauthorized access and resource manipulation."
-regex = '''(?i)\b(dor_v1_[a-f0-9]{64})(?:[`'"\s;]|$)'''
+regex = '''(?i)\b(dor_v1_[a-f0-9]{64})(?:[\x60'"\s;]|$)'''
 keywords = ["dor_v1_"]
 
 [[rules]]
 id = "discord-api-token"
 description = "Detected a Discord API key, potentially compromising communication channels and user data privacy on Discord."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-f0-9]{64})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-f0-9]{64})(?:[\x60'"\s;]|$)'''
 keywords = ["discord"]
 
 [[rules]]
 id = "discord-client-id"
 description = "Identified a Discord client ID, which may lead to unauthorized integrations and data exposure in Discord applications."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([0-9]{18})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([0-9]{18})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = ["discord"]
 
 [[rules]]
 id = "discord-client-secret"
 description = "Discovered a potential Discord client secret, risking compromised Discord bot integrations and data leaks."
-regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9=_\-]{32})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:discord)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9=_\-]{32})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = ["discord"]
 
@@ -366,25 +366,25 @@ keywords = ["dp.pt."]
 [[rules]]
 id = "droneci-access-token"
 description = "Detected a Droneci Access Token, potentially compromising continuous integration and deployment workflows."
-regex = '''(?i)[\w.-]{0,50}?(?:droneci)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{32})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:droneci)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{32})(?:[\x60'"\s;]|$)'''
 keywords = ["droneci"]
 
 [[rules]]
 id = "dropbox-api-token"
 description = "Identified a Dropbox API secret, which could lead to unauthorized file access and data breaches in Dropbox storage."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{15})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{15})(?:[\x60'"\s;]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
 id = "dropbox-long-lived-api-token"
 description = "Found a Dropbox long-lived API token, risking prolonged unauthorized access to cloud storage and sensitive data."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43})(?:[\x60'"\s;]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
 id = "dropbox-short-lived-api-token"
 description = "Discovered a Dropbox short-lived API token, posing a risk of temporary but potentially harmful data access and manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}(sl\.[a-z0-9\-=_]{135})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:dropbox)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}(sl\.[a-z0-9\-=_]{135})(?:[\x60'"\s;]|$)'''
 keywords = ["dropbox"]
 
 [[rules]]
@@ -418,20 +418,20 @@ keywords = ["eztk"]
 [[rules]]
 id = "etsy-access-token"
 description = "Found an Etsy Access Token, potentially compromising Etsy shop management and customer data."
-regex = '''(?i)[\w.-]{0,50}?(?:(?-i:ETSY|[Ee]tsy))(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{24})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:(?-i:ETSY|[Ee]tsy))(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{24})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["etsy"]
 
 [[rules]]
 id = "facebook-access-token"
 description = "Discovered a Facebook Access Token, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''(?i)\b(\d{15,16}(\||%)[0-9a-z\-_]{27,40})(?:[`'"\s;]|$)'''
+regex = '''(?i)\b(\d{15,16}(\||%)[0-9a-z\-_]{27,40})(?:[\x60'"\s;]|$)'''
 entropy = 3
 
 [[rules]]
 id = "facebook-page-access-token"
 description = "Discovered a Facebook Page Access Token, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''\b(EAA[MC](?i)[a-z0-9]{100,})(?:[`'"\s;]|$)'''
+regex = '''\b(EAA[MC](?i)[a-z0-9]{100,})(?:[\x60'"\s;]|$)'''
 entropy = 4
 keywords = [
     "eaam",
@@ -441,38 +441,38 @@ keywords = [
 [[rules]]
 id = "facebook-secret"
 description = "Discovered a Facebook Application secret, posing a risk of unauthorized access to Facebook accounts and personal data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:facebook)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-f0-9]{32})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:facebook)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-f0-9]{32})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["facebook"]
 
 [[rules]]
 id = "fastly-api-token"
 description = "Uncovered a Fastly API key, which may compromise CDN and edge cloud services, leading to content delivery and security issues."
-regex = '''(?i)[\w.-]{0,50}?(?:fastly)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9=_\-]{32})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:fastly)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9=_\-]{32})(?:[\x60'"\s;]|$)'''
 keywords = ["fastly"]
 
 [[rules]]
 id = "finicity-api-token"
 description = "Detected a Finicity API token, potentially risking financial data access and unauthorized financial operations."
-regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-f0-9]{32})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-f0-9]{32})(?:[\x60'"\s;]|$)'''
 keywords = ["finicity"]
 
 [[rules]]
 id = "finicity-client-secret"
 description = "Identified a Finicity Client Secret, which could lead to compromised financial service integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{20})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finicity)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{20})(?:[\x60'"\s;]|$)'''
 keywords = ["finicity"]
 
 [[rules]]
 id = "finnhub-access-token"
 description = "Found a Finnhub Access Token, risking unauthorized access to financial market data and analytics."
-regex = '''(?i)[\w.-]{0,50}?(?:finnhub)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{20})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:finnhub)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{20})(?:[\x60'"\s;]|$)'''
 keywords = ["finnhub"]
 
 [[rules]]
 id = "flickr-access-token"
 description = "Discovered a Flickr Access Token, posing a risk of unauthorized photo management and potential data leakage."
-regex = '''(?i)[\w.-]{0,50}?(?:flickr)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{32})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:flickr)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{32})(?:[\x60'"\s;]|$)'''
 keywords = ["flickr"]
 
 [[rules]]
@@ -499,7 +499,7 @@ keywords = ["flwseck_test"]
 [[rules]]
 id = "flyio-access-token"
 description = "Uncovered a Fly.io API key"
-regex = '''\b((?:fo1_[\w-]{43}|fm1[ar]_[a-zA-Z0-9+\/]{100,}={0,3}|fm2_[a-zA-Z0-9+\/]{100,}={0,3}))(?:[`'"\s;]|$)'''
+regex = '''\b((?:fo1_[\w-]{43}|fm1[ar]_[a-zA-Z0-9+\/]{100,}={0,3}|fm2_[a-zA-Z0-9+\/]{100,}={0,3}))(?:[\x60'"\s;]|$)'''
 entropy = 4
 keywords = [
     "fo1_",
@@ -523,13 +523,13 @@ keywords = ["secret_key"]
 [[rules]]
 id = "freshbooks-access-token"
 description = "Discovered a Freshbooks Access Token, posing a risk to accounting software access and sensitive financial data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:freshbooks)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{64})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:freshbooks)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{64})(?:[\x60'"\s;]|$)'''
 keywords = ["freshbooks"]
 
 [[rules]]
 id = "gcp-api-key"
 description = "Uncovered a GCP API key, which could lead to unauthorized access to Google Cloud services and data breaches."
-regex = '''\b(AIza[\w-]{35})(?:[`'"\s;]|$)'''
+regex = '''\b(AIza[\w-]{35})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["aiza"]
 [[rules.allowlists]]
@@ -555,7 +555,7 @@ regexes = [
 [[rules]]
 id = "generic-api-key"
 description = "Detected a Generic API Key, potentially exposing access to various services and sensitive operations."
-regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passwd|password|secret|token)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([\w.=-]{10,150})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passwd|password|secret|token)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([\w.=-]{10,150})(?:[\x60'"\s;]|$)'''
 entropy = 3.5
 keywords = [
     "access",
@@ -2204,13 +2204,13 @@ keywords = ["_gitlab_session="]
 [[rules]]
 id = "gitter-access-token"
 description = "Uncovered a Gitter Access Token, which may lead to unauthorized access to chat and communication services."
-regex = '''(?i)[\w.-]{0,50}?(?:gitter)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9_-]{40})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:gitter)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9_-]{40})(?:[\x60'"\s;]|$)'''
 keywords = ["gitter"]
 
 [[rules]]
 id = "gocardless-api-token"
 description = "Detected a GoCardless API token, potentially risking unauthorized direct debit payment operations and financial data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:gocardless)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}(live_(?i)[a-z0-9\-_=]{40})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:gocardless)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}(live_(?i)[a-z0-9\-_=]{40})(?:[\x60'"\s;]|$)'''
 keywords = [
     "live_",
     "gocardless",
@@ -2219,21 +2219,21 @@ keywords = [
 [[rules]]
 id = "grafana-api-key"
 description = "Identified a Grafana API key, which could compromise monitoring dashboards and sensitive data analytics."
-regex = '''(?i)\b(eyJrIjoi[A-Za-z0-9]{70,400}={0,3})(?:[`'"\s;]|$)'''
+regex = '''(?i)\b(eyJrIjoi[A-Za-z0-9]{70,400}={0,3})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["eyjrijoi"]
 
 [[rules]]
 id = "grafana-cloud-api-token"
 description = "Found a Grafana cloud API token, risking unauthorized access to cloud-based monitoring services and data exposure."
-regex = '''(?i)\b(glc_[A-Za-z0-9+/]{32,400}={0,3})(?:[`'"\s;]|$)'''
+regex = '''(?i)\b(glc_[A-Za-z0-9+/]{32,400}={0,3})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["glc_"]
 
 [[rules]]
 id = "grafana-service-account-token"
 description = "Discovered a Grafana service account token, posing a risk of compromised monitoring services and data integrity."
-regex = '''(?i)\b(glsa_[A-Za-z0-9]{32}_[A-Fa-f0-9]{8})(?:[`'"\s;]|$)'''
+regex = '''(?i)\b(glsa_[A-Za-z0-9]{32}_[A-Fa-f0-9]{8})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["glsa_"]
 
@@ -2256,7 +2256,7 @@ keywords = ["atlasv1"]
 [[rules]]
 id = "hashicorp-tf-password"
 description = "Identified a HashiCorp Terraform password field, risking unauthorized infrastructure configuration and security breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:administrator_login_password|password)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}("[a-z0-9=_\-]{8,20}")(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:administrator_login_password|password)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}("[a-z0-9=_\-]{8,20}")(?:[\x60'"\s;]|$)'''
 path = '''(?i)\.(?:tf|hcl)$'''
 entropy = 2
 keywords = [
@@ -2267,46 +2267,46 @@ keywords = [
 [[rules]]
 id = "heroku-api-key"
 description = "Detected a Heroku API Key, potentially compromising cloud application deployments and operational security."
-regex = '''(?i)[\w.-]{0,50}?(?:heroku)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:heroku)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\x60'"\s;]|$)'''
 keywords = ["heroku"]
 
 [[rules]]
 id = "hubspot-api-key"
 description = "Found a HubSpot API Token, posing a risk to CRM data integrity and unauthorized marketing operations."
-regex = '''(?i)[\w.-]{0,50}?(?:hubspot)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:hubspot)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})(?:[\x60'"\s;]|$)'''
 keywords = ["hubspot"]
 
 [[rules]]
 id = "huggingface-access-token"
 description = "Discovered a Hugging Face Access token, which could lead to unauthorized access to AI models and sensitive data."
-regex = '''\b(hf_(?i:[a-z]{34}))(?:[`'"\s;]|$)'''
+regex = '''\b(hf_(?i:[a-z]{34}))(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = ["hf_"]
 
 [[rules]]
 id = "huggingface-organization-api-token"
 description = "Uncovered a Hugging Face Organization API token, potentially compromising AI organization accounts and associated data."
-regex = '''\b(api_org_(?i:[a-z]{34}))(?:[`'"\s;]|$)'''
+regex = '''\b(api_org_(?i:[a-z]{34}))(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = ["api_org_"]
 
 [[rules]]
 id = "infracost-api-token"
 description = "Detected an Infracost API Token, risking unauthorized access to cloud cost estimation tools and financial data."
-regex = '''\b(ico-[a-zA-Z0-9]{32})(?:[`'"\s;]|$)'''
+regex = '''\b(ico-[a-zA-Z0-9]{32})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["ico-"]
 
 [[rules]]
 id = "intercom-api-key"
 description = "Identified an Intercom API Token, which could compromise customer communication channels and data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:intercom)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9=_\-]{60})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:intercom)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9=_\-]{60})(?:[\x60'"\s;]|$)'''
 keywords = ["intercom"]
 
 [[rules]]
 id = "intra42-client-secret"
 description = "Found a Intra42 client secret, which could lead to unauthorized access to the 42School API and sensitive data."
-regex = '''\b(s-s4t2(?:ud|af)-(?i)[abcdef0123456789]{64})(?:[`'"\s;]|$)'''
+regex = '''\b(s-s4t2(?:ud|af)-(?i)[abcdef0123456789]{64})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = [
     "intra",
@@ -2317,7 +2317,7 @@ keywords = [
 [[rules]]
 id = "jfrog-api-key"
 description = "Found a JFrog API Key, posing a risk of unauthorized access to software artifact repositories and build pipelines."
-regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{73})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{73})(?:[\x60'"\s;]|$)'''
 keywords = [
     "jfrog",
     "artifactory",
@@ -2328,7 +2328,7 @@ keywords = [
 [[rules]]
 id = "jfrog-identity-token"
 description = "Discovered a JFrog Identity Token, potentially compromising access to JFrog services and sensitive software artifacts."
-regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{64})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:jfrog|artifactory|bintray|xray)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{64})(?:[\x60'"\s;]|$)'''
 keywords = [
     "jfrog",
     "artifactory",
@@ -2339,7 +2339,7 @@ keywords = [
 [[rules]]
 id = "jwt"
 description = "Uncovered a JSON Web Token, which may lead to unauthorized access to web applications and sensitive user data."
-regex = '''\b(ey[a-zA-Z0-9]{17,}\.ey[a-zA-Z0-9\/\\_-]{17,}\.(?:[a-zA-Z0-9\/\\_-]{10,}={0,2})?)(?:[`'"\s;]|$)'''
+regex = '''\b(ey[a-zA-Z0-9]{17,}\.ey[a-zA-Z0-9\/\\_-]{17,}\.(?:[a-zA-Z0-9\/\\_-]{10,}={0,2})?)(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["ey"]
 
@@ -2353,7 +2353,7 @@ keywords = ["zxlk"]
 [[rules]]
 id = "kraken-access-token"
 description = "Identified a Kraken Access Token, potentially compromising cryptocurrency trading accounts and financial security."
-regex = '''(?i)[\w.-]{0,50}?(?:kraken)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9\/=_\+\-]{80,90})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kraken)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9\/=_\+\-]{80,90})(?:[\x60'"\s;]|$)'''
 keywords = ["kraken"]
 
 [[rules]]
@@ -2375,19 +2375,19 @@ regexes = [
 [[rules]]
 id = "kucoin-access-token"
 description = "Found a Kucoin Access Token, risking unauthorized access to cryptocurrency exchange services and transactions."
-regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-f0-9]{24})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-f0-9]{24})(?:[\x60'"\s;]|$)'''
 keywords = ["kucoin"]
 
 [[rules]]
 id = "kucoin-secret-key"
 description = "Discovered a Kucoin Secret Key, which could lead to compromised cryptocurrency operations and financial data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:kucoin)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\x60'"\s;]|$)'''
 keywords = ["kucoin"]
 
 [[rules]]
 id = "launchdarkly-access-token"
 description = "Uncovered a Launchdarkly Access Token, potentially compromising feature flag management and application functionality."
-regex = '''(?i)[\w.-]{0,50}?(?:launchdarkly)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9=_\-]{40})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:launchdarkly)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9=_\-]{40})(?:[\x60'"\s;]|$)'''
 keywords = ["launchdarkly"]
 
 [[rules]]
@@ -2400,14 +2400,14 @@ keywords = ["lin_api_"]
 [[rules]]
 id = "linear-client-secret"
 description = "Identified a Linear Client Secret, which may compromise secure integrations and sensitive project management data."
-regex = '''(?i)[\w.-]{0,50}?(?:linear)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-f0-9]{32})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linear)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-f0-9]{32})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = ["linear"]
 
 [[rules]]
 id = "linkedin-client-id"
 description = "Found a LinkedIn Client ID, risking unauthorized access to LinkedIn integrations and professional data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{14})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{14})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = [
     "linkedin",
@@ -2418,7 +2418,7 @@ keywords = [
 [[rules]]
 id = "linkedin-client-secret"
 description = "Discovered a LinkedIn Client secret, potentially compromising LinkedIn application integrations and user data."
-regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{16})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:linked[_-]?in)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{16})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = [
     "linkedin",
@@ -2429,7 +2429,7 @@ keywords = [
 [[rules]]
 id = "lob-api-key"
 description = "Uncovered a Lob API Key, which could lead to unauthorized access to mailing and address verification services."
-regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}((live|test)_[a-f0-9]{35})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}((live|test)_[a-f0-9]{35})(?:[\x60'"\s;]|$)'''
 keywords = [
     "test_",
     "live_",
@@ -2438,7 +2438,7 @@ keywords = [
 [[rules]]
 id = "lob-pub-api-key"
 description = "Detected a Lob Publishable API Key, posing a risk of exposing mail and print service integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}((test|live)_pub_[a-f0-9]{31})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:lob)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}((test|live)_pub_[a-f0-9]{31})(?:[\x60'"\s;]|$)'''
 keywords = [
     "test_pub",
     "live_pub",
@@ -2448,43 +2448,43 @@ keywords = [
 [[rules]]
 id = "mailchimp-api-key"
 description = "Identified a Mailchimp API key, potentially compromising email marketing campaigns and subscriber data."
-regex = '''(?i)[\w.-]{0,50}?(?:MailchimpSDK.initialize|mailchimp)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-f0-9]{32}-us\d\d)(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:MailchimpSDK.initialize|mailchimp)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-f0-9]{32}-us\d\d)(?:[\x60'"\s;]|$)'''
 keywords = ["mailchimp"]
 
 [[rules]]
 id = "mailgun-private-api-token"
 description = "Found a Mailgun private API token, risking unauthorized email service operations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}(key-[a-f0-9]{32})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}(key-[a-f0-9]{32})(?:[\x60'"\s;]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mailgun-pub-key"
 description = "Discovered a Mailgun public validation key, which could expose email verification processes and associated data."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}(pubkey-[a-f0-9]{32})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}(pubkey-[a-f0-9]{32})(?:[\x60'"\s;]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mailgun-signing-key"
 description = "Uncovered a Mailgun webhook signing key, potentially compromising email automation and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mailgun)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})(?:[\x60'"\s;]|$)'''
 keywords = ["mailgun"]
 
 [[rules]]
 id = "mapbox-api-token"
 description = "Detected a MapBox API token, posing a risk to geospatial services and sensitive location data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:mapbox)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}(pk\.[a-z0-9]{60}\.[a-z0-9]{22})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mapbox)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}(pk\.[a-z0-9]{60}\.[a-z0-9]{22})(?:[\x60'"\s;]|$)'''
 keywords = ["mapbox"]
 
 [[rules]]
 id = "mattermost-access-token"
 description = "Identified a Mattermost Access Token, which may compromise team communication channels and data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:mattermost)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{26})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:mattermost)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{26})(?:[\x60'"\s;]|$)'''
 keywords = ["mattermost"]
 
 [[rules]]
 id = "messagebird-api-token"
 description = "Found a MessageBird API token, risking unauthorized access to communication platforms and message data."
-regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{25})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{25})(?:[\x60'"\s;]|$)'''
 keywords = [
     "messagebird",
     "message-bird",
@@ -2494,7 +2494,7 @@ keywords = [
 [[rules]]
 id = "messagebird-client-id"
 description = "Discovered a MessageBird client ID, potentially compromising API integrations and sensitive communication data."
-regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:message[_-]?bird)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\x60'"\s;]|$)'''
 keywords = [
     "messagebird",
     "message-bird",
@@ -2514,25 +2514,25 @@ keywords = [
 [[rules]]
 id = "netlify-access-token"
 description = "Detected a Netlify Access Token, potentially compromising web hosting services and site management."
-regex = '''(?i)[\w.-]{0,50}?(?:netlify)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9=_\-]{40,46})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:netlify)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9=_\-]{40,46})(?:[\x60'"\s;]|$)'''
 keywords = ["netlify"]
 
 [[rules]]
 id = "new-relic-browser-api-token"
 description = "Identified a New Relic ingest browser API token, risking unauthorized access to application performance data and analytics."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}(NRJS-[a-f0-9]{19})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}(NRJS-[a-f0-9]{19})(?:[\x60'"\s;]|$)'''
 keywords = ["nrjs-"]
 
 [[rules]]
 id = "new-relic-insert-key"
 description = "Discovered a New Relic insight insert key, compromising data injection into the platform."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}(NRII-[a-z0-9-]{32})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}(NRII-[a-z0-9-]{32})(?:[\x60'"\s;]|$)'''
 keywords = ["nrii-"]
 
 [[rules]]
 id = "new-relic-user-api-id"
 description = "Found a New Relic user API ID, posing a risk to application monitoring services and data integrity."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{64})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{64})(?:[\x60'"\s;]|$)'''
 keywords = [
     "new-relic",
     "newrelic",
@@ -2542,13 +2542,13 @@ keywords = [
 [[rules]]
 id = "new-relic-user-api-key"
 description = "Discovered a New Relic user API Key, which could lead to compromised application insights and performance monitoring."
-regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}(NRAK-[a-z0-9]{27})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}(NRAK-[a-z0-9]{27})(?:[\x60'"\s;]|$)'''
 keywords = ["nrak"]
 
 [[rules]]
 id = "npm-access-token"
 description = "Uncovered an npm access token, potentially compromising package management and code repository access."
-regex = '''(?i)\b(npm_[a-z0-9]{36})(?:[`'"\s;]|$)'''
+regex = '''(?i)\b(npm_[a-z0-9]{36})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = ["npm_"]
 
@@ -2569,7 +2569,7 @@ regexes = [
 [[rules]]
 id = "nytimes-access-token"
 description = "Detected a Nytimes Access Token, risking unauthorized access to New York Times APIs and content services."
-regex = '''(?i)[\w.-]{0,50}?(?:nytimes|new-york-times,|newyorktimes)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9=_\-]{32})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:nytimes|new-york-times,|newyorktimes)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9=_\-]{32})(?:[\x60'"\s;]|$)'''
 keywords = [
     "nytimes",
     "new-york-times",
@@ -2579,21 +2579,21 @@ keywords = [
 [[rules]]
 id = "octopus-deploy-api-key"
 description = "Discovered a potential Octopus Deploy API key, risking application deployments and operational security."
-regex = '''\b(API-[A-Z0-9]{26})(?:[`'"\s;]|$)'''
+regex = '''\b(API-[A-Z0-9]{26})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["api-"]
 
 [[rules]]
 id = "okta-access-token"
 description = "Identified an Okta Access Token, which may compromise identity management services and user authentication data."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Oo]kta|OKTA))(?:[ \t\w.-]{0,20})[\s'"|]{0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}(00[\w=\-]{40})(?:[`'"\s;]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Oo]kta|OKTA))(?:[ \t\w.-]{0,20})[\s'"|]{0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}(00[\w=\-]{40})(?:[\x60'"\s;]|$)'''
 entropy = 4
 keywords = ["okta"]
 
 [[rules]]
 id = "openai-api-key"
 description = "Found an OpenAI API Key, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''\b(sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:[`'"\s;]|$)'''
+regex = '''\b(sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["t3blbkfj"]
 
@@ -2607,55 +2607,55 @@ keywords = ["sha256~"]
 [[rules]]
 id = "plaid-api-token"
 description = "Discovered a Plaid API Token, potentially compromising financial data aggregation and banking services."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\x60'"\s;]|$)'''
 keywords = ["plaid"]
 
 [[rules]]
 id = "plaid-client-id"
 description = "Uncovered a Plaid Client ID, which could lead to unauthorized financial service integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{24})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{24})(?:[\x60'"\s;]|$)'''
 entropy = 3.5
 keywords = ["plaid"]
 
 [[rules]]
 id = "plaid-secret-key"
 description = "Detected a Plaid Secret key, risking unauthorized access to financial accounts and sensitive transaction data."
-regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{30})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{30})(?:[\x60'"\s;]|$)'''
 entropy = 3.5
 keywords = ["plaid"]
 
 [[rules]]
 id = "planetscale-api-token"
 description = "Identified a PlanetScale API token, potentially compromising database management and operations."
-regex = '''\b(pscale_tkn_(?i)[\w=\.-]{32,64})(?:[`'"\s;]|$)'''
+regex = '''\b(pscale_tkn_(?i)[\w=\.-]{32,64})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["pscale_tkn_"]
 
 [[rules]]
 id = "planetscale-oauth-token"
 description = "Found a PlanetScale OAuth token, posing a risk to database access control and sensitive data integrity."
-regex = '''\b(pscale_oauth_[\w=\.-]{32,64})(?:[`'"\s;]|$)'''
+regex = '''\b(pscale_oauth_[\w=\.-]{32,64})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["pscale_oauth_"]
 
 [[rules]]
 id = "planetscale-password"
 description = "Discovered a PlanetScale password, which could lead to unauthorized database operations and data breaches."
-regex = '''(?i)\b(pscale_pw_(?i)[\w=\.-]{32,64})(?:[`'"\s;]|$)'''
+regex = '''(?i)\b(pscale_pw_(?i)[\w=\.-]{32,64})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["pscale_pw_"]
 
 [[rules]]
 id = "postman-api-token"
 description = "Uncovered a Postman API token, potentially compromising API testing and development workflows."
-regex = '''\b(PMAK-(?i)[a-f0-9]{24}\-[a-f0-9]{34})(?:[`'"\s;]|$)'''
+regex = '''\b(PMAK-(?i)[a-f0-9]{24}\-[a-f0-9]{34})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["pmak-"]
 
 [[rules]]
 id = "prefect-api-token"
 description = "Detected a Prefect API token, risking unauthorized access to workflow management and automation services."
-regex = '''\b(pnu_[a-zA-Z0-9]{36})(?:[`'"\s;]|$)'''
+regex = '''\b(pnu_[a-zA-Z0-9]{36})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = ["pnu_"]
 
@@ -2668,7 +2668,7 @@ keywords = ["-----begin"]
 [[rules]]
 id = "privateai-api-token"
 description = "Identified a PrivateAI Token, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:private[_-]?ai)(?:[ \t\w.-]{0,20})[\s'"|]{0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{32})(?:[`'"\s;]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:private[_-]?ai)(?:[ \t\w.-]{0,20})[\s'"|]{0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{32})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = [
     "privateai",
@@ -2679,7 +2679,7 @@ keywords = [
 [[rules]]
 id = "pulumi-api-token"
 description = "Found a Pulumi API token, posing a risk to infrastructure as code services and cloud resource management."
-regex = '''\b(pul-[a-f0-9]{40})(?:[`'"\s;]|$)'''
+regex = '''\b(pul-[a-f0-9]{40})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = ["pul-"]
 
@@ -2693,60 +2693,60 @@ keywords = ["pypi-ageichlwas5vcmc"]
 [[rules]]
 id = "rapidapi-access-token"
 description = "Uncovered a RapidAPI Access Token, which could lead to unauthorized access to various APIs and data services."
-regex = '''(?i)[\w.-]{0,50}?(?:rapidapi)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9_-]{50})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:rapidapi)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9_-]{50})(?:[\x60'"\s;]|$)'''
 keywords = ["rapidapi"]
 
 [[rules]]
 id = "readme-api-token"
 description = "Detected a Readme API token, risking unauthorized documentation management and content exposure."
-regex = '''\b(rdme_[a-z0-9]{70})(?:[`'"\s;]|$)'''
+regex = '''\b(rdme_[a-z0-9]{70})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = ["rdme_"]
 
 [[rules]]
 id = "rubygems-api-token"
 description = "Identified a Rubygem API token, potentially compromising Ruby library distribution and package management."
-regex = '''\b(rubygems_[a-f0-9]{48})(?:[`'"\s;]|$)'''
+regex = '''\b(rubygems_[a-f0-9]{48})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = ["rubygems_"]
 
 [[rules]]
 id = "scalingo-api-token"
 description = "Found a Scalingo API token, posing a risk to cloud platform services and application deployment security."
-regex = '''\b(tk-us-[\w-]{48})(?:[`'"\s;]|$)'''
+regex = '''\b(tk-us-[\w-]{48})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = ["tk-us-"]
 
 [[rules]]
 id = "sendbird-access-id"
 description = "Discovered a Sendbird Access ID, which could compromise chat and messaging platform integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\x60'"\s;]|$)'''
 keywords = ["sendbird"]
 
 [[rules]]
 id = "sendbird-access-token"
 description = "Uncovered a Sendbird Access Token, potentially risking unauthorized access to communication services and user data."
-regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-f0-9]{40})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sendbird)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-f0-9]{40})(?:[\x60'"\s;]|$)'''
 keywords = ["sendbird"]
 
 [[rules]]
 id = "sendgrid-api-token"
 description = "Detected a SendGrid API token, posing a risk of unauthorized email service operations and data exposure."
-regex = '''\b(SG\.(?i)[a-z0-9=_\-\.]{66})(?:[`'"\s;]|$)'''
+regex = '''\b(SG\.(?i)[a-z0-9=_\-\.]{66})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = ["sg."]
 
 [[rules]]
 id = "sendinblue-api-token"
 description = "Identified a Sendinblue API token, which may compromise email marketing services and subscriber data privacy."
-regex = '''\b(xkeysib-[a-f0-9]{64}\-(?i)[a-z0-9]{16})(?:[`'"\s;]|$)'''
+regex = '''\b(xkeysib-[a-f0-9]{64}\-(?i)[a-z0-9]{16})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = ["xkeysib-"]
 
 [[rules]]
 id = "sentry-access-token"
 description = "Found a Sentry.io Access Token (old format), risking unauthorized access to error tracking services and sensitive application data."
-regex = '''(?i)[\w.-]{0,50}?(?:sentry)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-f0-9]{64})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sentry)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-f0-9]{64})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["sentry"]
 
@@ -2760,35 +2760,35 @@ keywords = ["sntrys_eyjpyxqio"]
 [[rules]]
 id = "sentry-user-token"
 description = "Found a Sentry.io User Token, risking unauthorized access to error tracking services and sensitive application data."
-regex = '''\b(sntryu_[a-f0-9]{64})(?:[`'"\s;]|$)'''
+regex = '''\b(sntryu_[a-f0-9]{64})(?:[\x60'"\s;]|$)'''
 entropy = 3.5
 keywords = ["sntryu_"]
 
 [[rules]]
 id = "settlemint-application-access-token"
 description = "Found a Settlemint Application Access Token."
-regex = '''\b(sm_aat_[a-zA-Z0-9]{16})(?:[`'"\s;]|$)'''
+regex = '''\b(sm_aat_[a-zA-Z0-9]{16})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["sm_aat"]
 
 [[rules]]
 id = "settlemint-personal-access-token"
 description = "Found a Settlemint Personal Access Token."
-regex = '''\b(sm_pat_[a-zA-Z0-9]{16})(?:[`'"\s;]|$)'''
+regex = '''\b(sm_pat_[a-zA-Z0-9]{16})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["sm_pat"]
 
 [[rules]]
 id = "settlemint-service-access-token"
 description = "Found a Settlemint Service Access Token."
-regex = '''\b(sm_sat_[a-zA-Z0-9]{16})(?:[`'"\s;]|$)'''
+regex = '''\b(sm_sat_[a-zA-Z0-9]{16})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["sm_sat"]
 
 [[rules]]
 id = "shippo-api-token"
 description = "Discovered a Shippo API token, potentially compromising shipping services and customer order data."
-regex = '''\b(shippo_(?:live|test)_[a-fA-F0-9]{40})(?:[`'"\s;]|$)'''
+regex = '''\b(shippo_(?:live|test)_[a-fA-F0-9]{40})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = ["shippo_"]
 
@@ -2823,7 +2823,7 @@ keywords = ["shpss_"]
 [[rules]]
 id = "sidekiq-secret"
 description = "Discovered a Sidekiq Secret, which could lead to compromised background job processing and application data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:BUNDLE_ENTERPRISE__CONTRIBSYS__COM|BUNDLE_GEMS__CONTRIBSYS__COM)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-f0-9]{8}:[a-f0-9]{8})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:BUNDLE_ENTERPRISE__CONTRIBSYS__COM|BUNDLE_GEMS__CONTRIBSYS__COM)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-f0-9]{8}:[a-f0-9]{8})(?:[\x60'"\s;]|$)'''
 keywords = [
     "bundle_enterprise__contribsys__com",
     "bundle_gems__contribsys__com",
@@ -2915,13 +2915,13 @@ keywords = ["hooks.slack.com"]
 [[rules]]
 id = "snyk-api-token"
 description = "Uncovered a Snyk API token, potentially compromising software vulnerability scanning and code security."
-regex = '''(?i)[\w.-]{0,50}?(?:snyk[_.-]?(?:(?:api|oauth)[_.-]?)?(?:key|token))(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:snyk[_.-]?(?:(?:api|oauth)[_.-]?)?(?:key|token))(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\x60'"\s;]|$)'''
 keywords = ["snyk"]
 
 [[rules]]
 id = "square-access-token"
 description = "Detected a Square Access Token, risking unauthorized payment processing and financial transaction exposure."
-regex = '''\b((?:EAAA|sq0atp-)[\w-]{22,60})(?:[`'"\s;]|$)'''
+regex = '''\b((?:EAAA|sq0atp-)[\w-]{22,60})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = [
     "sq0atp-",
@@ -2931,13 +2931,13 @@ keywords = [
 [[rules]]
 id = "squarespace-access-token"
 description = "Identified a Squarespace Access Token, which may compromise website management and content control on Squarespace."
-regex = '''(?i)[\w.-]{0,50}?(?:squarespace)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:squarespace)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\x60'"\s;]|$)'''
 keywords = ["squarespace"]
 
 [[rules]]
 id = "stripe-access-token"
 description = "Found a Stripe Access Token, posing a risk to payment processing services and sensitive financial data."
-regex = '''\b((?:sk|rk)_(?:test|live|prod)_[a-zA-Z0-9]{10,99})(?:[`'"\s;]|$)'''
+regex = '''\b((?:sk|rk)_(?:test|live|prod)_[a-zA-Z0-9]{10,99})(?:[\x60'"\s;]|$)'''
 entropy = 2
 keywords = [
     "sk_test",
@@ -2951,27 +2951,27 @@ keywords = [
 [[rules]]
 id = "sumologic-access-id"
 description = "Discovered a SumoLogic Access ID, potentially compromising log management services and data analytics integrity."
-regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[ \t\w.-]{0,20})[\s'"|]{0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}(su[a-zA-Z0-9]{12})(?:[`'"\s;]|$)'''
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[ \t\w.-]{0,20})[\s'"|]{0,3})(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}(su[a-zA-Z0-9]{12})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["sumo"]
 
 [[rules]]
 id = "sumologic-access-token"
 description = "Uncovered a SumoLogic Access Token, which could lead to unauthorized access to log data and analytics insights."
-regex = '''(?i)[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{64})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:(?-i:[Ss]umo|SUMO))(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{64})(?:[\x60'"\s;]|$)'''
 entropy = 3
 keywords = ["sumo"]
 
 [[rules]]
 id = "telegram-bot-api-token"
 description = "Detected a Telegram Bot API Token, risking unauthorized bot operations and message interception on Telegram."
-regex = '''(?i)[\w.-]{0,50}?(?:telegr)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([0-9]{5,16}:(?-i:A)[a-z0-9_\-]{34})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:telegr)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([0-9]{5,16}:(?-i:A)[a-z0-9_\-]{34})(?:[\x60'"\s;]|$)'''
 keywords = ["telegr"]
 
 [[rules]]
 id = "travisci-access-token"
 description = "Identified a Travis CI Access Token, potentially compromising continuous integration services and codebase security."
-regex = '''(?i)[\w.-]{0,50}?(?:travis)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{22})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:travis)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{22})(?:[\x60'"\s;]|$)'''
 keywords = ["travis"]
 
 [[rules]]
@@ -2984,56 +2984,56 @@ keywords = ["sk"]
 [[rules]]
 id = "twitch-api-token"
 description = "Discovered a Twitch API token, which could compromise streaming services and account integrations."
-regex = '''(?i)[\w.-]{0,50}?(?:twitch)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{30})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitch)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{30})(?:[\x60'"\s;]|$)'''
 keywords = ["twitch"]
 
 [[rules]]
 id = "twitter-access-secret"
 description = "Uncovered a Twitter Access Secret, potentially risking unauthorized Twitter integrations and data breaches."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{45})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{45})(?:[\x60'"\s;]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-access-token"
 description = "Detected a Twitter Access Token, posing a risk of unauthorized account operations and social media data exposure."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([0-9]{15,25}-[a-zA-Z0-9]{20,40})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([0-9]{15,25}-[a-zA-Z0-9]{20,40})(?:[\x60'"\s;]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-api-key"
 description = "Identified a Twitter API Key, which may compromise Twitter application integrations and user data security."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{25})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{25})(?:[\x60'"\s;]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-api-secret"
 description = "Found a Twitter API Secret, risking the security of Twitter app integrations and sensitive data access."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{50})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{50})(?:[\x60'"\s;]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "twitter-bearer-token"
 description = "Discovered a Twitter Bearer Token, potentially compromising API access and data retrieval from Twitter."
-regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}(A{22}[a-zA-Z0-9%]{80,100})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:twitter)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}(A{22}[a-zA-Z0-9%]{80,100})(?:[\x60'"\s;]|$)'''
 keywords = ["twitter"]
 
 [[rules]]
 id = "typeform-api-token"
 description = "Uncovered a Typeform API token, which could lead to unauthorized survey management and data collection."
-regex = '''(?i)[\w.-]{0,50}?(?:typeform)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}(tfp_[a-z0-9\-_\.=]{59})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:typeform)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}(tfp_[a-z0-9\-_\.=]{59})(?:[\x60'"\s;]|$)'''
 keywords = ["tfp_"]
 
 [[rules]]
 id = "vault-batch-token"
 description = "Detected a Vault Batch Token, risking unauthorized access to secret management services and sensitive data."
-regex = '''\b(hvb\.[\w-]{138,300})(?:[`'"\s;]|$)'''
+regex = '''\b(hvb\.[\w-]{138,300})(?:[\x60'"\s;]|$)'''
 entropy = 4
 keywords = ["hvb."]
 
 [[rules]]
 id = "vault-service-token"
 description = "Identified a Vault Service Token, potentially compromising infrastructure security and access to sensitive credentials."
-regex = '''\b((?:hvs\.[\w-]{90,120}|s\.(?i:[a-z0-9]{24})))(?:[`'"\s;]|$)'''
+regex = '''\b((?:hvs\.[\w-]{90,120}|s\.(?i:[a-z0-9]{24})))(?:[\x60'"\s;]|$)'''
 entropy = 3.5
 keywords = [
     "hvs.",
@@ -3047,24 +3047,24 @@ regexes = [
 [[rules]]
 id = "yandex-access-token"
 description = "Found a Yandex Access Token, posing a risk to Yandex service integrations and user data privacy."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}(t1\.[A-Z0-9a-z_-]+[=]{0,2}\.[A-Z0-9a-z_-]{86}[=]{0,2})(?:[\x60'"\s;]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "yandex-api-key"
 description = "Discovered a Yandex API Key, which could lead to unauthorized access to Yandex services and data manipulation."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}(AQVN[A-Za-z0-9_\-]{35,38})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}(AQVN[A-Za-z0-9_\-]{35,38})(?:[\x60'"\s;]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "yandex-aws-access-token"
 description = "Uncovered a Yandex AWS Access Token, potentially compromising cloud resource access and data security on Yandex Cloud."
-regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}(YC[a-zA-Z0-9_\-]{38})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:yandex)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}(YC[a-zA-Z0-9_\-]{38})(?:[\x60'"\s;]|$)'''
 keywords = ["yandex"]
 
 [[rules]]
 id = "zendesk-secret-key"
 description = "Detected a Zendesk Secret Key, risking unauthorized access to customer support services and sensitive ticketing data."
-regex = '''(?i)[\w.-]{0,50}?(?:zendesk)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[`'"\s=]{0,5}([a-z0-9]{40})(?:[`'"\s;]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:zendesk)(?:[ \t\w.-]{0,20})[\s'"|]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{40})(?:[\x60'"\s;]|$)'''
 keywords = ["zendesk"]
 


### PR DESCRIPTION
### Description:
This partially reverts #1620.

While using `\x60` isn't ideal, literal \` characters cause issues in a few places (e.g., https://regex101.com/).

![image](https://github.com/user-attachments/assets/ddd06a93-a682-43cb-b3cb-731af8aaed46)
![image](https://github.com/user-attachments/assets/a6a07892-8e46-4b0b-84cd-10e594cabbec)
![image](https://github.com/user-attachments/assets/1aea5f11-9910-4d0d-bab0-e9465b235807)


### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
