### PR TITLE
Run CI on Windows as well?

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,17 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ ubuntu-latest, windows-latest ]
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
 
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.22
+          go-version: 1.23
 
       - name: Build
         run: go build -v ./...
@@ -25,5 +28,7 @@ jobs:
       - name: Test
         run: make test
 
+      # Don't run for Windows, it will fail due to CRLF.
       - name: Validate Config
+        if: ${{ matrix.platform == 'ubuntu-latest' }}
         run: go generate ./... && git diff --exit-code


### PR DESCRIPTION
### Description:
Windows seems to be a blindspot. Including a windows runner in the `test` phase will help surface discrepancies and bugs.

Potential con: Windows runners are more expensive than Linux ones[[1]].

[1]: https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions#per-minute-rates-for-standard-runners

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
