### PR TITLE
Don't exit with error if git repacking is required

### DIFF
--- a/sources/git.go
+++ b/sources/git.go
@@ -158,6 +158,9 @@ func listenForStdErr(stderr io.ReadCloser, errCh chan<- error) {
 		//  you may want to set your diff.renameLimit variable to at least
 		//  (some large number) and retry the command.
 		//
+		//  Auto packing the repository in background for optimum performance.
+		//  See "git help gc" for manual housekeeping.
+		//
 		// we skip exiting the program as git log -p/git diff will continue
 		// to send data to stdout and finish executing. This next bit of
 		// code prevents gitleaks from stopping mid scan if this error is
@@ -167,7 +170,11 @@ func listenForStdErr(stderr io.ReadCloser, errCh chan<- error) {
 			strings.Contains(scanner.Text(),
 				"inexact rename detection was skipped") ||
 			strings.Contains(scanner.Text(),
-				"you may want to set your diff.renameLimit") {
+				"you may want to set your diff.renameLimit") ||
+			strings.Contains(scanner.Text(),
+				"See \"git help gc\" for manual housekeeping") ||
+			strings.Contains(scanner.Text(),
+				"Auto packing the repository in background for optimum performance") {
 			logging.Warn().Msg(scanner.Text())
 		} else {
 			logging.Error().Msgf("[git] %s", scanner.Text())


### PR DESCRIPTION
### Description:
Repacking writes a message to stderr but is not problematic. It is required quite often when using shallow/treeless clones, which is common in CI/CD environments. Fixes #1168.

I did not add tests as the tests file is commented out (?)

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
