### PR TITLE
Remove .git suffix for links

### DIFF
--- a/detect/git.go
+++ b/detect/git.go
@@ -145,10 +145,9 @@ func getRemoteUrl(source string) (*url.URL, error) {
 
 	remoteUrl := string(bytes.TrimSpace(stdout))
 	if matches := sshUrlpat.FindStringSubmatch(remoteUrl); matches != nil {
-		host := matches[1]
-		repo := strings.TrimSuffix(matches[2], ".git")
-		remoteUrl = fmt.Sprintf("https://%s/%s", host, repo)
+		remoteUrl = fmt.Sprintf("https://%s/%s", matches[1], matches[2])
 	}
+	remoteUrl = strings.TrimSuffix(remoteUrl, ".git")
 
 	parsedUrl, err := url.Parse(remoteUrl)
 	if err != nil {


### PR DESCRIPTION
### Description:
Repositories can be cloned with a `.git` suffix; this is what is provided by GitHub by default.

```
https://github.com/gitleaks/gitleaks.git
git@github.com:gitleaks/gitleaks.git
```

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
