### PR TITLE
Add rule for .p12 files

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -172,6 +172,7 @@ func main() {
 		rules.Prefect(),
 		rules.PrivateAIToken(),
 		rules.PrivateKey(),
+		rules.PrivateKeyPKCS12File(),
 		rules.PulumiAPIToken(),
 		rules.PyPiUploadToken(),
 		rules.RapidAPIAccessToken(),

--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -29,7 +29,8 @@ paths = [{{ range $i, $path := . }}
 {{- range $i, $rule := .Rules }}{{println}}[[rules]]
 id = "{{$rule.RuleID}}"
 description = "{{$rule.Description}}"
-regex = '''{{$rule.Regex}}'''
+{{- with $rule.Regex }}
+regex = '''{{ . }}'''{{ end -}}
 {{- with $rule.Path }}
 path = '''{{ . }}'''{{ end -}}
 {{- with $rule.SecretGroup }}

--- a/cmd/generate/config/rules/privatekey.go
+++ b/cmd/generate/config/rules/privatekey.go
@@ -9,8 +9,8 @@ import (
 func PrivateKey() *config.Rule {
 	// define rule
 	r := config.Rule{
-		Description: "Identified a Private Key, which may compromise cryptographic security and sensitive data encryption.",
 		RuleID:      "private-key",
+		Description: "Identified a Private Key, which may compromise cryptographic security and sensitive data encryption.",
 		Regex:       regexp.MustCompile(`(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY(?: BLOCK)?-----[\s\S-]*?KEY(?: BLOCK)?-----`),
 		Keywords:    []string{"-----BEGIN"},
 	}
@@ -28,4 +28,25 @@ anything
 -----END PRIVATE KEY BLOCK-----`,
 	} // gitleaks:allow
 	return utils.Validate(r, tps, nil)
+}
+
+func PrivateKeyPKCS12File() *config.Rule {
+	// https://en.wikipedia.org/wiki/PKCS_12
+	r := config.Rule{
+		RuleID:      "pkcs12-file",
+		Description: "Found a PKCS #12 file, which commonly contain bundled private keys.",
+		Path:        regexp.MustCompile(`(?i)(?:^|\/)[^\/]+\.p(?:12|fx)$`),
+	}
+
+	// validate
+	tps := map[string]string{
+		"security/es_certificates/opensearch/es_kibana_client.p12": "",
+		"cagw_key.P12": "",
+		"ToDo/ToDo.UWP/ToDo.UWP_TemporaryKey.pfx": "",
+	}
+	fps := map[string]string{
+		"doc/typenum/type.P126.html":         "",
+		"scripts/keeneland/syntest.p1200.sh": "",
+	}
+	return utils.ValidateWithPaths(r, tps, fps)
 }

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2621,6 +2621,11 @@ entropy = 3.5
 keywords = ["sha256~"]
 
 [[rules]]
+id = "pkcs12-file"
+description = "Found a PKCS #12 file, which commonly contain bundled private keys."
+path = '''(?i)(?:^|\/)[^\/]+\.p(?:12|fx)$'''
+
+[[rules]]
 id = "plaid-api-token"
 description = "Discovered a Plaid API Token, potentially compromising financial data aggregation and banking services."
 regex = '''(?i)[\w.-]{0,50}?(?:plaid)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}(access-(?:sandbox|development|production)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:[\x60'"\s;]|\\[nr]|$)'''


### PR DESCRIPTION
### Description:
Detect [PKCS #12 files](https://en.wikipedia.org/wiki/PKCS_12), which commonly contain private keys.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
