### PR TITLE
add deno.lock to default exclusions

### DIFF
--- a/cmd/generate/config/base/config.go
+++ b/cmd/generate/config/base/config.go
@@ -77,7 +77,7 @@ func CreateGlobalConfig() config.Config {
 				// ----------- JavaScript files -----------
 				// Dependencies and lock files.
 				regexp.MustCompile(`(?:^|/)node_modules(?:/.*)?$`),
-				regexp.MustCompile(`(?:^|/)(?:npm-shrinkwrap\.json|package-lock\.json|pnpm-lock\.yaml|yarn\.lock)$`),
+				regexp.MustCompile(`(?:^|/)(?:deno\.lock|npm-shrinkwrap\.json|package-lock\.json|pnpm-lock\.yaml|yarn\.lock)$`),
 				regexp.MustCompile(`(?:^|/)bower_components(?:/.*)?$`),
 				// TODO: Add more common static assets, such as swagger-ui.
 				regexp.MustCompile(`(?:^|/)(?:angular|bootstrap|jquery(?:-?ui)?|plotly|swagger-?ui)[a-zA-Z0-9.-]*(?:\.min)?\.js(?:\.map)?$`),

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -38,7 +38,7 @@ paths = [
     '''(?:^|/)mvnw(?:\.cmd)?$''',
     '''(?:^|/)\.mvn/wrapper/MavenWrapperDownloader\.java$''',
     '''(?:^|/)node_modules(?:/.*)?$''',
-    '''(?:^|/)(?:npm-shrinkwrap\.json|package-lock\.json|pnpm-lock\.yaml|yarn\.lock)$''',
+    '''(?:^|/)(?:deno\.lock|npm-shrinkwrap\.json|package-lock\.json|pnpm-lock\.yaml|yarn\.lock)$''',
     '''(?:^|/)bower_components(?:/.*)?$''',
     '''(?:^|/)(?:angular|bootstrap|jquery(?:-?ui)?|plotly|swagger-?ui)[a-zA-Z0-9.-]*(?:\.min)?\.js(?:\.map)?$''',
     '''(?:^|/)javascript\.json$''',


### PR DESCRIPTION
### Description:
https://deno.com/ is the successor of node.js

Since package-lock.json is excluded by default, the deno.lock file should be excluded by default as well.

Multiple package checksums are detected as generic-api-key.

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
