### PR TITLE
Add database password rule

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -56,6 +56,7 @@ func main() {
 		rules.Contentful(),
 		rules.CurlHeaderAuth(),
 		rules.CurlBasicAuth(),
+		rules.DatabaseCredentials(),
 		rules.Databricks(),
 		rules.DatadogtokenAccessToken(),
 		rules.DefinedNetworkingAPIToken(),

--- a/cmd/generate/config/rules/database.go
+++ b/cmd/generate/config/rules/database.go
@@ -1,0 +1,38 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+func DatabaseCredentials() *config.Rule {
+	// define rule
+	r := config.Rule{
+		Description: "Discovered a possible database credentials.",
+		RuleID:      "database-password",
+		Regex: utils.GenerateSemiGenericRegex([]string{
+			"db_passw(?:or)?d",
+			"database_passw(?:or)?d",
+			"pwd",
+		}, `[a-zA-Z0-9:;<@=},!$?^]{1,100}`, false),
+	}
+
+	// validate
+	tps := utils.GenerateSampleSecrets("DB_PASSWORD", secrets.NewSecret(`[a-zA-Z0-9:;<@=},!$?^]{20}`))
+	tps = append(tps, utils.GenerateSampleSecrets("db_password", secrets.NewSecret(`[a-zA-Z0-9:;<@=},!$?^]{6}`))...)
+	tps = append(tps, utils.GenerateSampleSecrets("DB_PASSWD", secrets.NewSecret(`[a-zA-Z0-9:;<@=},!$?^]{10}`))...)
+	tps = append(tps, utils.GenerateSampleSecrets("$DB_PASSWD", secrets.NewSecret(`[a-zA-Z0-9:;<@=},!$?^]{15}`))...)
+	tps = append(tps, utils.GenerateSampleSecrets("$DB_PASSWORD", secrets.NewSecret(`[a-zA-Z0-9:;<@=},!$?^]{50}`))...)
+	tps = append(tps,
+		`pwd = `+secrets.NewSecret(`[a-zA-Z0-9:;<@=},!$?^]{20}`),
+		`pwd: `+secrets.NewSecret(`[a-zA-Z0-9:;<@=},!$?^]{50}`),
+	)
+
+	fps := []string{
+		// readme values
+		"DB_PASSWORD=[value]",
+		"somepwd=XXXXXXXXXXXXXXX",
+	}
+	return utils.Validate(r, tps, fps)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -307,6 +307,11 @@ regexes = [
 ]
 
 [[rules]]
+id = "database-password"
+description = "Discovered a possible database credentials."
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:db_passw(?:or)?d|database_passw(?:or)?d|pwd)(?:[ \t\w.-]{0,20})[\s'"]{0,3})(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([a-zA-Z0-9:;<@=},!$?^]{1,100})(?:[\x60'"\s;]|\\[nr]|$)'''
+
+[[rules]]
 id = "databricks-api-token"
 description = "Uncovered a Databricks API token, which may compromise big data analytics platforms and sensitive data processing."
 regex = '''\b(dapi[a-f0-9]{32}(?:-\d)?)(?:[\x60'"\s;]|\\[nr]|$)'''

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -468,6 +468,52 @@ func TestDetect(t *testing.T) {
 				},
 			},
 		},
+		{
+			cfgName: "database",
+			fragment: Fragment{
+				Raw:      `$DB_PASSWORD=12X?249x$@123`,
+				FilePath: "tmp.env",
+			},
+			expectedFindings: []report.Finding{
+				{
+					Description: "Discovered a possible database credentials.",
+					Match:       "DB_PASSWORD=12X?249x$@123",
+					Secret:      "12X?249x$@123",
+					File:        "tmp.env",
+					Line:        "$DB_PASSWORD=12X?249x$@123",
+					RuleID:      "database-password",
+					Tags:        []string{},
+					Entropy:     3.180833,
+					StartLine:   0,
+					EndLine:     0,
+					StartColumn: 2,
+					EndColumn:   26,
+				},
+			},
+		},
+		{
+			cfgName: "database",
+			fragment: Fragment{
+				Raw:      `pwd: ?:123@@;:asdASD`,
+				FilePath: "tmp.md",
+			},
+			expectedFindings: []report.Finding{
+				{
+					Description: "Discovered a possible database credentials.",
+					Match:       "pwd: ?:123@@;:asdASD",
+					Secret:      "?:123@@;:asdASD",
+					File:        "tmp.md",
+					Line:        "pwd: ?:123@@;:asdASD",
+					RuleID:      "database-password",
+					Tags:        []string{},
+					Entropy:     3.640224,
+					StartLine:   0,
+					EndLine:     0,
+					StartColumn: 1,
+					EndColumn:   20,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/testdata/config/database.toml
+++ b/testdata/config/database.toml
@@ -1,0 +1,6 @@
+title = "gitleaks config"
+
+[[rules]]
+id = "database-password"
+description = "Discovered a possible database credentials."
+regex = '''[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:db_passw(?:or)?d|database_passw(?:or)?d|pwd)(?:[ \t\w.-]{0,20})[\s'"]{0,3})(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([a-zA-Z0-9:;<@=},!$?^]{1,100})(?:[\x60'"\s;]|\\[nr]|$)'''


### PR DESCRIPTION
### Description:
When doing checks in config files or workflows - there were multiple situations where the database passwords outside of connection strings were omitted during checking.
Examples would be: `DB_PASSWORD`, `DB_PASSWD`, `pwd` etc.

This adds handling of them, in various configurations and variations. There are also added unit tests for confirmation

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
