### PR TITLE
Fix `platform` flag being ignored with `gitleaks detect`

### DIFF
--- a/cmd/detect.go
+++ b/cmd/detect.go
@@ -99,7 +99,7 @@ func runDetect(cmd *cobra.Command, args []string) {
 			logOpts     = mustGetStringFlag(cmd, "log-opts")
 			gitCmd      *sources.GitCmd
 			scmPlatform scm.Platform
-			remote      = detect.NewRemoteInfo(scmPlatform, source)
+			remote      *detect.RemoteInfo
 		)
 		if gitCmd, err = sources.NewGitLogCmd(source, logOpts); err != nil {
 			logging.Fatal().Err(err).Msg("could not create Git cmd")
@@ -107,6 +107,7 @@ func runDetect(cmd *cobra.Command, args []string) {
 		if scmPlatform, err = scm.PlatformFromString(mustGetStringFlag(cmd, "platform")); err != nil {
 			logging.Fatal().Err(err).Send()
 		}
+		remote = detect.NewRemoteInfo(scmPlatform, source)
 
 		if findings, err = detector.DetectGit(gitCmd, remote); err != nil {
 			// don't exit on error, just log it


### PR DESCRIPTION
### Description:
This fixes #1764.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
