### PR TITLE
Make AddFinding public

### DIFF
--- a/detect/baseline_test.go
+++ b/detect/baseline_test.go
@@ -133,7 +133,7 @@ func TestIgnoreIssuesInBaseline(t *testing.T) {
 		require.NoError(t, err)
 		d.baseline = test.baseline
 		for _, finding := range test.findings {
-			d.addFinding(finding)
+			d.AddFinding(finding)
 		}
 		assert.Len(t, d.findings, test.expectCount)
 	}

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -568,8 +568,8 @@ func allTrue(bools []bool) bool {
 	return allMatch
 }
 
-// addFinding synchronously adds a finding to the findings slice
-func (d *Detector) addFinding(finding report.Finding) {
+// AddFinding synchronously adds a finding to the findings slice
+func (d *Detector) AddFinding(finding report.Finding) {
 	globalFingerprint := fmt.Sprintf("%s:%s:%d", finding.File, finding.RuleID, finding.StartLine)
 	if finding.Commit != "" {
 		finding.Fingerprint = fmt.Sprintf("%s:%s:%s:%d", finding.Commit, finding.File, finding.RuleID, finding.StartLine)
@@ -609,7 +609,12 @@ func (d *Detector) addFinding(finding report.Finding) {
 	d.findingMutex.Unlock()
 }
 
-// addCommit synchronously adds a commit to the commit slice
+// Findings returns the findings added to the detector
+func (d *Detector) Findings() []report.Finding {
+	return d.findings
+}
+
+// AddCommit synchronously adds a commit to the commit slice
 func (d *Detector) addCommit(commit string) {
 	d.commitMap[commit] = true
 }

--- a/detect/directory.go
+++ b/detect/directory.go
@@ -102,7 +102,7 @@ func (d *Detector) DetectFiles(paths <-chan sources.ScanTarget) ([]report.Findin
 						// need to add 1 since line counting starts at 1
 						finding.StartLine += (totalLines - linesInChunk) + 1
 						finding.EndLine += (totalLines - linesInChunk) + 1
-						d.addFinding(finding)
+						d.AddFinding(finding)
 					}
 				}
 

--- a/detect/git.go
+++ b/detect/git.go
@@ -62,7 +62,7 @@ func (d *Detector) DetectGit(cmd *sources.GitCmd, remote *RemoteInfo) ([]report.
 					}
 
 					for _, finding := range d.Detect(fragment) {
-						d.addFinding(augmentGitFinding(remote, finding, textFragment, gitdiffFile))
+						d.AddFinding(augmentGitFinding(remote, finding, textFragment, gitdiffFile))
 					}
 				}
 				return nil


### PR DESCRIPTION
### Description:

To allow other tools using d.Detect() to leverage the code in AddFinding

Changes:

- Rename d.addFinding -> d.AddFinding
- Add d.Findings()

My use case: https://github.com/leaktk/scanner/pull/107/files#diff-f8472fe0bafccc33f268c74d1bd2a697594914d4e1d796805b254249cbc78828R175-R182

### Checklist:

* [x] Does your PR pass tests?
* [ ] ~Have you written new tests for your changes?~ (N/A)
* [x] Have you lint your code locally prior to submission?

cc: @zricethezav && @rgmz 
