### PR TITLE
Infer `report-format` from `report-path` extension if no value is provided

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("config", "c", "", configDescription)
 	rootCmd.PersistentFlags().Int("exit-code", 1, "exit code when leaks have been encountered")
 	rootCmd.PersistentFlags().StringP("report-path", "r", "", "report file")
-	rootCmd.PersistentFlags().StringP("report-format", "f", "json", "output format (json, jsonextra, csv, junit, sarif, template)")
+	rootCmd.PersistentFlags().StringP("report-format", "f", "", "output format (json, csv, junit, sarif, template)")
 	rootCmd.PersistentFlags().StringP("report-template", "", "", "template file used to generate the report (implies --report-format=template)")
 	rootCmd.PersistentFlags().StringP("baseline-path", "b", "", "path to baseline with issues that can be ignored")
 	rootCmd.PersistentFlags().StringP("log-level", "l", "info", "log level (trace, debug, info, warn, error, fatal)")
@@ -297,6 +297,20 @@ func Detector(cmd *cobra.Command, cfg config.Config, source string) *detect.Dete
 			reportFormat   = mustGetStringFlag(cmd, "report-format")
 			reportTemplate = mustGetStringFlag(cmd, "report-template")
 		)
+		if reportFormat == "" {
+			ext := strings.ToLower(filepath.Ext(reportPath))
+			switch ext {
+			case ".csv":
+				reportFormat = "csv"
+			case ".json":
+				reportFormat = "json"
+			case ".sarif":
+				reportFormat = "sarif"
+			default:
+				logging.Fatal().Msgf("Unknown report format: %s", reportFormat)
+			}
+			logging.Debug().Msgf("No report format specified, inferred %q from %q", reportFormat, ext)
+		}
 		switch strings.TrimSpace(strings.ToLower(reportFormat)) {
 		case "csv":
 			reporter = &report.CsvReporter{}


### PR DESCRIPTION
### Description:
This fixes #1717.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
