### PR TITLE
Prevent Yocto/BitBake false positives with generic-api-key rule

### DIFF
--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -51,7 +51,7 @@ tags = [
     {{ range $j, $tag := . }}"{{ $tag }}",{{ end }}
 ]{{ end }}
 {{- with $rule.Allowlists }}{{ range $i, $allowlist := . }}{{ if or $allowlist.Regexes $allowlist.Paths $allowlist.Commits $allowlist.StopWords }}{{println}}[[rules.allowlists]]
-{{- with .MatchCondition }}{{println}}condition = "{{ .MatchCondition.String }}"{{ end }}
+{{- with .MatchCondition }}{{println}}condition = "{{ .String }}"{{ end }}
 {{- with .Commits -}}{{println}}commits = [
     {{ range $j, $commit := . }}"{{ $commit }}",{{ end }}
 ]{{ end }}

--- a/cmd/generate/config/rules/generic.go
+++ b/cmd/generate/config/rules/generic.go
@@ -100,6 +100,21 @@ func GenericCredential() *config.Rule {
 					regexp.MustCompile(`--mount=type=secret,`),
 				},
 			},
+			{
+				MatchCondition: config.AllowlistMatchAnd,
+				RegexTarget:    "line",
+				Regexes: []*regexp.Regexp{
+					regexp.MustCompile(`LICENSE[^=]*=\s*"[^"]+`),
+					regexp.MustCompile(`LIC_FILES_CHKSUM[^=]*=\s*"[^"]+`),
+					regexp.MustCompile(`SRC[^=]*=\s*"[a-zA-Z0-9]+`),
+				},
+				Paths: []*regexp.Regexp{
+					regexp.MustCompile(`\.bb$`),
+					regexp.MustCompile(`\.bbappend$`),
+					regexp.MustCompile(`\.bbclass$`),
+					regexp.MustCompile(`\.inc$`),
+				},
+			},
 		},
 	}
 
@@ -250,6 +265,10 @@ R5: Regulatory--21`,
 DYNATRACE_API_KEY=`,
 		`snowflake.password=
 jdbc.snowflake.url=`,
+
+		// Yocto/BitBake
+		`SRCREV_moby = "43fc912ef59a83054ea7f6706df4d53a7dea4d80"`,
+		`LIC_FILES_CHKSUM = "file://${WORKDIR}/license.html;md5=5c94767cedb5d6987c902ac850ded2c6"`,
 	}
 	return utils.Validate(r, tps, fps)
 }

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2077,6 +2077,17 @@ regexTarget = "line"
 regexes = [
     '''--mount=type=secret,''',
 ]
+[[rules.allowlists]]
+condition = "AND"
+paths = [
+    '''\.bb$''','''\.bbappend$''','''\.bbclass$''','''\.inc$''',
+]
+regexTarget = "line"
+regexes = [
+    '''LICENSE[^=]*=\s*"[^"]+''',
+    '''LIC_FILES_CHKSUM[^=]*=\s*"[^"]+''',
+    '''SRC[^=]*=\s*"[a-zA-Z0-9]+''',
+]
 
 [[rules]]
 id = "github-app-token"


### PR DESCRIPTION
### Description:

This PR implements exceptions to the generic-api-key rule to prevent false positives experienced with Yocto/BitBake projects as explained in #1775 

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
