### PR TITLE
A first attempt adding hooks.slack.com/triggers/

### DIFF
--- a/cmd/generate/config/rules/slack.go
+++ b/cmd/generate/config/rules/slack.go
@@ -272,7 +272,7 @@ func SlackWebHookUrl() *config.Rule {
 		Description: "Discovered a Slack Webhook, which could lead to unauthorized message posting and data leakage in Slack channels.",
 		// If this generates too many false-positives we should define an allowlist (e.g., "xxxx", "00000").
 		Regex: regexp.MustCompile(
-			`(?:https?://)?hooks.slack.com/(?:services|workflows)/[A-Za-z0-9+/]{43,46}`),
+			`(?:https?://)?hooks.slack.com/(?:services|workflows|triggers)/[A-Za-z0-9+/]{43,56}`),
 		Keywords: []string{
 			"hooks.slack.com",
 		},
@@ -290,6 +290,7 @@ func SlackWebHookUrl() *config.Rule {
 		"https://hooks.slack.com/workflows/" + secrets.NewSecret(utils.AlphaNumeric("46")),
 		"https://hooks.slack.com/workflows/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", // gitleaks:allow
 		"http://hooks.slack.com/workflows/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",    // gitleaks:allow
+		"https://hooks.slack.com/triggers/" + secrets.NewSecret(utils.AlphaNumeric("56")),
 	}
 	return utils.Validate(r, tps, nil)
 }

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2946,7 +2946,7 @@ keywords = [
 [[rules]]
 id = "slack-webhook-url"
 description = "Discovered a Slack Webhook, which could lead to unauthorized message posting and data leakage in Slack channels."
-regex = '''(?:https?://)?hooks.slack.com/(?:services|workflows)/[A-Za-z0-9+/]{43,46}'''
+regex = '''(?:https?://)?hooks.slack.com/(?:services|workflows|triggers)/[A-Za-z0-9+/]{43,56}'''
 keywords = ["hooks.slack.com"]
 
 [[rules]]


### PR DESCRIPTION
As described in issue #1791, the `https://hooks.slack.com/triggers/` secrets should perhaps also be detected.

Reference
https://slack.com/help/articles/360041352714-Build-a-workflow--Create-a-workflow-that-starts-outside-of-Slack

Feel free to use, change any part of this proposed fix, or to simply discard it.

(ps. I did a minor typo in a comment in issue 1791, proposing this change but that was corrected here. ds.)

### Description:
Explain the purpose of the PR.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
