### PR TITLE
feat(regexp): use standard regexp by default, make go-re2 opt-in

### DIFF
--- a/regexp/stdlib_regex.go
+++ b/regexp/stdlib_regex.go
@@ -1,4 +1,4 @@
-//go:build stdregex
+//go:build !gore2regex
 
 package regexp
 

--- a/regexp/wasilibs_regex.go
+++ b/regexp/wasilibs_regex.go
@@ -1,4 +1,4 @@
-//go:build !stdregex
+//go:build gore2regex
 
 package regexp
 


### PR DESCRIPTION
### Description:

Fixes #1796.

This switches the default regular expression package back to Go's standard `regexp` package. Users can still opt-in to using `github.com/wasilabs/go-re2` by building with the `gore2regex` build tag.

See the discussion in #1796. This regexp will likely be a significant performance improvement in all cases except very long-running processes. Specifically, go-re2 has very high initialization and regular expression compilation costs that the standard library does not.

### Checklist:

* [x] Does your PR pass tests? Yes -- all existing tests pass.
* [x] Have you written new tests for your changes? No -- they are already covered by existing tests.
* [x] Have you lint your code locally prior to submission? Yes -- there are lint errors in the current code, but they are unrelated to this PR.
