### PR TITLE
Tweak logging and readme for GITLEAKS_CONFIG_TOML feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,23 +229,23 @@ your `.git/hooks/` directory.
 The order of precedence is:
 
 1. `--config/-c` option:
-  ```bash
-  gitleaks git --config /home/dev/customgitleaks.toml .
-  ```
-1. Environment variable `GITLEAKS_CONFIG` with the file path:
-  ```bash
-  export GITLEAKS_CONFIG="/home/dev/customgitleaks.toml"
-  gitleaks git .
-  ```
-1. Environment variable `GITLEAKS_CONFIG_TOML` with the file content:
-  ```bash
-  export GITLEAKS_CONFIG_TOML=`cat customgitleaks.toml`
-  gitleaks git .
-  ```
-1. A `.gitleaks.toml` file within the target path:
-  ```bash
-  gitleaks git .
-  ```
+      ```bash
+      gitleaks git --config /home/dev/customgitleaks.toml .
+      ```
+2. Environment variable `GITLEAKS_CONFIG` with the file path:
+      ```bash
+      export GITLEAKS_CONFIG="/home/dev/customgitleaks.toml"
+      gitleaks git .
+      ```
+3. Environment variable `GITLEAKS_CONFIG_TOML` with the file content:
+      ```bash
+      export GITLEAKS_CONFIG_TOML=`cat customgitleaks.toml`
+      gitleaks git .
+      ```
+4. A `.gitleaks.toml` file within the target path:
+      ```bash
+      gitleaks git .
+      ```
 
 If none of the four options are used, then gitleaks will use the default config.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -131,9 +131,9 @@ func initConfig(source string) {
 	} else if os.Getenv("GITLEAKS_CONFIG_TOML") != "" {
 		configContent := []byte(os.Getenv("GITLEAKS_CONFIG_TOML"))
 		if err := viper.ReadConfig(bytes.NewBuffer(configContent)); err != nil {
-			logging.Fatal().Msgf("unable to load gitleaks config from GITLEAKS_CONFIG_TOML env var content(%s), err: %s", configContent, err)
+			logging.Fatal().Err(err).Str("content", os.Getenv("GITLEAKS_CONFIG_TOML")).Msg("unable to load gitleaks config from GITLEAKS_CONFIG_TOML env var")
 		}
-		logging.Debug().Msgf("using gitleaks config from GITLEAKS_CONFIG_TOML env var content: %s", configContent)
+		logging.Debug().Str("content", os.Getenv("GITLEAKS_CONFIG_TOML")).Msg("using gitleaks config from GITLEAKS_CONFIG_TOML env var content")
 		return
 	} else {
 		fileInfo, err := os.Stat(source)


### PR DESCRIPTION
### Description:
This is a follow-up to #1662.

1. Fix the ordered list number in the README
2. Use `.Str()` instead of `.Msgf()` so that content is encoded nicely, instead of verbosely logging tens/hundreds/thousands of lines into the terminal.

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
