### PR TITLE
Add Azure DevOps SSH platform detection

### DIFF
--- a/cmd/detect.go
+++ b/cmd/detect.go
@@ -38,7 +38,7 @@ func init() {
 	detectCmd.Flags().Bool("follow-symlinks", false, "scan files that are symlinks to other files")
 	detectCmd.Flags().StringP("source", "s", ".", "path to source")
 	detectCmd.Flags().String("log-opts", "", "git log options")
-	detectCmd.Flags().String("platform", "", "the target platform used to generate links (github, gitlab)")
+	detectCmd.Flags().String("platform", "", "the target platform used to generate links (github, gitlab, azuredevops)")
 }
 
 var detectCmd = &cobra.Command{

--- a/detect/git.go
+++ b/detect/git.go
@@ -98,6 +98,7 @@ func NewRemoteInfo(platform scm.Platform, source string) *RemoteInfo {
 	if platform == scm.UnknownPlatform {
 		platform = platformFromHost(source)
 	}
+	
 	remoteUrl, err := getRemoteUrl(platform, source)
 
 	if platform == scm.UnknownPlatform {

--- a/detect/git.go
+++ b/detect/git.go
@@ -191,7 +191,7 @@ func platformFromHost(url string) scm.Platform {
 		return scm.GitLabPlatform
 	case strings.Contains(url, "dev.azure.com"):
 		return scm.AzureDevOpsPlatform
-	case strings.Contains(url, "visualstiudio.com"):
+	case strings.Contains(url, "visualstudio.com"):
 		return scm.AzureDevOpsPlatform
 	default:
 		return scm.UnknownPlatform

--- a/detect/git.go
+++ b/detect/git.go
@@ -98,8 +98,17 @@ func NewRemoteInfo(platform scm.Platform, source string) *RemoteInfo {
 	if platform == scm.UnknownPlatform {
 		platform = platformFromHost(source)
 	}
-	
+
 	remoteUrl, err := getRemoteUrl(platform, source)
+	if err != nil {
+		if strings.Contains(err.Error(), "No remote configured") {
+			logging.Debug().Msg("skipping finding links: repository has no configured remote.")
+			platform = scm.NoPlatform
+		} else {
+			logging.Error().Err(err).Msg("skipping finding links: unable to parse remote URL")
+		}
+		goto End
+	}
 
 	if platform == scm.UnknownPlatform {
 		logging.Info().
@@ -110,16 +119,6 @@ func NewRemoteInfo(platform scm.Platform, source string) *RemoteInfo {
 			Str("host", remoteUrl.Hostname()).
 			Str("platform", platform.String()).
 			Msg("SCM platform parsed from host")
-	}
-
-	if err != nil {
-		if strings.Contains(err.Error(), "No remote configured") {
-			logging.Debug().Msg("skipping finding links: repository has no configured remote.")
-			platform = scm.NoPlatform
-		} else {
-			logging.Error().Err(err).Msg("skipping finding links: unable to parse remote URL")
-		}
-		goto End
 	}
 
 End:

--- a/detect/git.go
+++ b/detect/git.go
@@ -134,7 +134,7 @@ End:
 
 var (
 	sshUrlpat            = regexp.MustCompile(`^git@([a-zA-Z0-9.-]+):([\w/.-]+?)(?:\.git)?$`)
-	azureDevOpsSshUrlpat = regexp.MustCompile(`^git@ssh\.dev\.azure\.com:v3/([^/]+)/([^/]+)/([^/]+)$`)
+	azureDevOpsSshUrlpat = regexp.MustCompile(`^git@(?:ssh\.)((?:dev\.azure\.com|visualstudio\.com)):v3/([^/]+)/([^/]+)/([^/]+)$`)
 )
 
 func getRemoteUrl(platform scm.Platform, source string) (*url.URL, error) {
@@ -164,13 +164,14 @@ func getRemoteUrl(platform scm.Platform, source string) (*url.URL, error) {
 		if matches := sshUrlpat.FindStringSubmatch(remoteUrl); matches != nil {
 			remoteUrl = fmt.Sprintf("https://%s/%s", matches[1], matches[2])
 		}
-		// Handle Azure DevOps SSH URLs
+	// Handle Azure DevOps SSH URLs
 	} else if platform == scm.AzureDevOpsPlatform {
 		if matches := azureDevOpsSshUrlpat.FindStringSubmatch(remoteUrl); matches != nil {
-			organization := matches[1]
-			project := matches[2]
-			repository := matches[3]
-			remoteUrl = fmt.Sprintf("https://dev.azure.com/%s/%s/_git/%s", organization, project, repository)
+			hostname:= matches[1]
+			organization := matches[2]
+			project := matches[3]
+			repository := matches[4]
+			remoteUrl = fmt.Sprintf("https://%s/%s/%s/_git/%s", hostname, organization, project, repository)
 		}
 	}
 

--- a/detect/git.go
+++ b/detect/git.go
@@ -154,7 +154,6 @@ func getRemoteUrl(platform scm.Platform, source string) (*url.URL, error) {
 
 	remoteUrl := string(bytes.TrimSpace(stdout))
 
-	
 	if platform == scm.UnknownPlatform {
 		return nil, fmt.Errorf("unable to detect platform: %w", err)
 	}


### PR DESCRIPTION
### Description:
Okay.. this requires a real review since this is my first real go experience and there are no tests for the git.go file. 

This PR adds the ability to detect azure devops git repo's that are fetched with ssh. Because this requires a totally different regex I've made changes how the host is detected. Basically a string contains. To make this work I needed to reshuffle stuff  where the platform was detected.

Tested manually with:

- GitHub.com HTTPS
- GitHub.com SSH
- AzureDevops HTTPS
- AzureDevOps SSH
- Providing the --platform
- Not providing the platform

I did not test anything with GitLab, however I think the risk is low since the regex is the same.

### Checklist:

* [X] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [X] Have you lint your code locally prior to submission?
