### PR TITLE
Fix currentLine out of bounds error

### DIFF
--- a/detect/decoder.go
+++ b/detect/decoder.go
@@ -280,24 +280,27 @@ func segmentWithDecodedOverlap(encodedSegments []EncodedSegment, start, end int)
 	return nil
 }
 
-func (s EncodedSegment) lineStartIndex(currentRaw string) int {
+func (s EncodedSegment) currentLine(currentRaw string) string {
+	start := 0
+	end := len(currentRaw)
+
+	// Find the start of the range
 	for i := s.decodedStart; i > -1; i-- {
 		c := currentRaw[i]
 		if c == '\n' {
-			return i
+			start = i
+			break
 		}
 	}
 
-	return 0
-}
-
-func (s EncodedSegment) lineEndIndex(currentRaw string, matchLen int) int {
-	for i := s.decodedStart; i < s.decodedStart+matchLen; i++ {
+	// Find the end of the range
+	for i := s.decodedEnd; i < end; i++ {
 		c := currentRaw[i]
 		if c == '\n' {
-			return i
+			end = i
+			break
 		}
 	}
 
-	return len(currentRaw) - 1
+	return currentRaw[start:end]
 }

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -392,7 +392,7 @@ MatchLoop:
 			if segment := segmentWithDecodedOverlap(encodedSegments, matchIndex[0], matchIndex[1]); segment != nil {
 				matchIndex = segment.adjustMatchIndex(matchIndex)
 				metaTags = append(metaTags, segment.tags()...)
-				currentLine = currentRaw[segment.lineStartIndex(currentRaw):segment.lineEndIndex(currentRaw, matchIndex[1]-matchIndex[0])]
+				currentLine = segment.currentLine(currentRaw)
 			} else {
 				// This item has already been added to a finding
 				continue


### PR DESCRIPTION
### Description:

`segment.adjustMatchIndex(matchIndex)` was above `segment.lineEndIndex(currentRaw, matchIndex[1]-matchIndex[0])` there were cases where it would cause an out of bounds error.

This change resolves the issue by just assuming the whole segment is a opaque chunk of text and starts at the boundaries of the segment instead so that the order doesn't matter as much.

The other option would have been to reorder the assignments and add tests to account for that case, but I figured this option is less likely to have gotchas when working with different encoding formats at the potential expense of getting an extra line or two if an encoding format in the future ever allows multiple lines of encoded content to be considered a single segment.


Explain the purpose of the PR.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes? (**N/A**: covered by existing tests)
* [x] Have you lint your code locally prior to submission?
