### PR TITLE
Sub finding detection (WIP)

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -38,6 +38,7 @@ func main() {
 		rules.Atlassian(),
 		rules.Authress(),
 		rules.AWS(),
+		rules.AWSSecret(),
 		rules.AzureActiveDirectoryClientSecret(),
 		rules.BitBucketClientID(),
 		rules.BitBucketClientSecret(),

--- a/cmd/generate/config/rules/aws.go
+++ b/cmd/generate/config/rules/aws.go
@@ -22,6 +22,9 @@ func AWS() *config.Rule {
 			"ABIA", // AWS STS service bearer token
 			"ACCA", // Context-specific credential
 		},
+		SubRules: []string {
+			"aws-secret-access-key",
+		},
 		Allowlists: []config.Allowlist{
 			{
 				Regexes: []*regexp.Regexp{

--- a/cmd/generate/config/rules/aws_secret.go
+++ b/cmd/generate/config/rules/aws_secret.go
@@ -1,0 +1,33 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/config"
+	"github.com/zricethezav/gitleaks/v8/regexp"
+)
+
+func AWSSecret() *config.Rule {
+	// define rule
+	r := config.Rule{
+		RuleID:      "aws-secret-access-key",
+		Description: "TODO: write proper description",
+		Regex:       utils.GenerateUniqueTokenRegex(`[A-Za-z0-9/+=]{40}`, false),
+		Entropy:     3,
+		IsSubRule:  true,
+		Allowlists: []config.Allowlist{
+			{
+				Regexes: []*regexp.Regexp{
+					regexp.MustCompile(`.+EXAMPLE$`),
+				},
+			},
+		},
+	}
+
+	// validate
+	tps := utils.GenerateSampleSecrets("AWSSecret", "lbqlNh3FW5/3AwnBoWsYIJam9w2Us4ZOH5Un8RyR") // gitleaks:allow
+	fps := []string{
+		"lbqlNh3FW5/3AwnBoWsYIJam9w2Us4ZOH5Un8RyRX", // wrong length
+		"lbqlN'3FW5/3AwnBoWsYIJam9w2Us4ZOH5Un8RyR",	 // invalid character
+	}
+	return utils.Validate(r, tps, fps)
+}

--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -32,6 +32,10 @@ paths = [{{ range $i, $path := . }}
 {{- range $i, $rule := .Rules }}{{println}}[[rules]]
 id = "{{$rule.RuleID}}"
 description = "{{$rule.Description}}"
+isSubRule = {{$rule.IsSubRule}}
+{{- with $rule.SubRules }}{{ if gt (len .) 0 }}
+subRules = [{{ range $j, $subRule := . }}"{{ $subRule }}",{{ end }}]
+{{- end }}{{ end }}
 {{- with $rule.Regex }}
 regex = '''{{ . }}'''{{ end -}}
 {{- with $rule.Path }}

--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -32,10 +32,15 @@ paths = [{{ range $i, $path := . }}
 {{- range $i, $rule := .Rules }}{{println}}[[rules]]
 id = "{{$rule.RuleID}}"
 description = "{{$rule.Description}}"
-isSubRule = {{$rule.IsSubRule}}
-{{- with $rule.SubRules }}{{ if gt (len .) 0 }}
-subRules = [{{ range $j, $subRule := . }}"{{ $subRule }}",{{ end }}]
-{{- end }}{{ end }}
+{{- if $rule.IsSubRule }}
+isSubRule = true
+{{- end }}
+{{- with $rule.SubRules }}
+{{- if gt (len .) 1}}
+subRules = [{{ range $j, $subRule := . }}
+    "{{ $subRule }}",{{ end }}
+]{{else}}
+subRules = [{{ range $j, $subRule := . }}"{{ $subRule }}"{{ end }}]{{end}}{{ end }}
 {{- with $rule.Regex }}
 regex = '''{{ . }}'''{{ end -}}
 {{- with $rule.Path }}

--- a/cmd/generate/config/rules/openai.go
+++ b/cmd/generate/config/rules/openai.go
@@ -19,6 +19,19 @@ func OpenAI() *config.Rule {
 	}
 
 	// validate
-	tps := utils.GenerateSampleSecrets("openaiApiKey", "sk-"+secrets.NewSecret(utils.AlphaNumeric("20"))+"T3BlbkFJ"+secrets.NewSecret(utils.AlphaNumeric("20")))
+	tps := append(utils.GenerateSampleSecrets("openaiApiKey", "sk-"+secrets.NewSecret(utils.AlphaNumeric("20"))+"T3BlbkFJ"+secrets.NewSecret(utils.AlphaNumeric("20"))),
+		[]string{
+			"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",
+			"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",
+			"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",
+
+			"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",
+			"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",
+			"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",
+
+			"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",
+			"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",
+			"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",
+		}...)
 	return utils.Validate(r, tps, nil)
 }

--- a/cmd/generate/config/rules/openai.go
+++ b/cmd/generate/config/rules/openai.go
@@ -11,7 +11,7 @@ func OpenAI() *config.Rule {
 	r := config.Rule{
 		RuleID:      "openai-api-key",
 		Description: "Found an OpenAI API Key, posing a risk of unauthorized access to AI services and data manipulation.",
-		Regex:       utils.GenerateUniqueTokenRegex(`sk-(?:proj|svcacct)-[A-Za-z0-9_-]{74}T3BlbkFJ[A-Za-z0-9_-]{74}\b|sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20}`, false),
+		Regex:       utils.GenerateUniqueTokenRegex(`sk-(?:proj|svcacct|admin)-(?:[A-Za-z0-9_-]{74}|[A-Za-z0-9_-]{58})T3BlbkFJ(?:[A-Za-z0-9_-]{74}|[A-Za-z0-9_-]{58})\b|sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20}`, false),
 		Entropy:     3,
 		Keywords: []string{
 			"T3BlbkFJ",

--- a/cmd/generate/config/rules/openai.go
+++ b/cmd/generate/config/rules/openai.go
@@ -11,7 +11,7 @@ func OpenAI() *config.Rule {
 	r := config.Rule{
 		RuleID:      "openai-api-key",
 		Description: "Found an OpenAI API Key, posing a risk of unauthorized access to AI services and data manipulation.",
-		Regex:       utils.GenerateUniqueTokenRegex(`sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20}`, false),
+		Regex:       utils.GenerateUniqueTokenRegex(`sk-(?:proj|svcacct)-[A-Za-z0-9_-]{74}T3BlbkFJ[A-Za-z0-9_-]{74}\b|sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20}`, false),
 		Entropy:     3,
 		Keywords: []string{
 			"T3BlbkFJ",

--- a/cmd/generate/config/utils/validate.go
+++ b/cmd/generate/config/utils/validate.go
@@ -15,6 +15,16 @@ import (
 
 func Validate(rule config.Rule, truePositives []string, falsePositives []string) *config.Rule {
 	r := &rule
+
+	// We temporarily set the SubRule status to false to make its
+	// matches present in the Findings list. Otherwise, they would
+	// need a main rule to be matched against.
+	wasSubRule := false
+	if r.IsSubRule {
+		r.IsSubRule = false
+		wasSubRule = true
+	}
+
 	d := createSingleRuleDetector(r)
 	for _, tp := range truePositives {
 		if len(d.DetectString(tp)) < 1 {
@@ -35,6 +45,9 @@ func Validate(rule config.Rule, truePositives []string, falsePositives []string)
 				Msg("Failed to Validate. False positive was detected by regex.")
 		}
 	}
+
+	r.IsSubRule = wasSubRule
+
 	return r
 }
 

--- a/cmd/generate/config/utils/validate.go
+++ b/cmd/generate/config/utils/validate.go
@@ -56,7 +56,8 @@ func ValidateWithPaths(rule config.Rule, truePositives map[string]string, falseP
 	d := createSingleRuleDetector(r)
 	for path, tp := range truePositives {
 		f := detect.Fragment{Raw: tp, FilePath: path}
-		if len(d.Detect(f)) != 1 {
+		findings, _ := d.Detect(f)
+		if len(findings) != 1 {
 			logging.Fatal().
 				Str("rule", r.RuleID).
 				Str("value", tp).
@@ -67,7 +68,8 @@ func ValidateWithPaths(rule config.Rule, truePositives map[string]string, falseP
 	}
 	for path, fp := range falsePositives {
 		f := detect.Fragment{Raw: fp, FilePath: path}
-		if len(d.Detect(f)) != 0 {
+		findings, _ := d.Detect(f)
+		if len(findings) != 0 {
 			logging.Fatal().
 				Str("rule", r.RuleID).
 				Str("value", fp).

--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,8 @@ type ViperConfig struct {
 		Keywords    []string
 		Path        string
 		Tags        []string
+		IsSubRule   bool
+		SubRules    []string
 
 		// Deprecated: this is a shim for backwards-compatibility. It should be removed in 9.x.
 		AllowList  *viperRuleAllowlist
@@ -124,6 +126,8 @@ func (vc *ViperConfig) Translate() (Config, error) {
 			Path:        configPathRegex,
 			Keywords:    vr.Keywords,
 			Tags:        vr.Tags,
+			IsSubRule:   vr.IsSubRule,
+			SubRules:    vr.SubRules,
 		}
 		// Parse the allowlist, including the older format for backwards compatibility.
 		if vr.AllowList != nil {

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -159,6 +159,7 @@ keywords = [
 [[rules]]
 id = "aws-access-token"
 description = "Identified a pattern that may indicate AWS credentials, risking unauthorized cloud resource access and data breaches on AWS platforms."
+subRules = ["aws-secret-access-key"]
 regex = '''\b((?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16})\b'''
 entropy = 3
 keywords = [
@@ -168,6 +169,17 @@ keywords = [
     "abia",
     "acca",
 ]
+[[rules.allowlists]]
+regexes = [
+    '''.+EXAMPLE$''',
+]
+
+[[rules]]
+id = "aws-secret-access-key"
+description = "TODO: write proper description"
+isSubRule = true
+regex = '''\b([A-Za-z0-9/+=]{40})(?:[\x60'"\s;]|\\[nr]|$)'''
+entropy = 3
 [[rules.allowlists]]
 regexes = [
     '''.+EXAMPLE$''',

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2614,7 +2614,7 @@ keywords = ["okta"]
 [[rules]]
 id = "openai-api-key"
 description = "Found an OpenAI API Key, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''\b(sk-(?:proj|svcacct)-[A-Za-z0-9_-]{74}T3BlbkFJ[A-Za-z0-9_-]{74}\b|sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:[\x60'"\s;]|\\[nr]|$)'''
+regex = '''\b(sk-(?:proj|svcacct|admin)-(?:[A-Za-z0-9_-]{74}|[A-Za-z0-9_-]{58})T3BlbkFJ(?:[A-Za-z0-9_-]{74}|[A-Za-z0-9_-]{58})\b|sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:[\x60'"\s;]|\\[nr]|$)'''
 entropy = 3
 keywords = ["t3blbkfj"]
 

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2614,7 +2614,7 @@ keywords = ["okta"]
 [[rules]]
 id = "openai-api-key"
 description = "Found an OpenAI API Key, posing a risk of unauthorized access to AI services and data manipulation."
-regex = '''\b(sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:[\x60'"\s;]|\\[nr]|$)'''
+regex = '''\b(sk-(?:proj|svcacct)-[A-Za-z0-9_-]{74}T3BlbkFJ[A-Za-z0-9_-]{74}\b|sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:[\x60'"\s;]|\\[nr]|$)'''
 entropy = 3
 keywords = ["t3blbkfj"]
 

--- a/config/rule.go
+++ b/config/rule.go
@@ -42,6 +42,16 @@ type Rule struct {
 
 	// Allowlists allows a rule to be ignored for specific commits, paths, regexes, and/or stopwords.
 	Allowlists []Allowlist
+
+	// SubRules defines a list of RuleIDs that this rule takes as
+	// SubRules. SubRules are used to make associations between
+	// secrets. Since some secrets need others to be actually usable,
+	// a SubRule can be used to relate them, and have an easier time
+	// verifying their validity.
+	SubRules []string
+
+	// IsSubRule marks this rule as a SubRule.
+	IsSubRule bool
 }
 
 // Validate guards against common misconfigurations.

--- a/detect/baseline.go
+++ b/detect/baseline.go
@@ -29,7 +29,8 @@ func IsNew(finding report.Finding, baseline []report.Finding) bool {
 			finding.RuleID == b.RuleID &&
 			finding.Secret == b.Secret &&
 			finding.StartColumn == b.StartColumn &&
-			finding.StartLine == b.StartLine {
+			finding.StartLine == b.StartLine &&
+			finding.IsSubFinding == b.IsSubFinding {
 			return false
 		}
 	}

--- a/detect/baseline_test.go
+++ b/detect/baseline_test.go
@@ -133,7 +133,7 @@ func TestIgnoreIssuesInBaseline(t *testing.T) {
 		require.NoError(t, err)
 		d.baseline = test.baseline
 		for _, finding := range test.findings {
-			d.AddFinding(finding)
+			d.AddMainFinding(finding)
 		}
 		assert.Len(t, d.findings, test.expectCount)
 	}

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -205,16 +205,16 @@ func (d *Detector) AddGitleaksIgnore(gitleaksIgnorePath string) error {
 }
 
 // DetectBytes scans the given bytes and returns a list of findings
-func (d *Detector) DetectBytes(content []byte) []report.Finding {
+func (d *Detector) DetectBytes(content []byte) ([]report.Finding, []report.Finding) {
 	return d.DetectString(string(content))
 }
 
 // DetectString scans the given string and returns a list of findings
-func (d *Detector) DetectString(content string) []report.Finding {
-	mainFindings, _ := d.Detect(Fragment{
+func (d *Detector) DetectString(content string) ([]report.Finding, []report.Finding) {
+	findings, subFindings := d.Detect(Fragment{
 		Raw: content,
 	})
-	return mainFindings
+	return findings, subFindings
 }
 
 // Associates sub findings with their main findings

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -73,6 +73,15 @@ type Detector struct {
 	// report.
 	findings []report.Finding
 
+	// subFindingsMutex is to prevent concurrent access to the
+	// subFindings slice when adding subFindings.
+	subFindingsMutex *sync.Mutex
+
+	// subFindings is a slice of report.Findings. This is the result
+	// of the detector's subFinding scan which can then be used to
+	// merge with the main findings slice.
+	subFindings []report.Finding
+
 	// prefilter is a ahocorasick struct used for doing efficient string
 	// matching given a set of words (keywords from the rules in the config)
 	prefilter ahocorasick.Trie
@@ -122,13 +131,15 @@ type Fragment struct {
 // NewDetector creates a new detector with the given config
 func NewDetector(cfg config.Config) *Detector {
 	return &Detector{
-		commitMap:      make(map[string]bool),
-		gitleaksIgnore: make(map[string]struct{}),
-		findingMutex:   &sync.Mutex{},
-		findings:       make([]report.Finding, 0),
-		Config:         cfg,
-		prefilter:      *ahocorasick.NewTrieBuilder().AddStrings(maps.Keys(cfg.Keywords)).Build(),
-		Sema:           semgroup.NewGroup(context.Background(), 40),
+		commitMap:        make(map[string]bool),
+		gitleaksIgnore:   make(map[string]struct{}),
+		findingMutex:     &sync.Mutex{},
+		subFindingsMutex: &sync.Mutex{},
+		findings:         make([]report.Finding, 0),
+		subFindings:      make([]report.Finding, 0),
+		Config:           cfg,
+		prefilter:        *ahocorasick.NewTrieBuilder().AddStrings(maps.Keys(cfg.Keywords)).Build(),
+		Sema:             semgroup.NewGroup(context.Background(), 40),
 	}
 }
 
@@ -200,32 +211,31 @@ func (d *Detector) DetectBytes(content []byte) []report.Finding {
 
 // DetectString scans the given string and returns a list of findings
 func (d *Detector) DetectString(content string) []report.Finding {
-	return d.Detect(Fragment{
+	mainFindings, _ := d.Detect(Fragment{
 		Raw: content,
 	})
+	return mainFindings
 }
 
-// Associates sub findings with their main findings, returns the modified list of findings
-func (d *Detector) MapFindings(findings []report.Finding, subFindings []report.Finding) []report.Finding {
-	for i := range findings {
-		subRules := d.Config.Rules[findings[i].RuleID].SubRules
+// Associates sub findings with their main findings
+func (d *Detector) MapFindings() {
+	for i := range d.findings {
+		subRules := d.Config.Rules[d.findings[i].RuleID].SubRules
 
 		subFinding:
-		for _, subFinding := range subFindings {
+		for _, subFinding := range d.subFindings {
 			for _, subRule := range subRules {
 				if subFinding.RuleID == subRule {
-					findings[i].SubFindings = append(findings[i].SubFindings, subFinding)
+					d.findings[i].SubFindings = append(d.findings[i].SubFindings, subFinding)
 					continue subFinding
 				}
 			}
 		}
 	}
-
-	return findings
 }
 
-// Detect scans the given fragment and returns a list of findings
-func (d *Detector) Detect(fragment Fragment) []report.Finding {
+// Detect scans the given fragment and returns a list of findings and subFindings
+func (d *Detector) Detect(fragment Fragment) ([]report.Finding, []report.Finding) {
 	if fragment.Bytes == nil {
 		d.TotalBytes.Add(uint64(len(fragment.Raw)))
 	}
@@ -240,7 +250,7 @@ func (d *Detector) Detect(fragment Fragment) []report.Finding {
 		if fragment.FilePath == d.Config.Path || (d.baselinePath != "" && fragment.FilePath == d.baselinePath) ||
 			// is the path excluded by the global allowlist?
 			(d.Config.Allowlist.PathAllowed(fragment.FilePath) || (fragment.WindowsFilePath != "" && d.Config.Allowlist.PathAllowed(fragment.WindowsFilePath))) {
-			return findings
+			return findings, subFindings
 		}
 	}
 
@@ -308,9 +318,7 @@ func (d *Detector) Detect(fragment Fragment) []report.Finding {
 		}
 	}
 
-	findings = d.MapFindings(findings, subFindings)
-
-	return filter(findings, d.Redact)
+	return filter(findings, d.Redact), filter(subFindings, d.Redact)
 }
 
 // detectRule scans the given fragment for the given rule and returns a list of findings
@@ -607,7 +615,7 @@ func allTrue(bools []bool) bool {
 }
 
 // AddFinding synchronously adds a finding to the findings slice
-func (d *Detector) AddFinding(finding report.Finding) {
+func (d *Detector) ShouldAddFinding(finding report.Finding) (report.Finding, bool) {
 	globalFingerprint := fmt.Sprintf("%s:%s:%d", finding.File, finding.RuleID, finding.StartLine)
 	if finding.Commit != "" {
 		finding.Fingerprint = fmt.Sprintf("%s:%s:%s:%d", finding.Commit, finding.File, finding.RuleID, finding.StartLine)
@@ -621,14 +629,14 @@ func (d *Detector) AddFinding(finding report.Finding) {
 		logger.Debug().
 			Str("fingerprint", globalFingerprint).
 			Msg("skipping finding: global fingerprint")
-		return
+		return report.Finding{}, false
 	} else if finding.Commit != "" {
 		// Awkward nested if because I'm not sure how to chain these two conditions.
 		if _, ok := d.gitleaksIgnore[finding.Fingerprint]; ok {
 			logger.Debug().
 				Str("fingerprint", finding.Fingerprint).
 				Msgf("skipping finding: fingerprint")
-			return
+			return report.Finding{}, false
 		}
 	}
 
@@ -636,6 +644,25 @@ func (d *Detector) AddFinding(finding report.Finding) {
 		logger.Debug().
 			Str("fingerprint", finding.Fingerprint).
 			Msgf("skipping finding: baseline")
+		return report.Finding{}, false
+	}
+
+	return finding, true
+}
+
+func (d *Detector) AddFindings(mainFindings []report.Finding, subFindings []report.Finding) {
+	for _, finding := range mainFindings {
+		d.AddMainFinding(finding)
+	}
+
+	for _, subFinding := range subFindings {
+		d.AddSubFinding(subFinding)
+	}
+}
+
+func (d *Detector) AddMainFinding(finding report.Finding) {
+	finding, ok := d.ShouldAddFinding(finding)
+	if !ok {
 		return
 	}
 
@@ -645,6 +672,20 @@ func (d *Detector) AddFinding(finding report.Finding) {
 		printFinding(finding, d.NoColor)
 	}
 	d.findingMutex.Unlock()
+}
+
+func (d *Detector) AddSubFinding(finding report.Finding) {
+	finding, ok := d.ShouldAddFinding(finding)
+	if !ok {
+		return
+	}
+
+	d.subFindingsMutex.Lock()
+	d.subFindings = append(d.subFindings, finding)
+	if d.Verbose {
+		printFinding(finding, d.NoColor)
+	}
+	d.subFindingsMutex.Unlock()
 }
 
 // Findings returns the findings added to the detector

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -1288,6 +1288,55 @@ func TestWindowsFileSeparator_RulePath(t *testing.T) {
 	}
 }
 
+func TestSubFindingDetection(t *testing.T) {
+	tests := map[string]struct {
+		fragment Fragment
+		expected []report.Finding
+	}{
+		"AWS access token is found alongside its secret key": {
+			fragment: Fragment{
+				Raw: `AKIALALEMEL33243OLIA
+                      lbqlNh3FW5/3AwnBoWsYIJam9w2Us4ZOH5Un8RyR`,
+				FilePath: "someScript.py",
+			},
+			expected: []report.Finding{
+				{
+					RuleID: "aws-access-token",
+					StartLine: 0,
+					EndLine: 0,
+					StartColumn: 0,
+					Match: "AKIALALEMEL33243OLIA",
+					IsSubFinding: false,
+					SubFindings: []report.Finding{
+						{
+							RuleID: "aws-secret-access-key",
+							StartLine: 1,
+							EndLine: 1,
+							Match: "lbqlNh3FW5/3AwnBoWsYIJam9w2Us4ZOH5Un8RyR",
+							IsSubFinding: true,
+							SubFindings: []report.Finding{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	d, err := NewDetectorDefaultConfig()
+	require.NoError(t, err)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			findings, subFindings := d.Detect(test.fragment)
+			d.AddFindings(findings, subFindings)
+			d.MapFindings()
+			actual := d.findings
+			if diff := cmp.Diff(test.expected, actual); diff != "" {
+				t.Errorf("diff: (-want +got)\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestWindowsFileSeparator_RuleAllowlistPaths(t *testing.T) {
 	tests := map[string]struct {
 		fragment Fragment

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -492,7 +492,7 @@ func TestDetect(t *testing.T) {
 			d.MaxDecodeDepth = maxDecodeDepth
 			d.baselinePath = tt.baselinePath
 
-			findings := d.Detect(tt.fragment)
+			findings, _ := d.Detect(tt.fragment)
 			assert.ElementsMatch(t, tt.expectedFindings, findings)
 		})
 	}

--- a/detect/directory.go
+++ b/detect/directory.go
@@ -98,11 +98,19 @@ func (d *Detector) DetectFiles(paths <-chan sources.ScanTarget) ([]report.Findin
 						fragment.FilePath = pa.Path
 					}
 
-					for _, finding := range d.Detect(fragment) {
+					findings, subFindings := d.Detect(fragment)
+					for _, finding := range findings {
 						// need to add 1 since line counting starts at 1
 						finding.StartLine += (totalLines - linesInChunk) + 1
 						finding.EndLine += (totalLines - linesInChunk) + 1
-						d.AddFinding(finding)
+						d.AddMainFinding(finding)
+					}
+
+					for _, subFinding := range subFindings {
+						// need to add 1 since line counting starts at 1
+						subFinding.StartLine += (totalLines - linesInChunk) + 1
+						subFinding.EndLine += (totalLines - linesInChunk) + 1
+						d.AddSubFinding(subFinding)
 					}
 				}
 
@@ -119,6 +127,8 @@ func (d *Detector) DetectFiles(paths <-chan sources.ScanTarget) ([]report.Findin
 	if err := d.Sema.Wait(); err != nil {
 		return d.findings, err
 	}
+
+	d.MapFindings()
 
 	return d.findings, nil
 }

--- a/detect/git.go
+++ b/detect/git.go
@@ -61,9 +61,8 @@ func (d *Detector) DetectGit(cmd *sources.GitCmd, remote *RemoteInfo) ([]report.
 						FilePath:  gitdiffFile.NewName,
 					}
 
-					for _, finding := range d.Detect(fragment) {
-						d.AddFinding(augmentGitFinding(remote, finding, textFragment, gitdiffFile))
-					}
+					findings, subFindings := d.Detect(fragment)
+					d.AddFindings(findings, subFindings)
 				}
 				return nil
 			})
@@ -82,6 +81,9 @@ func (d *Detector) DetectGit(cmd *sources.GitCmd, remote *RemoteInfo) ([]report.
 	}
 	logging.Info().Msgf("%d commits scanned.", len(d.commitMap))
 	logging.Debug().Msg("Note: this number might be smaller than expected due to commits with no additions")
+
+	d.MapFindings()
+
 	return d.findings, nil
 }
 

--- a/report/finding.go
+++ b/report/finding.go
@@ -34,11 +34,13 @@ type Finding struct {
 	// Entropy is the shannon entropy of Value
 	Entropy float32
 
-	Author  string
-	Email   string
-	Date    string
-	Message string
-	Tags    []string
+	Author        string
+	Email         string
+	Date          string
+	Message       string
+	Tags          []string
+	SubFindings   []Finding
+	IsSubFinding  bool
 
 	// unique identifier
 	Fingerprint string


### PR DESCRIPTION
### Checklist:

* [ ] Does your PR pass tests?
* [X] Have you written new tests for your changes?
* [X] Have you lint your code locally prior to submission?

As discussed in #1794, I've been working these past few days to implement some method to detect "multi secrets".

The PR is currently working, but unfinished. I will need to discuss with other gitleaks contributors to figure out what the best approach may be to tackle this issue.

The PR adds quite a bit of complexity to the project, which I'm not really proud of. As such I want to hear criticism and alternative ideas for the implementation. I'm willing to implement whatever idea ends up being the preferred one, and I would even ditch this PR in its entirety, if the alternatives prove to be better.

## What this PR introduces

This PR introduces the concept of `SubRules` and `SubFindings`. Now, any rule can be declared in the configuration file with the new key `isSubRule`, which is a boolean. Another key is added, `subRules`, which is a list of strings, declaring what SubRules a particular "MainRule" is associated with.

Here's an example:

```toml
id = "aws-access-token"
description = "Identified a pattern that may indicate AWS credentials, risking unauthorized cloud resource access and data breaches on AWS platforms."
subRules = ["aws-secret-access-key"]
regex = '''\b((?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16})\b'''
entropy = 3
keywords = [
    "a3t",
    "akia",
    "asia",
    "abia",
    "acca",
]
[[rules.allowlists]]
regexes = [
    '''.+EXAMPLE$''',
]

[[rules]]
id = "aws-secret-access-key"
description = "TODO: write proper description"
isSubRule = true
regex = '''\b([A-Za-z0-9/+=]{40})(?:[\x60'"\s;]|\\[nr]|$)'''
entropy = 3
[[rules.allowlists]]
regexes = [
    '''.+EXAMPLE$''',
]
```

As you can see, the `aws-secret-access-key` is declared to be a SubRule, and the `aws-access-token` contains its rule ID in its SubRules list.

SubFindings (being findings derived from a SubRule) *do not* get detected on their own. If there's a SubFinding present in a scan, but no MainFinding that contains it, the SubFinding *will not* get reported.

The rationale behind this is that many of these secondary secrets usually have pretty generic patterns. If we allow SubFindings to be detected regardless, we will pollute the results with tons of false positives.

Now, how do we know which of the SubFinding matches belongs to each MainFinding? We don't. If there's 10 possible candidates for the `aws-secret-access-key`, then all 10 will be reported as SubFindings for the MainFinding. And if there's 10 MainRules which all declare the same types for their SubRules, then the same 10 SubFindings will be reported in each 10 MainFindings.

This generates a lot of duplication on the output. Its currently one of the main drawbacks of this approach.

Speaking of, how does the output look like? Since gitleaks supports two main output formats, JSON and CSV, I modified them both to accomodate for the new data. Here's a sample of each:

```json
[
 {
  "RuleID": "aws-access-token",
  "Description": "Identified a pattern that may indicate AWS credentials, risking unauthorized cloud resource access and data breaches on AWS platforms.",
  "StartLine": 1,
  "EndLine": 1,
  "StartColumn": 1,
  "EndColumn": 20,
  "Match": "AKIA3NRIQH6HVKGHTADD",
  "Secret": "AKIA3NRIQH6HVKGHTADD",
  "File": "leaks_dir/leaks",
  "SymlinkFile": "",
  "Commit": "",
  "Entropy": 3.5464394,
  "Author": "",
  "Email": "",
  "Date": "",
  "Message": "",
  "Tags": [],
  "SubFindings": [
   {
    "RuleID": "aws-secret-access-key",
    "Description": "TODO: write proper description",
    "StartLine": 2,
    "EndLine": 2,
    "StartColumn": 2,
    "EndColumn": 41,
    "Match": "lbqlNh3FW5/3AwnBoWsYIJam9w2Us4ZOH5Un8RyR",
    "Secret": "lbqlNh3FW5/3AwnBoWsYIJam9w2Us4ZOH5Un8RyR",
    "File": "leaks_dir/leaks",
    "SymlinkFile": "",
    "Commit": "",
    "Entropy": 4.871928,
    "Author": "",
    "Email": "",
    "Date": "",
    "Message": "",
    "Tags": [],
    "SubFindings": [],
    "IsSubFinding": true,
    "Fingerprint": "leaks_dir/leaks:aws-secret-access-key:2"
   }
  ],
  "IsSubFinding": false,
  "Fingerprint": "leaks_dir/leaks:aws-access-token:1"
 }
]
```

```csv
ID, RuleID,               Commit, File,           SymlinkFile, Secret,                                   Match,                                    StartLine, EndLine, StartColumn, EndColumn, Author, Message, Date, Email, Fingerprint,                            Tags, IsSubFinding, SubFindings
1,  aws-access-token,           , leaks_dir/leaks,           , AKIA3NRIQH6HVKGHTADD,                     AKIA3NRIQH6HVKGHTADD,                     1,         1,       1,           20,              ,        ,     ,      , leaks_dir/leaks:aws-access-token:1,         , false,        2
2,  aws-secret-access-key,      , leaks_dir/leaks,           , lbqlNh3FW5/3AwnBoWsYIJam9w2Us4ZOH5Un8RyR, lbqlNh3FW5/3AwnBoWsYIJam9w2Us4ZOH5Un8RyR, 2,         2,       2,           41,              ,        ,     ,      , leaks_dir/leaks:aws-secret-access-key:2,    , true,
```

(CSV padding was added by me, output doesn't contain it)

The JSON output simply lists the SubFindings in the SubFindings array, with all the data of a regular Finding.

CSV is trickier. Since CSVs can't contain complex objects inside their fields, I added an ID system. Now each entry contains an ID, and the SubFindings are referenced by it.

## Technical details

So how is all this implemented? Well, apart from the modifications to the config parsing and generation to accomodate for the new keys, the main difference is that there's two finding slices.

When you call the `Detect` method of the detector, the result gets added to a `findings` or `subFindings` slice, depending on the finding's `isSubFinding` value. The value is set by `detectRule` depending on the rule's `isSubRule` value. This can be seen [here](https://github.com/tralph3/gitleaks/blob/f0c86a22845e6689bf0464680ab62f7f01c3f1ae/detect/detect.go#L280).

`Detect` now returns the two slices, the findings and subFindings. However, simply calling `Detect` is not enough now, because you have the two types of findings separated. To associate each Finding with its SubFindings, you need to call `MapFindings`, a new method for the detector.

The reason this is not done automatically when calling `Detect`, is that `Detect` is often called in different goroutines per Fragment. It's possible that the Finding and a corresponding SubFinding are in different Fragments. So to ensure everything is picked up, once all the detection is done, `MapFindings` is manually called to make the associations. The `findings` slice of the detector gets modified to populate all the `SubFindings` slices of the needed Findings. This can be seen in multiple places, for example, [here](https://github.com/tralph3/gitleaks/blob/f0c86a22845e6689bf0464680ab62f7f01c3f1ae/detect/git.go#L85).

## Things to take into account

* Tests are broken. I can't make much sense of the output unfortunately.
* I manually modified the template to generate the config. The comment said it was auto generated, but I couldn't figure out how.
* The regex for the `aws-secret-access-key` can probably be improved, but its not the priority of this PR. It also needs a description.
* `Detect` is no longer self-contained, as it needs a separate call to `AddFindings` to add its results to the detector's slices, and then to `MapFindings` to associate the SubFindings with their main ones. I'd really like to have a better solution.
