### PR TITLE
bump repo version in pre-commit example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ jobs:
    ```
    repos:
      - repo: https://github.com/gitleaks/gitleaks
-       rev: v8.23.1
+       rev: v8.24.2
        hooks:
          - id: gitleaks
    ```


### PR DESCRIPTION
### Description:
I tried to setup pre-commit hook using example in README but it was failing because of #1751 
Bump to latest version fixes the issue, hence I thought it was a good idea to update the README.