### PR TITLE
Adjust AWS key rule to accept only base32

### DIFF
--- a/cmd/generate/config/rules/aws.go
+++ b/cmd/generate/config/rules/aws.go
@@ -12,7 +12,7 @@ func AWS() *config.Rule {
 	r := config.Rule{
 		RuleID:      "aws-access-token",
 		Description: "Identified a pattern that may indicate AWS credentials, risking unauthorized cloud resource access and data breaches on AWS platforms.",
-		Regex:       regexp.MustCompile(`\b((?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16})\b`),
+		Regex:       regexp.MustCompile(`\b((?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z2-7]{16})\b`),
 		Entropy:     3,
 		Keywords: []string{
 			// https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-unique-ids

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -159,7 +159,7 @@ keywords = [
 [[rules]]
 id = "aws-access-token"
 description = "Identified a pattern that may indicate AWS credentials, risking unauthorized cloud resource access and data breaches on AWS platforms."
-regex = '''\b((?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16})\b'''
+regex = '''\b((?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z2-7]{16})\b'''
 entropy = 3
 keywords = [
     "a3t",


### PR DESCRIPTION
### Description:

Since the data in AWS keys are base32 encoded, you should only have to look for [A-Z2-7]+.

Sources:

 - https://medium.com/@TalBeerySec/a-short-note-on-aws-key-id-f88cc4317489
 - https://en.wikipedia.org/wiki/Base32

I ran the updated regex against my last 90 days of scan data and the only things not found with the new regex were false positives. But please feel free to double check me on this. I don't want to tune out any true positives.

### Checklist:

* [X] Does your PR pass tests?
* [ ] Have you written new tests for your changes? (no but I totally can if desired ^\_^)
* [X] Have you lint your code locally prior to submission?

cc: @zricethezav && @rgmz 
