### PR TITLE
fix(adobe-client-secret): adobe client secret regex

### DIFF
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -84,7 +84,7 @@ keywords = ["adobe"]
 [[rules]]
 id = "adobe-client-secret"
 description = "Discovered a potential Adobe Client Secret, which, if exposed, could allow unauthorized Adobe service access and data manipulation."
-regex = '''\b(p8e-(?i)[a-z0-9]{32})(?:[\x60'"\s;]|\\[nr]|$)'''
+regex = '''\b(p8e-(?i)[a-z0-9-]{32})(?:[\x60'"\s;]|\\[nr]|$)'''
 entropy = 2
 keywords = ["p8e-"]
 


### PR DESCRIPTION
Adobe client secret can contain `-`

### Description:
According to the screenshot from the official documentation Adobe client secret can contain `-`
<img width="423" alt="image" src="https://github.com/user-attachments/assets/32f8b0e2-9ad7-47ea-8956-27133838ffda" />

https://experienceleague.adobe.com/en/docs/experience-manager-learn/cloud-service/developing/extensibility/app-builder/jwt-auth

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?

