### PR TITLE
Introduce context propagation for git operations

### DIFF
--- a/cmd/detect.go
+++ b/cmd/detect.go
@@ -19,6 +19,7 @@
 package cmd
 
 import (
+	"context"
 	"os"
 	"time"
 
@@ -101,7 +102,7 @@ func runDetect(cmd *cobra.Command, args []string) {
 			scmPlatform scm.Platform
 			remote      *detect.RemoteInfo
 		)
-		if gitCmd, err = sources.NewGitLogCmd(source, logOpts); err != nil {
+		if gitCmd, err = sources.NewGitLogCmd(context.Background(), source, logOpts); err != nil {
 			logging.Fatal().Err(err).Msg("could not create Git cmd")
 		}
 		if scmPlatform, err = scm.PlatformFromString(mustGetStringFlag(cmd, "platform")); err != nil {
@@ -109,7 +110,7 @@ func runDetect(cmd *cobra.Command, args []string) {
 		}
 		remote = detect.NewRemoteInfo(scmPlatform, source)
 
-		if findings, err = detector.DetectGit(gitCmd, remote); err != nil {
+		if findings, err = detector.DetectGit(context.Background(), gitCmd, remote); err != nil {
 			// don't exit on error, just log it
 			logging.Error().Err(err).Msg("failed to scan Git repository")
 		}

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -62,13 +63,13 @@ func runGit(cmd *cobra.Command, args []string) {
 		remote      *detect.RemoteInfo
 	)
 	if preCommit || staged {
-		if gitCmd, err = sources.NewGitDiffCmd(source, staged); err != nil {
+		if gitCmd, err = sources.NewGitDiffCmd(context.Background(), source, staged); err != nil {
 			logging.Fatal().Err(err).Msg("could not create Git diff cmd")
 		}
 		// Remote info + links are irrelevant for staged changes.
 		remote = &detect.RemoteInfo{Platform: scm.NoPlatform}
 	} else {
-		if gitCmd, err = sources.NewGitLogCmd(source, logOpts); err != nil {
+		if gitCmd, err = sources.NewGitLogCmd(context.Background(), source, logOpts); err != nil {
 			logging.Fatal().Err(err).Msg("could not create Git log cmd")
 		}
 		if scmPlatform, err = scm.PlatformFromString(mustGetStringFlag(cmd, "platform")); err != nil {
@@ -77,7 +78,7 @@ func runGit(cmd *cobra.Command, args []string) {
 		remote = detect.NewRemoteInfo(scmPlatform, source)
 	}
 
-	findings, err = detector.DetectGit(gitCmd, remote)
+	findings, err = detector.DetectGit(context.Background(), gitCmd, remote)
 	if err != nil {
 		// don't exit on error, just log it
 		logging.Error().Err(err).Msg("failed to scan Git repository")

--- a/cmd/protect.go
+++ b/cmd/protect.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -51,12 +52,12 @@ func runProtect(cmd *cobra.Command, args []string) {
 		remote *detect.RemoteInfo
 	)
 
-	if gitCmd, err = sources.NewGitDiffCmd(source, staged); err != nil {
+	if gitCmd, err = sources.NewGitDiffCmd(context.Background(), source, staged); err != nil {
 		logging.Fatal().Err(err).Msg("could not create Git diff cmd")
 	}
 	remote = &detect.RemoteInfo{Platform: scm.NoPlatform}
 
-	if findings, err = detector.DetectGit(gitCmd, remote); err != nil {
+	if findings, err = detector.DetectGit(context.Background(), gitCmd, remote); err != nil {
 		// don't exit on error, just log it
 		logging.Error().Err(err).Msg("failed to scan Git repository")
 	}

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -1,6 +1,7 @@
 package detect
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -637,11 +638,11 @@ func TestFromGit(t *testing.T) {
 			err = detector.AddGitleaksIgnore(ignorePath)
 			require.NoError(t, err)
 
-			gitCmd, err := sources.NewGitLogCmd(tt.source, tt.logOpts)
+			gitCmd, err := sources.NewGitLogCmd(context.Background(), tt.source, tt.logOpts)
 			require.NoError(t, err)
 
 			remote := NewRemoteInfo(scm.UnknownPlatform, tt.source)
-			findings, err := detector.DetectGit(gitCmd, remote)
+			findings, err := detector.DetectGit(context.Background(), gitCmd, remote)
 			require.NoError(t, err)
 
 			for _, f := range findings {
@@ -710,10 +711,11 @@ func TestFromGitStaged(t *testing.T) {
 		detector := NewDetector(cfg)
 		err = detector.AddGitleaksIgnore(filepath.Join(tt.source, ".gitleaksignore"))
 		require.NoError(t, err)
-		gitCmd, err := sources.NewGitDiffCmd(tt.source, true)
+		gitCmd, err := sources.NewGitDiffCmd(context.Background(), tt.source, true)
 		require.NoError(t, err)
 		remote := NewRemoteInfo(scm.UnknownPlatform, tt.source)
-		findings, err := detector.DetectGit(gitCmd, remote)
+
+		findings, err := detector.DetectGit(context.Background(), gitCmd, remote)
 		require.NoError(t, err)
 
 		for _, f := range findings {


### PR DESCRIPTION
### Description:

This commit introduces context propagation throughout the Gitleaks library's git scanning process, specifically within the `detect` and `sources` packages.

Function signatures in `detect.DetectGit`, `sources.NewGitLogCmd`, and `sources.NewGitDiffCmd` have been updated to accept a `context.Context` as the first argument.

Internally, `exec.Command` has been replaced with `exec.CommandContext` to allow for cancellation signals (e.g., timeouts or explicit cancellation) from the calling application to be passed down to the underlying `git` processes (`git log`, `git diff`, `git clone`, `git fetch`).

This ensures that long-running or hung git operations can be properly terminated, preventing resource leaks and improving application responsiveness. Context cancellation checks have also been added within the detection loops and associated goroutines to respect cancellation signals promptly.

Existing call sites for these modified functions within the `cmd` package and tests have been updated to pass `context.Background()`.

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
