### PR TITLE
feat(rules): Add Perplexity AI API key detection

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"golang.org/x/exp/slices"
 	"os"
 	"text/template"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/base"
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/rules"
@@ -165,6 +166,7 @@ func main() {
 		rules.OktaAccessToken(),
 		rules.OpenAI(),
 		rules.OpenshiftUserToken(),
+		rules.PerplexityAPIKey(),
 		rules.PlaidAccessID(),
 		rules.PlaidSecretKey(),
 		rules.PlaidAccessToken(),

--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -1,10 +1,9 @@
 package main
 
 import (
+	"golang.org/x/exp/slices"
 	"os"
 	"text/template"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/base"
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/rules"

--- a/cmd/generate/config/rules/perplexity.go
+++ b/cmd/generate/config/rules/perplexity.go
@@ -3,6 +3,8 @@ package rules
 import (
 	"regexp"
 
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+
 	"github.com/zricethezav/gitleaks/v8/config"
 )
 
@@ -11,7 +13,7 @@ func PerplexityAPIKey() *config.Rule {
 	r := config.Rule{
 		RuleID:      "perplexity-api-key",
 		Description: "Detected a Perplexity API key, which could lead to unauthorized access to Perplexity AI services and data exposure.",
-		Regex:       regexp.MustCompile(`\b(pplx-[\w]{48})(?:[\x60'"\s;]|\\[nr]|$|\b)`),
+		Regex:       regexp.MustCompile(`\b(pplx-[a-zA-Z0-9]{48})(?:[\x60'"\s;]|\\[nr]|$|\b)`),
 		Keywords:    []string{"pplx-"},
 		Entropy:     4.0,
 	}

--- a/cmd/generate/config/rules/perplexity.go
+++ b/cmd/generate/config/rules/perplexity.go
@@ -13,7 +13,7 @@ func PerplexityAPIKey() *config.Rule {
 		Description: "Detected a Perplexity API key, which could lead to unauthorized access to Perplexity AI services and data exposure.",
 		Regex:       regexp.MustCompile(`\b(pplx-[\w]{48})(?:[\x60'"\s;]|\\[nr]|$|\b)`),
 		Keywords:    []string{"pplx"},
-		Entropy:     2.0,
+		Entropy:     4.0,
 	}
 
 	return &r

--- a/cmd/generate/config/rules/perplexity.go
+++ b/cmd/generate/config/rules/perplexity.go
@@ -16,5 +16,10 @@ func PerplexityAPIKey() *config.Rule {
 		Entropy:     4.0,
 	}
 
-	return &r
+	// validate
+	tps := utils.GenerateSampleSecrets("perplexity", "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'")
+	fps := []string{
+		"PERPLEXITY_API_KEY=pplx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+	}
+	return utils.Validate(r, tps, fps)
 }

--- a/cmd/generate/config/rules/perplexity.go
+++ b/cmd/generate/config/rules/perplexity.go
@@ -1,0 +1,20 @@
+package rules
+
+import (
+	"regexp"
+
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+func PerplexityAPIKey() *config.Rule {
+	// Define Rule
+	r := config.Rule{
+		RuleID:      "perplexity-api-key",
+		Description: "Detected a Perplexity API key, which could lead to unauthorized access to Perplexity AI services and data exposure.",
+		Regex:       regexp.MustCompile(`\b(pplx-[\w]{48})(?:[\x60'"\s;]|\\[nr]|$|\b)`),
+		Keywords:    []string{"pplx"},
+		Entropy:     2.0,
+	}
+
+	return &r
+}

--- a/cmd/generate/config/rules/perplexity.go
+++ b/cmd/generate/config/rules/perplexity.go
@@ -12,7 +12,7 @@ func PerplexityAPIKey() *config.Rule {
 		RuleID:      "perplexity-api-key",
 		Description: "Detected a Perplexity API key, which could lead to unauthorized access to Perplexity AI services and data exposure.",
 		Regex:       regexp.MustCompile(`\b(pplx-[\w]{48})(?:[\x60'"\s;]|\\[nr]|$|\b)`),
-		Keywords:    []string{"pplx"},
+		Keywords:    []string{"pplx-"},
 		Entropy:     4.0,
 	}
 

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2622,7 +2622,7 @@ keywords = ["sha256~"]
 
 [[rules]]
 id = "perplexity-api-key"
-description = "Found a Perplexity api key."
+description = "Detected a Perplexity API key, which could lead to unauthorized access to Perplexity AI services and data exposure."
 regex = '''\b(pplx-[\w]{48})(?:[\x60'"\s;]|\\[nr]|$|\b)'''
 entropy = 2
 keywords = ["pplx"]

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2623,9 +2623,9 @@ keywords = ["sha256~"]
 [[rules]]
 id = "perplexity-api-key"
 description = "Detected a Perplexity API key, which could lead to unauthorized access to Perplexity AI services and data exposure."
-regex = '''\b(pplx-[\w]{48})(?:[\x60'"\s;]|\\[nr]|$|\b)'''
-entropy = 2
-keywords = ["pplx"]
+regex = '''\b(pplx-[a-zA-Z0-9]{48})(?:[\x60'"\s;]|\\[nr]|$|\b)'''
+entropy = 4
+keywords = ["pplx-"]
 
 [[rules]]
 id = "pkcs12-file"

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2621,6 +2621,13 @@ entropy = 3.5
 keywords = ["sha256~"]
 
 [[rules]]
+id = "perplexity-api-key"
+description = "Found a Perplexity api key."
+regex = '''\b(pplx-[\w]{48})(?:[\x60'"\s;]|\\[nr]|$|\b)'''
+entropy = 2
+keywords = ["pplx"]
+
+[[rules]]
 id = "pkcs12-file"
 description = "Found a PKCS #12 file, which commonly contain bundled private keys."
 path = '''(?i)(?:^|\/)[^\/]+\.p(?:12|fx)$'''


### PR DESCRIPTION
### Description:
Adds a new rule to detect Perplexity AI API keys (pplx-...). This enhances secret detection capabilities by including keys for the Perplexity AI service.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
