### PR TITLE
Adding clickhouse scanner

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"golang.org/x/exp/slices"
 	"os"
 	"text/template"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/base"
 	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/rules"
@@ -47,6 +48,7 @@ func main() {
 		rules.Beamer(),
 		rules.CodecovAccessToken(),
 		rules.CoinbaseAccessToken(),
+		rules.ClickHouseCloud(),
 		rules.Clojars(),
 		rules.CloudflareAPIKey(),
 		rules.CloudflareGlobalAPIKey(),

--- a/cmd/generate/config/rules/clickhouse.go
+++ b/cmd/generate/config/rules/clickhouse.go
@@ -1,0 +1,31 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
+	"github.com/zricethezav/gitleaks/v8/config"
+	"github.com/zricethezav/gitleaks/v8/regexp"
+)
+
+func ClickHouseCloud() *config.Rule {
+	// define rule
+	r := config.Rule{
+		RuleID:      "clickhouse-cloud-api-secret-key",
+		Description: "Identified a pattern that may indicate clickhouse cloud API secret key, risking unauthorized clickhouse cloud api access and data breaches on ClickHouse Cloud platforms.",
+		Regex:       regexp.MustCompile(`\b(4b1d[A-Za-z0-9]{38})\b`),
+		Entropy:     3,
+		Keywords: []string{
+			"4b1d", // Prefix
+		},
+	}
+
+	// validate
+	tps := utils.GenerateSampleSecrets("ClickHouse", "4b1dbRdW3rOcB7xLthrM4BTBGK1qPLkHigpN1bXD6z") // gitleaks:allow
+	// current AWS tokens cannot contain [0,1,8,9], so their entropy is slightly lower than expected.
+	tps = append(tps, utils.GenerateSampleSecrets("ClickHouse", "4b1d"+secrets.NewSecret("[A-Za-z0-9]{38}"))...)
+	fps := []string{
+		`key = 4b1dXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`,    // Low entropy
+		`key = adf4b1dbRdW3rOcB7xLthrM4BTBGK1qPLkHigpN1bXD6z`, // Not start of a word
+	}
+	return utils.Validate(r, tps, fps)
+}

--- a/cmd/generate/config/rules/clickhouse.go
+++ b/cmd/generate/config/rules/clickhouse.go
@@ -20,8 +20,7 @@ func ClickHouseCloud() *config.Rule {
 	}
 
 	// validate
-	tps := utils.GenerateSampleSecrets("ClickHouse", "4b1dbRdW3rOcB7xLthrM4BTBGK1qPLkHigpN1bXD6z") // gitleaks:allow
-	// current AWS tokens cannot contain [0,1,8,9], so their entropy is slightly lower than expected.
+	tps := utils.GenerateSampleSecrets("ClickHouse", "4b1dbRdW3rOcB7xLthrM4BTBGK1qPLkHigpN1bXD6z")
 	tps = append(tps, utils.GenerateSampleSecrets("ClickHouse", "4b1d"+secrets.NewSecret("[A-Za-z0-9]{38}"))...)
 	fps := []string{
 		`key = 4b1dXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`,    // Low entropy

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -218,6 +218,13 @@ entropy = 3
 keywords = ["meraki"]
 
 [[rules]]
+id = "clickhouse-cloud-api-secret-key"
+description = "Identified a pattern that may indicate clickhouse cloud API secret key, risking unauthorized clickhouse cloud api access and data breaches on ClickHouse Cloud platforms."
+regex = '''\b(4b1d[A-Za-z0-9]{38})\b'''
+entropy = 3
+keywords = ["4b1d"]
+
+[[rules]]
 id = "clojars-api-token"
 description = "Uncovered a possible Clojars API token, risking unauthorized access to Clojure libraries and potential code manipulation."
 regex = '''(?i)CLOJARS_[a-z0-9]{60}'''


### PR DESCRIPTION
### Description:
Hi all, I would like to add the pattern for clickhouse cloud api secret, when building our api, we specifically choose a prefix (4b1d...) to be added and can be easily detected on.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
