### PR TITLE
Increase `gcp-api-key` entropy

### DIFF
--- a/cmd/generate/config/rules/gcp.go
+++ b/cmd/generate/config/rules/gcp.go
@@ -30,10 +30,8 @@ func GCPAPIKey() *config.Rule {
 		RuleID:      "gcp-api-key",
 		Description: "Uncovered a GCP API key, which could lead to unauthorized access to Google Cloud services and data breaches.",
 		Regex:       utils.GenerateUniqueTokenRegex(`AIza[\w-]{35}`, false),
-		Entropy:     3.0,
-		Keywords: []string{
-			"AIza",
-		},
+		Entropy:     4,
+		Keywords:    []string{"AIza"},
 		Allowlists: []*config.Allowlist{
 			{
 				Regexes: []*regexp.Regexp{

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -552,7 +552,7 @@ keywords = ["freshbooks"]
 id = "gcp-api-key"
 description = "Uncovered a GCP API key, which could lead to unauthorized access to Google Cloud services and data breaches."
 regex = '''\b(AIza[\w-]{35})(?:[\x60'"\s;]|\\[nr]|$)'''
-entropy = 3
+entropy = 4
 keywords = ["aiza"]
 [[rules.allowlists]]
 regexes = [


### PR DESCRIPTION
### Description:
Real results tend to have entropy >= 4.5.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
