### PR TITLE
Fix rule-specific allowlist paths not working

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -547,10 +547,10 @@ func checkCommitOrPathAllowed(
 			}
 			// These will be checked later.
 			if len(a.Regexes) > 0 {
-				return false, nil
+				continue
 			}
 			if len(a.StopWords) > 0 {
-				return false, nil
+				continue
 			}
 
 			isAllowed = allTrue(allowlistChecks)

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -376,6 +376,13 @@ const token = "mockSecret";
 				FilePath: "tmp.go",
 			},
 		},
+		"allowlist - ignore path when extending": {
+			cfgName: "valid/allowlist_rule_extend_default",
+			fragment: Fragment{
+				Raw:      `token = "aebfab88-7596-481d-82e8-c60c8f7de0c0"`,
+				FilePath: "path/to/your/problematic/file.js",
+			},
+		},
 		"allowlist - ignore regex": {
 			cfgName: "valid/allowlist_rule_regex",
 			fragment: Fragment{

--- a/testdata/config/valid/allowlist_rule_extend_default.toml
+++ b/testdata/config/valid/allowlist_rule_extend_default.toml
@@ -1,0 +1,11 @@
+# https://github.com/gitleaks/gitleaks/issues/1844
+[extend]
+useDefault = true
+
+[[rules]]
+id = "generic-api-key"
+[[rules.allowlists]]
+description = "Exclude a specific file from generic-api-key rule"
+paths = [
+    '''^path/to/your/problematic/file\.js$'''
+]


### PR DESCRIPTION
### Description:
Fixes #1844. Doing `return` caused the function to potentially exit before testing all allowlists. An oversight on my part.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
