### PR TITLE
Set `pass_filenames` to `false` for Docker hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -9,8 +9,9 @@
   description: Detect hardcoded secrets using Gitleaks
   entry: zricethezav/gitleaks git --pre-commit --redact --staged --verbose
   language: docker_image
+  pass_filenames: false
 - id: gitleaks-system
   name: Detect hardcoded secrets
   description: Detect hardcoded secrets using Gitleaks
-  entry: gitleaks git  --pre-commit --redact --staged --verbose
+  entry: gitleaks git --pre-commit --redact --staged --verbose
   language: system


### PR DESCRIPTION
### Description:
Fixes #1749.

I've tested it successfully with

```bash
 pre-commit try-repo /path/to/gitleaks gitleaks-docker --verbose --all-files 
```

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
