### PR TITLE
Include decoder in debug log

### DIFF
--- a/detect/codec/decoder.go
+++ b/detect/codec/decoder.go
@@ -2,6 +2,7 @@ package codec
 
 import (
 	"bytes"
+
 	"github.com/zricethezav/gitleaks/v8/logging"
 )
 
@@ -89,13 +90,15 @@ func (d *Decoder) findEncodedSegments(data string, predecessors []*EncodedSegmen
 		}
 
 		segments = append(segments, segment)
-		logging.Debug().Msgf(
-			"segment found: original=%s pos=%s: %q -> %q",
-			segment.original,
-			segment.encoded,
-			encodedValue,
-			segment.decodedValue,
-		)
+		logging.Debug().
+			Str("decoder", m.encoding.kind.String()).
+			Msgf(
+				"segment found: original=%s pos=%s: %q -> %q",
+				segment.original,
+				segment.encoded,
+				encodedValue,
+				segment.decodedValue,
+			)
 	}
 
 	return segments


### PR DESCRIPTION
### Description:
This updates the `findEncodedSegments` log statement to include which decoder produced the segment.
```
6:01PM DBG using stdlib regex engine
6:01PM DBG unable to load gitleaks config from /tmp/decode.txt/.gitleaks.toml since --source=/tmp/decode.txt is a file, using default config
6:01PM DBG found .gitleaksignore file: .gitleaksignore
6:01PM DBG segment found: original=[29,38] pos=[29,38]: "%3D%3D%0A" -> "==\n" decoder=percent
6:01PM DBG segment found: original=[11,38] pos=[11,31]: "aGVsbG8sIHdvcmxkIQ==" -> "hello, world!" decoder=base64
6:01PM INF scanned ~51 bytes (51 bytes) in 2.75ms
6:01PM INF no leaks found
```

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
