### PR TITLE
Reduce aws-access-token false positives

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ If you want to add a new rule to the [default Gitleaks configuration](https://gi
            RuleID:      "beamer-api-token",
 
            // Regex capture group for the actual secret
-           
+
 
 
            // Regex used for detecting secrets. See regex section below for more details
@@ -95,7 +95,7 @@ If you want to add a new rule to the [default Gitleaks configuration](https://gi
    the `rules.Beamer(),` in `main()`. Try and keep
    this alphabetically pretty please.
 
-1. Run `go generate ./...`
+1. Run `make config/gitleaks.toml`
 
 1. Check out your new rules in `config/gitleaks.toml` and see if everything looks good.
 

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,16 @@ test-cover:
 format:
 	go fmt ./...
 
-test: format
+test: config/gitleaks.toml format
 	go test -v ./... --race $(PKG)
 
-build: format
+build: config/gitleaks.toml format
 	go mod tidy
 	go build $(LDFLAGS)
 
 clean:
 	find . -type f -name '*.got.*' -delete
 	find . -type f -name '*.out' -delete
+
+config/gitleaks.toml: $(wildcard cmd/generate/config/**/*)
+	go generate ./...

--- a/cmd/diagnostics.go
+++ b/cmd/diagnostics.go
@@ -125,7 +125,7 @@ func (dm *DiagnosticsManager) StartCPUProfile() error {
 	}
 
 	if err := pprof.StartCPUProfile(f); err != nil {
-		f.Close()
+		_ = f.Close()
 		return fmt.Errorf("could not start CPU profile: %w", err)
 	}
 
@@ -188,7 +188,7 @@ func (dm *DiagnosticsManager) StartTraceProfile() error {
 	}
 
 	if err := trace.Start(f); err != nil {
-		f.Close()
+		_ = f.Close()
 		return fmt.Errorf("could not start trace profile: %w", err)
 	}
 

--- a/cmd/generate/config/rules/aws.go
+++ b/cmd/generate/config/rules/aws.go
@@ -12,7 +12,7 @@ func AWS() *config.Rule {
 	r := config.Rule{
 		RuleID:      "aws-access-token",
 		Description: "Identified a pattern that may indicate AWS credentials, risking unauthorized cloud resource access and data breaches on AWS platforms.",
-		Regex:       regexp.MustCompile(`\b((?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16})\b`),
+		Regex:       regexp.MustCompile(`\b((?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z2-7]{16})\b`),
 		Entropy:     3,
 		Keywords: []string{
 			// https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-unique-ids

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -167,7 +167,7 @@ keywords = [
 [[rules]]
 id = "aws-access-token"
 description = "Identified a pattern that may indicate AWS credentials, risking unauthorized cloud resource access and data breaches on AWS platforms."
-regex = '''\b((?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16})\b'''
+regex = '''\b((?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z2-7]{16})\b'''
 entropy = 3
 keywords = [
     "a3t",


### PR DESCRIPTION
### Description:

**Adjust aws-access-token regex**
    
AWS Access Key IDs are [base32 encoded][1] so the numerical values here will [only be 2-7][2]
    
[1]: https://medium.com/@TalBeerySec/a-short-note-on-aws-key-id-f88cc4317489
[2]: https://en.wikipedia.org/wiki/Base32#Base_32_Encoding_with_Extended_Hex_Alphabet_per_%C2%A77:~:text=It%20uses%20an%20alphabet%20of%20A%E2%80%93Z%2C%20followed%20by%202%E2%80%937

**Update config/gitleaks.toml during build and test**
    
Summary:
    
- Add `config/gitleaks.toml` make target
- Make it a dep of `build` and `test`
- Update CONTRIBUTING.md to reference the new target
    
Reason: Makes dev easier because you can just tweak the code and run `make test` without an extra step.

**Resolve lint issues in cmd/diagnostics.go**

```
$ golangci-lint run cmd/
cmd/diagnostics.go:128:10: Error return value of `f.Close` is not checked (errcheck)
                f.Close()
                       ^
cmd/diagnostics.go:191:10: Error return value of `f.Close` is not checked (errcheck)
                f.Close()
                       ^
2 issues:
* errcheck: 2
```

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes? (**N/A**)
* [x] Have you lint your code locally prior to submission?