### PR TITLE
Detect Notion Public API Keys #1889

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -161,6 +161,7 @@ func main() {
 		rules.NewRelicUserKey(),
 		rules.NewRelicBrowserAPIKey(),
 		rules.NewRelicInsertKey(),
+		rules.Notion(),
 		rules.NPM(),
 		rules.NugetConfigPassword(),
 		rules.NytimesAccessToken(),

--- a/cmd/generate/config/rules/notion.go
+++ b/cmd/generate/config/rules/notion.go
@@ -18,6 +18,7 @@ func Notion() *config.Rule {
         Description: "Notion API token",
         RuleID: "notion-api-token",
         Regex: regex,
+        Entropy: 4,
         Keywords: identifiers,
     }
 

--- a/cmd/generate/config/rules/notion.go
+++ b/cmd/generate/config/rules/notion.go
@@ -7,7 +7,7 @@ import (
 
 func Notion() *config.Rule {
     // Define the identifiers that match the Keywords
-    identifiers := []string{"ntn", "ntn_", "notion"}
+    identifiers := []string{"ntn_"}
     
     // Define the regex pattern for Notion API token
     secretRegex := `ntn_[0-9]{11}[A-Za-z0-9]{32}[A-Za-z0-9]{3}`

--- a/cmd/generate/config/rules/notion.go
+++ b/cmd/generate/config/rules/notion.go
@@ -1,0 +1,38 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+func Notion() *config.Rule {
+    // Define the identifiers that match the Keywords
+    identifiers := []string{"ntn", "ntn_", "notion"}
+    
+    // Define the regex pattern for Notion API token
+    secretRegex := `ntn_[0-9]{11}[A-Za-z0-9]{32}[A-Za-z0-9]{3}`
+    
+    regex := utils.GenerateUniqueTokenRegex(secretRegex, false)
+    
+    r := config.Rule{
+        Description: "Notion API token",
+        RuleID: "notion-api-token",
+        Regex: regex,
+        Keywords: identifiers,
+    }
+
+    // validate
+	tps := []string{
+		"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",
+		"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",
+		"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",
+	}
+
+	fps:= []string{
+		"ntn_12345678901",
+		"ntn_123456789012345678901234567890123456789012345678901234567890",
+		"ntn_12345678901abc",
+	}
+
+    return utils.Validate(r, tps, fps)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2586,6 +2586,16 @@ regex = '''(?i)[\w.-]{0,50}?(?:new-relic|newrelic|new_relic)(?:[ \t\w.-]{0,20})[
 keywords = ["nrak"]
 
 [[rules]]
+id = "notion-api-token"
+description = "Notion API token"
+regex = '''\b(ntn_[0-9]{11}[A-Za-z0-9]{32}[A-Za-z0-9]{3})(?:[\x60'"\s;]|\\[nr]|$)'''
+keywords = [
+    "ntn",
+    "ntn_",
+    "notion",
+]
+
+[[rules]]
 id = "npm-access-token"
 description = "Uncovered an npm access token, potentially compromising package management and code repository access."
 regex = '''(?i)\b(npm_[a-z0-9]{36})(?:[\x60'"\s;]|\\[nr]|$)'''

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2589,11 +2589,8 @@ keywords = ["nrak"]
 id = "notion-api-token"
 description = "Notion API token"
 regex = '''\b(ntn_[0-9]{11}[A-Za-z0-9]{32}[A-Za-z0-9]{3})(?:[\x60'"\s;]|\\[nr]|$)'''
-keywords = [
-    "ntn",
-    "ntn_",
-    "notion",
-]
+entropy = 4
+keywords = ["ntn_"]
 
 [[rules]]
 id = "npm-access-token"


### PR DESCRIPTION
Closes #1889

This commit adds the Notion API regex key token pattern and detection rule to GitLeaks. 

Notion API tokens have the format `ntn_{11-digit timestamp}_{32-character alphanumeric}_{3-character suffix}`

You can retrieve test Notion API keys by creating a Notion account, then navigating to the [integrations page ](https://www.notion.so/profile/integrations) to create an API key. Reference documentation for the Notion Public API can be found here: [https://developers.notion.com/docs/create-a-notion-integration](https://developers.notion.com/docs/create-a-notion-integration)