### PR TITLE
feat: add Anthropic API key detection

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -35,6 +35,8 @@ func main() {
 		rules.AlgoliaApiKey(),
 		rules.AlibabaAccessKey(),
 		rules.AlibabaSecretKey(),
+		rules.AnthropicAdminApiKey(),
+		rules.AnthropicApiKey(),
 		rules.ArtifactoryApiKey(),
 		rules.ArtifactoryReferenceToken(),
 		rules.AsanaClientID(),

--- a/cmd/generate/config/rules/anthropic.go
+++ b/cmd/generate/config/rules/anthropic.go
@@ -1,0 +1,69 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+func AnthropicApiKey() *config.Rule {
+	// define rule
+	r := config.Rule{
+		RuleID:      "anthropic-api-key",
+		Description: "Identified an Anthropic API Key, which may compromise AI assistant integrations and expose sensitive data to unauthorized access.",
+		Regex:       utils.GenerateUniqueTokenRegex(`sk-ant-api03-[a-zA-Z0-9_\-]{93}AA`, false),
+		Keywords: []string{
+			"sk-ant-api03",
+		},
+	}
+
+	// validate
+	tps := []string{
+		// Valid API key example
+		"sk-ant-api03-abc123xyz-456def789ghij-klmnopqrstuvwx-3456yza789bcde-1234fghijklmnopby56aaaogaopaaaabc123xyzAA",
+		// Generate additional random test keys
+		utils.GenerateSampleSecret("anthropic", "sk-ant-api03-"+secrets.NewSecret(utils.AlphaNumericExtendedShort("93"))+"AA"),
+	}
+
+	fps := []string{
+		// Too short key (missing characters)
+		"sk-ant-api03-abc123xyz-456de-klMnopqrstuvwx-3456yza789bcde-1234fghijklmnopAA",
+		// Wrong suffix
+		"sk-ant-api03-abc123xyz-456def789ghij-klmnopqrstuvwx-3456yza789bcde-1234fghijklmnopby56aaaogaopaaaabc123xyzBB",
+		// Wrong prefix (admin key, not API key)
+		"sk-ant-admin01-abc123xyz-456def789ghij-klmnopqrstuvwx-3456yza789bcde-1234fghijklmnopby56aaaogaopaaaabc123xyzAA",
+	}
+
+	return utils.Validate(r, tps, fps)
+}
+
+func AnthropicAdminApiKey() *config.Rule {
+	// define rule
+	r := config.Rule{
+		RuleID:      "anthropic-admin-api-key",
+		Description: "Detected an Anthropic Admin API Key, risking unauthorized access to administrative functions and sensitive AI model configurations.",
+		Regex:       utils.GenerateUniqueTokenRegex(`sk-ant-admin01-[a-zA-Z0-9_\-]{93}AA`, false),
+		Keywords: []string{
+			"sk-ant-admin01",
+		},
+	}
+
+	// validate
+	tps := []string{
+		// Valid admin key example
+		"sk-ant-admin01-abc12fake-456def789ghij-klmnopqrstuvwx-3456yza789bcde-12fakehijklmnopby56aaaogaopaaaabc123xyzAA",
+		// Generate additional random test keys
+		utils.GenerateSampleSecret("anthropic", "sk-ant-admin01-"+secrets.NewSecret(utils.AlphaNumericExtendedShort("93"))+"AA"),
+	}
+
+	fps := []string{
+		// Too short key (missing characters)
+		"sk-ant-admin01-abc123xyz-456de-klMnopqrstuvwx-3456yza789bcde-1234fghijklmnopAA",
+		// Wrong suffix
+		"sk-ant-admin01-abc123xyz-456def789ghij-klmnopqrstuvwx-3456yza789bcde-1234fghijklmnopby56aaaogaopaaaabc123xyzBB",
+		// Wrong prefix (API key, not admin key)
+		"sk-ant-api03-abc123xyz-456def789ghij-klmnopqrstuvwx-3456yza789bcde-1234fghijklmnopby56aaaogaopaaaabc123xyzAA",
+	}
+
+	return utils.Validate(r, tps, fps)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -130,6 +130,18 @@ entropy = 2
 keywords = ["alibaba"]
 
 [[rules]]
+id = "anthropic-admin-api-key"
+description = "Detected an Anthropic Admin API Key, risking unauthorized access to administrative functions and sensitive AI model configurations."
+regex = '''\b(sk-ant-admin01-[a-zA-Z0-9_\-]{93}AA)(?:[\x60'"\s;]|\\[nr]|$)'''
+keywords = ["sk-ant-admin01"]
+
+[[rules]]
+id = "anthropic-api-key"
+description = "Identified an Anthropic API Key, which may compromise AI assistant integrations and expose sensitive data to unauthorized access."
+regex = '''\b(sk-ant-api03-[a-zA-Z0-9_\-]{93}AA)(?:[\x60'"\s;]|\\[nr]|$)'''
+keywords = ["sk-ant-api03"]
+
+[[rules]]
 id = "artifactory-api-key"
 description = "Detected an Artifactory api key, posing a risk unauthorized access to the central repository."
 regex = '''\bAKCp[A-Za-z0-9]{69}\b'''


### PR DESCRIPTION
### Description:

Add detection rules for Anthropic API keys:
- anthropic-api-key: detects sk-ant-api03-... keys
- anthropic-admin-api-key: detects sk-ant-admin01-... keys

Both key types follow the pattern sk-ant-{type}-{93 chars}AA and are detected as separate rules to align with gitleaks patterns for multi-token providers.

The base regex patterns are aligned with what TruffleHog uses here: https://github.com/trufflesecurity/trufflehog/blob/main/pkg/detectors/anthropic/anthropic.go

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
