### PR TITLE
feat: improve regex to detect Sonar tokens with prefixes

### DIFF
--- a/cmd/generate/config/rules/sonar.go
+++ b/cmd/generate/config/rules/sonar.go
@@ -10,18 +10,22 @@ func Sonar() *config.Rule {
 	r := config.Rule{
 		Description: "Uncovered a Sonar API token, potentially compromising software vulnerability scanning and code security.",
 		RuleID:      "sonar-api-token",
-		Regex:       utils.GenerateSemiGenericRegex([]string{"sonar[_.-]?(login|token)"}, utils.AlphaNumericExtended("40"), true),
+		Regex:       utils.GenerateSemiGenericRegex([]string{"sonar[_.-]?(login|token)"}, "(?:squ_|sqp_|sqa_)?"+utils.AlphaNumericExtended("40"), true),
 		Keywords:    []string{"sonar"},
+		SecretGroup: 2,
 	}
 
 	// validate
 	tps := utils.GenerateSampleSecrets("sonar", "12345678ABCDEFH1234567890ABCDEFH12345678")
 	tps = append(tps,
-		`const SONAR_LOGIN = "12345678ABCDEFH1234567890ABCDEFH12345678"`, // gitleaks:allow
-		`SONAR_LOGIN := "12345678ABCDEFH1234567890ABCDEFH12345678"`,      // gitleaks:allow
-		`SONAR.LOGIN ::= "12345678ABCDEFH1234567890ABCDEFH12345678"`,     // gitleaks:allow
-		`SONAR.LOGIN :::= "12345678ABCDEFH1234567890ABCDEFH12345678"`,    // gitleaks:allow
-		`SONAR.LOGIN ?= "12345678ABCDEFH1234567890ABCDEFH12345678"`,      // gitleaks:allow
+		`const SONAR_LOGIN = "12345678ABCDEFH1234567890ABCDEFH12345678"`,     // gitleaks:allow
+		`SONAR_LOGIN := "12345678ABCDEFH1234567890ABCDEFH12345678"`,          // gitleaks:allow
+		`SONAR.LOGIN ::= "12345678ABCDEFH1234567890ABCDEFH12345678"`,         // gitleaks:allow
+		`SONAR.LOGIN :::= "12345678ABCDEFH1234567890ABCDEFH12345678"`,        // gitleaks:allow
+		`SONAR.LOGIN ?= "12345678ABCDEFH1234567890ABCDEFH12345678"`,          // gitleaks:allow
+		`const SONAR_TOKEN = "squ_12345678ABCDEFH1234567890ABCDEFH12345678"`, // gitleaks:allow
+		`SONAR_LOGIN := "sqp_12345678ABCDEFH1234567890ABCDEFH12345678"`,      // gitleaks:allow
+		`SONAR.TOKEN = "sqa_12345678ABCDEFH1234567890ABCDEFH12345678"`,       // gitleaks:allow
 	)
 	return utils.Validate(r, tps, nil)
 }

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -3006,7 +3006,8 @@ keywords = ["snyk"]
 [[rules]]
 id = "sonar-api-token"
 description = "Uncovered a Sonar API token, potentially compromising software vulnerability scanning and code security."
-regex = '''(?i)[\w.-]{0,50}?(?:sonar[_.-]?(login|token))(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([a-z0-9=_\-]{40})(?:[\x60'"\s;]|\\[nr]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:sonar[_.-]?(login|token))(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}((?:squ_|sqp_|sqa_)?[a-z0-9=_\-]{40})(?:[\x60'"\s;]|\\[nr]|$)'''
+secretGroup = 2
 keywords = ["sonar"]
 
 [[rules]]


### PR DESCRIPTION
### Description:

Since Sonar 9.5, a prefix was added to the tokens. Gitleaks isn't currently detecting those tokens with prefixes (`sqa_`, `sqp_` and `squ_`).

See: https://www.sonarsource.com/products/sonarqube/whats-new/sonarqube-9-5/

### Checklist:

* [X] Does your PR pass tests?
* [X] Have you written new tests for your changes?
* [X] Have you lint your code locally prior to submission?
