### PR TITLE
feat: add Amazon Bedrock API key detection

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -35,6 +35,8 @@ func main() {
 		rules.AlgoliaApiKey(),
 		rules.AlibabaAccessKey(),
 		rules.AlibabaSecretKey(),
+		rules.AmazonBedrockAPIKeyLongLived(),
+		rules.AmazonBedrockAPIKeyShortLived(),
 		rules.AnthropicAdminApiKey(),
 		rules.AnthropicApiKey(),
 		rules.ArtifactoryApiKey(),

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -209,6 +209,20 @@ regexes = [
 ]
 
 [[rules]]
+id = "aws-amazon-bedrock-api-key-long-lived"
+description = "Identified a pattern that may indicate long-lived Amazon Bedrock API keys, risking unauthorized Amazon Bedrock usage"
+regex = '''\b(ABSK[A-Za-z0-9+/]{109,269}={0,2})(?:[\x60'"\s;]|\\[nr]|$)'''
+entropy = 3
+keywords = ["absk"]
+
+[[rules]]
+id = "aws-amazon-bedrock-api-key-short-lived"
+description = "Identified a pattern that may indicate short-lived Amazon Bedrock API keys, risking unauthorized Amazon Bedrock usage"
+regex = '''bedrock-api-key-YmVkcm9jay5hbWF6b25hd3MuY29t'''
+entropy = 3
+keywords = ["bedrock-api-key-"]
+
+[[rules]]
 id = "azure-ad-client-secret"
 description = "Azure AD Client Secret"
 regex = '''(?:^|[\\'"\x60\s>=:(,)])([a-zA-Z0-9_~.]{3}\dQ~[a-zA-Z0-9_~.-]{31,34})(?:$|[\\'"\x60\s<),])'''


### PR DESCRIPTION
### Description:

Add secret detection of [Amazon Bedrock API Keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-how.html)

- Long-lived via `ABSK[A-Za-z0-9+/]{109,269}={0,2}`
- Short-lived via `bedrock-api-key-YmVkcm9jay5hbWF6b25hd3MuY29t`

### Checklist:

* [X] Does your PR pass tests?
* [X] Have you written new tests for your changes?
* [X] Have you lint your code locally prior to submission?
