### PR TITLE
Add new Looker client ID and client secret rules

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -150,6 +150,8 @@ func main() {
 		rules.LinkedinClientSecret(),
 		rules.LobAPIToken(),
 		rules.LobPubAPIToken(),
+		rules.LookerClientID(),
+		rules.LookerClientSecret(),
 		rules.MailChimp(),
 		rules.MailGunPubAPIToken(),
 		rules.MailGunPrivateAPIToken(),

--- a/cmd/generate/config/rules/looker.go
+++ b/cmd/generate/config/rules/looker.go
@@ -1,0 +1,35 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+func LookerClientID() *config.Rule {
+	// define rule
+	r := config.Rule{
+		Description: "Found a Looker Client ID, risking unauthorized access to a Looker account and exposing sensitive data.",
+		RuleID:      "looker-client-id",
+		Regex:       utils.GenerateSemiGenericRegex([]string{"looker"}, utils.AlphaNumeric("20"), true),
+		Keywords:    []string{"looker"},
+	}
+
+	// validate
+	tps := utils.GenerateSampleSecrets("looker", secrets.NewSecret(utils.AlphaNumeric("20")))
+	return utils.Validate(r, tps, nil)
+}
+
+func LookerClientSecret() *config.Rule {
+	// define rule
+	r := config.Rule{
+		Description: "Found a Looker Client Secret, risking unauthorized access to a Looker account and exposing sensitive data.",
+		RuleID:      "looker-client-secret",
+		Regex:       utils.GenerateSemiGenericRegex([]string{"looker"}, utils.AlphaNumeric("24"), true),
+		Keywords:    []string{"looker"},
+	}
+
+	// validate
+	tps := utils.GenerateSampleSecrets("looker", secrets.NewSecret(utils.AlphaNumeric("24")))
+	return utils.Validate(r, tps, nil)
+}

--- a/cmd/generate/config/rules/notion.go
+++ b/cmd/generate/config/rules/notion.go
@@ -6,34 +6,34 @@ import (
 )
 
 func Notion() *config.Rule {
-    // Define the identifiers that match the Keywords
-    identifiers := []string{"ntn_"}
-    
-    // Define the regex pattern for Notion API token
-    secretRegex := `ntn_[0-9]{11}[A-Za-z0-9]{32}[A-Za-z0-9]{3}`
-    
-    regex := utils.GenerateUniqueTokenRegex(secretRegex, false)
-    
-    r := config.Rule{
-        Description: "Notion API token",
-        RuleID: "notion-api-token",
-        Regex: regex,
-        Entropy: 4,
-        Keywords: identifiers,
-    }
+	// Define the identifiers that match the Keywords
+	identifiers := []string{"ntn_"}
 
-    // validate
+	// Define the regex pattern for Notion API token
+	secretRegex := `ntn_[0-9]{11}[A-Za-z0-9]{32}[A-Za-z0-9]{3}`
+
+	regex := utils.GenerateUniqueTokenRegex(secretRegex, false)
+
+	r := config.Rule{
+		Description: "Notion API token",
+		RuleID:      "notion-api-token",
+		Regex:       regex,
+		Entropy:     4,
+		Keywords:    identifiers,
+	}
+
+	// validate
 	tps := []string{
 		"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",
 		"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",
 		"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",
 	}
 
-	fps:= []string{
+	fps := []string{
 		"ntn_12345678901",
 		"ntn_123456789012345678901234567890123456789012345678901234567890",
 		"ntn_12345678901abc",
 	}
 
-    return utils.Validate(r, tps, fps)
+	return utils.Validate(r, tps, fps)
 }

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2505,6 +2505,18 @@ keywords = [
 ]
 
 [[rules]]
+id = "looker-client-id"
+description = "Found a Looker Client ID, risking unauthorized access to a Looker account and exposing sensitive data."
+regex = '''(?i)[\w.-]{0,50}?(?:looker)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{20})(?:[\x60'"\s;]|\\[nr]|$)'''
+keywords = ["looker"]
+
+[[rules]]
+id = "looker-client-secret"
+description = "Found a Looker Client Secret, risking unauthorized access to a Looker account and exposing sensitive data."
+regex = '''(?i)[\w.-]{0,50}?(?:looker)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{24})(?:[\x60'"\s;]|\\[nr]|$)'''
+keywords = ["looker"]
+
+[[rules]]
 id = "mailchimp-api-key"
 description = "Identified a Mailchimp API key, potentially compromising email marketing campaigns and subscriber data."
 regex = '''(?i)[\w.-]{0,50}?(?:MailchimpSDK.initialize|mailchimp)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([a-f0-9]{32}-us\d\d)(?:[\x60'"\s;]|\\[nr]|$)'''


### PR DESCRIPTION
### Description:
Add two provider-specific rules to detect leaked Looker SDK API3 credentials: looker-client-id and looker-client-secret. These rules target alphanumeric client_id (20 chars) and client_secret (24 chars) commonly committed in configuration (for example, looker.ini), environment variables, and inline literals. The implementation uses SemiGeneric patterns keyed on the “looker” identifier plus deterministic length constraints. This helps prevent unauthorized access to Looker instances and sensitive analytics data.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
Not applicable
* [x] Have you lint your code locally prior to submission?
