### PR TITLE
sources: replace filetype with mimetype and add explicit human-readable filter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/charmbracelet/lipgloss v0.5.0
 	github.com/fatih/semgroup v1.2.0
+	github.com/gabriel-vasile/mimetype v1.4.10
 	github.com/gitleaks/go-gitdiff v0.9.1
 	github.com/google/go-cmp v0.6.0
-	github.com/h2non/filetype v1.1.3
 	github.com/mholt/archives v0.1.2
 	github.com/rs/zerolog v1.33.0
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/gabriel-vasile/mimetype v1.4.10 h1:zyueNbySn/z8mJZHLt6IPw0KoZsiQNszIpU+bX4+ZK0=
+github.com/gabriel-vasile/mimetype v1.4.10/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/gitleaks/go-gitdiff v0.9.1 h1:ni6z6/3i9ODT685OLCTf+s/ERlWUNWQF4x1pvoNICw0=
 github.com/gitleaks/go-gitdiff v0.9.1/go.mod h1:pKz0X4YzCKZs30BL+weqBIG7mx0jl4tF1uXV9ZyNvrA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -98,8 +100,6 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
-github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
-github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/sources/file_test.go
+++ b/sources/file_test.go
@@ -1,0 +1,62 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gabriel-vasile/mimetype"
+)
+
+var minimalPNG = []byte{
+	0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+	0x00, 0x00, 0x00, 0x0D, // length = 13
+	0x49, 0x48, 0x44, 0x52, // "IHDR"
+	0x00, 0x00, 0x00, 0x01, // width: 1
+	0x00, 0x00, 0x00, 0x01, // height: 1
+	0x08,                   // bit depth: 8
+	0x02,                   // color type: truecolor
+	0x00,                   // compression
+	0x00,                   // filter
+	0x00,                   // interlace
+	0x90, 0x77, 0x53, 0xDE, // CRC
+}
+
+// expected values: whether isHumanReadable should return true or false
+var testCases = map[string]struct {
+	content  string
+	expected bool
+}{
+	"test.json": {`{"key":"value"}`, true},
+	"test.xml":  {`<root><foo/></root>`, true},
+	"test.yaml": {"foo: bar\n", true},
+	"test.toml": {"foo=\"bar\"\n", true},
+	"test.txt":  {"hello world\n", true},
+	"test.sh":   {"#!/bin/bash\necho hi\n", true},
+	"test.png":  {string(minimalPNG), false},
+	"test.pdf":  {"%PDF-1.4\n", false},
+}
+
+func TestIsHumanReadable(t *testing.T) {
+	tmpdir := t.TempDir()
+
+	for name, tc := range testCases {
+		path := filepath.Join(tmpdir, name)
+		if err := os.WriteFile(path, []byte(tc.content), 0644); err != nil {
+			t.Fatalf("failed to write %s: %v", name, err)
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", name, err)
+		}
+
+		m := mimetype.Detect(data)
+		got := isHumanReadable(m)
+
+		if got != tc.expected {
+			t.Errorf("%s: got %v for MIME %s, expected %v",
+				name, got, m.String(), tc.expected)
+		}
+	}
+}


### PR DESCRIPTION
### Description:
The old logic skipped all `application/*` files as binary, which risked ignoring human-readable formats if detection improved. In practice, JSON/YAML/etc. were scanned only because filetype returned "unknown".

This change:
- uses mimetype for broader and more accurate detection
- adds `isHumanReadable()` to explicitly whitelist `text/*` and common textual `application/*` types (json, xml, yaml, toml, js, xhtml)
- makes the skip policy explicit instead of relying on "unknown" fallback
- adds regression tests to verify classification

Additionally, this patch migrates the detection library from `h2non/filetype` to the more accurate and actively maintained `gabriel-vasile/mimetype`.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
