### PR TITLE
feat(config): read [tool.gitleaks] from pyproject.toml (#2066)

### DIFF
--- a/cmd/pyproject.go
+++ b/cmd/pyproject.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// pyprojectFilename is the conventional Python project metadata file name.
+// gitleaks reads its own configuration from a [tool.gitleaks] sub-table when
+// pointed at one of these (or when one is auto-discovered alongside
+// .gitleaks.toml).
+const pyprojectFilename = "pyproject.toml"
+
+// errNoGitleaksTable is returned when a pyproject.toml is parseable but does
+// not contain a [tool.gitleaks] sub-table.
+var errNoGitleaksTable = errors.New("pyproject.toml has no [tool.gitleaks] section")
+
+// isPyprojectPath reports whether path looks like a pyproject.toml (matches
+// case-insensitively on the basename so users on case-insensitive filesystems
+// don't get surprised).
+func isPyprojectPath(path string) bool {
+	return strings.EqualFold(filepath.Base(path), pyprojectFilename)
+}
+
+// extractGitleaksFromPyproject reads pyproject.toml from path, isolates the
+// [tool.gitleaks] sub-table, and returns it re-marshalled as standalone TOML
+// suitable for feeding directly to viper. The structure of the [tool.gitleaks]
+// section is otherwise unchanged — every key supported by .gitleaks.toml is
+// supported here verbatim.
+func extractGitleaksFromPyproject(path string) ([]byte, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	// Parse into a generic map first, then walk to [tool.gitleaks].
+	var doc map[string]any
+	if err := toml.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	tool, ok := doc["tool"].(map[string]any)
+	if !ok {
+		return nil, errNoGitleaksTable
+	}
+	cfg, ok := tool["gitleaks"].(map[string]any)
+	if !ok {
+		return nil, errNoGitleaksTable
+	}
+
+	out, err := toml.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshal [tool.gitleaks] from %s: %w", path, err)
+	}
+	return out, nil
+}

--- a/cmd/pyproject_test.go
+++ b/cmd/pyproject_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsPyprojectPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"pyproject.toml", true},
+		{"./pyproject.toml", true},
+		{"/abs/path/pyproject.toml", true},
+		{"PyProject.toml", true},
+		{".gitleaks.toml", false},
+		{"gitleaks.toml", false},
+		{"/some/dir/", false},
+		{"", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.path, func(t *testing.T) {
+			assert.Equal(t, tc.want, isPyprojectPath(tc.path))
+		})
+	}
+}
+
+func TestExtractGitleaksFromPyproject_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pyproject.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+[project]
+name = "myapp"
+version = "1.2.3"
+
+[tool.black]
+line-length = 100
+
+[tool.gitleaks]
+title = "myapp gitleaks config"
+
+[[tool.gitleaks.rules]]
+id = "custom-token"
+description = "Custom internal token"
+regex = '''internal-[a-z0-9]{32}'''
+keywords = ["internal-"]
+`), 0o644))
+
+	out, err := extractGitleaksFromPyproject(path)
+	require.NoError(t, err)
+	require.NotEmpty(t, out)
+
+	// Feed it through viper the same way initConfig will at runtime.
+	v := viper.New()
+	v.SetConfigType("toml")
+	require.NoError(t, v.ReadConfig(strings.NewReader(string(out))))
+
+	assert.Equal(t, "myapp gitleaks config", v.GetString("title"))
+	rules := v.Get("rules")
+	require.NotNil(t, rules, "the [[tool.gitleaks.rules]] array of tables should land at top-level rules")
+	rs, ok := rules.([]any)
+	require.True(t, ok, "rules should decode as a TOML array of tables, got %T", rules)
+	require.Len(t, rs, 1)
+	first, ok := rs[0].(map[string]any)
+	require.True(t, ok, "first rule should be a TOML table, got %T", rs[0])
+	assert.Equal(t, "custom-token", first["id"])
+}
+
+func TestExtractGitleaksFromPyproject_NoTable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pyproject.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+[project]
+name = "myapp"
+
+[tool.black]
+line-length = 100
+`), 0o644))
+
+	_, err := extractGitleaksFromPyproject(path)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errNoGitleaksTable))
+}
+
+func TestExtractGitleaksFromPyproject_NoToolKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pyproject.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+[project]
+name = "myapp"
+`), 0o644))
+
+	_, err := extractGitleaksFromPyproject(path)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errNoGitleaksTable))
+}
+
+func TestExtractGitleaksFromPyproject_FileMissing(t *testing.T) {
+	_, err := extractGitleaksFromPyproject(filepath.Join(t.TempDir(), "missing.toml"))
+	require.Error(t, err)
+}
+
+func TestExtractGitleaksFromPyproject_InvalidToml(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pyproject.toml")
+	require.NoError(t, os.WriteFile(path, []byte("this is = not = valid [toml"), 0o644))
+
+	_, err := extractGitleaksFromPyproject(path)
+	require.Error(t, err)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -147,10 +147,18 @@ func initConfig(source string) {
 		logging.Fatal().Msg(err.Error())
 	}
 	if cfgPath != "" {
+		if isPyprojectPath(cfgPath) {
+			loadPyprojectConfig(cfgPath, "--config")
+			return
+		}
 		viper.SetConfigFile(cfgPath)
 		logging.Debug().Msgf("using gitleaks config %s from `--config`", cfgPath)
 	} else if os.Getenv("GITLEAKS_CONFIG") != "" {
 		envPath := os.Getenv("GITLEAKS_CONFIG")
+		if isPyprojectPath(envPath) {
+			loadPyprojectConfig(envPath, "GITLEAKS_CONFIG env var")
+			return
+		}
 		viper.SetConfigFile(envPath)
 		logging.Debug().Msgf("using gitleaks config from GITLEAKS_CONFIG env var: %s", envPath)
 	} else if os.Getenv("GITLEAKS_CONFIG_TOML") != "" {
@@ -175,23 +183,45 @@ func initConfig(source string) {
 			return
 		}
 
-		if _, err := os.Stat(filepath.Join(source, ".gitleaks.toml")); os.IsNotExist(err) {
-			logging.Debug().Msgf("no gitleaks config found in path %s, using default gitleaks config", filepath.Join(source, ".gitleaks.toml"))
+		gitleaksTomlPath := filepath.Join(source, ".gitleaks.toml")
+		pyprojectTomlPath := filepath.Join(source, pyprojectFilename)
+
+		if _, err := os.Stat(gitleaksTomlPath); err == nil {
+			logging.Debug().Msgf("using existing gitleaks config %s from `(--source)/.gitleaks.toml`", gitleaksTomlPath)
+			viper.AddConfigPath(source)
+			viper.SetConfigName(".gitleaks")
+		} else if _, perr := os.Stat(pyprojectTomlPath); perr == nil {
+			// Auto-discover pyproject.toml only when .gitleaks.toml is absent;
+			// .gitleaks.toml wins when both exist so existing setups don't change.
+			loadPyprojectConfig(pyprojectTomlPath, "(--source)/pyproject.toml")
+			return
+		} else {
+			logging.Debug().Msgf("no gitleaks config found in path %s, using default gitleaks config", gitleaksTomlPath)
 
 			if err = viper.ReadConfig(strings.NewReader(config.DefaultConfig)); err != nil {
 				logging.Fatal().Msgf("err reading default config toml %s", err.Error())
 			}
 			return
-		} else {
-			logging.Debug().Msgf("using existing gitleaks config %s from `(--source)/.gitleaks.toml`", filepath.Join(source, ".gitleaks.toml"))
 		}
-
-		viper.AddConfigPath(source)
-		viper.SetConfigName(".gitleaks")
 	}
 	if err := viper.ReadInConfig(); err != nil {
 		logging.Fatal().Msgf("unable to load gitleaks config, err: %s", err)
 	}
+}
+
+// loadPyprojectConfig reads pyproject.toml at path, extracts [tool.gitleaks],
+// and feeds it into viper. source describes where the path came from for log
+// messages (e.g. "--config", "GITLEAKS_CONFIG env var",
+// "(--source)/pyproject.toml").
+func loadPyprojectConfig(path, source string) {
+	cfgBytes, err := extractGitleaksFromPyproject(path)
+	if err != nil {
+		logging.Fatal().Err(err).Str("path", path).Msgf("unable to load gitleaks config from %s", source)
+	}
+	if err := viper.ReadConfig(bytes.NewReader(cfgBytes)); err != nil {
+		logging.Fatal().Err(err).Str("path", path).Msgf("unable to parse [tool.gitleaks] from %s", source)
+	}
+	logging.Debug().Str("path", path).Msgf("using gitleaks config from [tool.gitleaks] in %s", source)
 }
 
 func initDiagnostics() {

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/h2non/filetype v1.1.3
 	github.com/hashicorp/go-version v1.7.0
 	github.com/mholt/archives v0.1.2
+	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/rs/zerolog v1.33.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.19.0
@@ -47,7 +48,6 @@ require (
 	github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68 // indirect
 	github.com/muesli/termenv v0.15.1 // indirect
 	github.com/nwaples/rardecode/v2 v2.1.0 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect


### PR DESCRIPTION
Closes #2066.

Python projects keep tool configuration centralized in `pyproject.toml` (black, ruff, pytest, etc.). Asking Python users to maintain a separate `.gitleaks.toml` for one tool is repetitive and easy to forget — see the issue for the demand signal (and an external workaround the reporter built to bridge the gap until native support landed).

## Activation

```bash
# explicit
gitleaks dir . -c pyproject.toml
GITLEAKS_CONFIG=pyproject.toml gitleaks dir .

# auto-discovered (when .gitleaks.toml is absent)
cd /myrepo && gitleaks dir .
```

`.gitleaks.toml` still wins when both files exist in the source directory — auto-discovery only falls back to `pyproject.toml` when `.gitleaks.toml` doesn't exist, so no existing setup is silently rerouted.

## What goes inside `pyproject.toml`

The `[tool.gitleaks]` sub-table is a 1:1 reflection of `.gitleaks.toml`'s top-level. Example:

\`\`\`toml
[project]
name = \"myapp\"

[tool.gitleaks]
title = \"myapp gitleaks\"

[[tool.gitleaks.rules]]
id          = \"internal-secret\"
description = \"Internal hardcoded marker\"
regex       = '''internal-secret-[a-z0-9]{16}'''
keywords    = [\"internal-\"]
\`\`\`

## Implementation

- \`cmd/pyproject.go\`
  - \`isPyprojectPath\` — case-insensitive basename check.
  - \`extractGitleaksFromPyproject\` — reads, parses with \`go-toml/v2\`, isolates \`[tool.gitleaks]\`, re-marshals as standalone TOML so the existing viper / config parsing is unchanged.
  - \`errNoGitleaksTable\` — sentinel error so callers can distinguish \"file exists but no gitleaks section\" from \"file is malformed\".
- \`cmd/root.go::initConfig\` — three new entry points (\`--config\`, \`GITLEAKS_CONFIG\` env, auto-discovery in source dir), all routing through a single \`loadPyprojectConfig\` helper.
- \`go.mod\` — promotes \`pelletier/go-toml/v2\` from indirect to direct (already in the dependency graph via \`mholt/archives\` etc., so no new vendored code).

## Tests

\`cmd/pyproject_test.go\`:

- \`TestIsPyprojectPath\` — 8 cases incl. case-insensitive.
- \`TestExtractGitleaksFromPyproject_HappyPath\` — full round-trip through viper, verifies \`[[tool.gitleaks.rules]]\` lands at top-level \`rules\`.
- Negative paths: \`_NoTable\`, \`_NoToolKey\`, \`_FileMissing\`, \`_InvalidToml\`.

Live-verified end-to-end against a fixture repo containing a custom \`[tool.gitleaks]\` rule + a \`config.py\` that trips it. Both \`gitleaks dir . -c pyproject.toml\` and plain \`gitleaks dir .\` (auto-discovery) find 1 leak.

Full suite: \`go test ./...\` green (config / detect / report / sources). Build clean.