### PR TITLE
Reduce Square access token false positives in base64 blobs

### DIFF
--- a/cmd/generate/config/rules/square.go
+++ b/cmd/generate/config/rules/square.go
@@ -11,19 +11,20 @@ func SquareAccessToken() *config.Rule {
 	r := config.Rule{
 		RuleID:      "square-access-token",
 		Description: "Detected a Square Access Token, risking unauthorized payment processing and financial transaction exposure.",
-		Regex:       utils.GenerateUniqueTokenRegex(`(?:EAAA|sq0atp-)[\w-]{22,60}`, false),
+		Regex:       utils.GenerateUniqueTokenRegex(`(?:EAAA[\w-]{60}|sq0atp-[\w-]{22,60})`, false),
 		Entropy:     2,
 		Keywords:    []string{"sq0atp-", "EAAA"},
 	}
 
 	// validate
-	tps := utils.GenerateSampleSecrets("square", secrets.NewSecret(`(?:EAAA|sq0atp-)[\w-]{22,60}`))
+	tps := utils.GenerateSampleSecrets("square", secrets.NewSecret(`(?:EAAA[\w-]{60}|sq0atp-[\w-]{22,60})`))
 	tps = append(tps,
 		"ARG token=sq0atp-812erere3wewew45678901",                                    // gitleaks:allow
-		"ARG token=EAAAlsBxkkVgvmr7FasTFbM6VUGZ31EJ4jZKTJZySgElBDJ_wyafHuBFquFexY7E", // gitleaks:allow",
+		"ARG token=EAAAlsBxkkVgvmr7FasTFbM6VUGZ31EJ4jZKTJZySgElBDJ_wyafHuBFquFexY7E", // gitleaks:allow
 	)
 	fps := []string{
 		`aws-cli@sha256:eaaa7b11777babe28e6133a8b19ff71cea687e0d7f05158dee95a71f76ce3d00`,
+		`mJeJ0b3bVQZu6P8AUEsHCFDBu3Q+EAAAWRAAAFBLAwQUAAgICAAYZxlbAAAAAAAAAAAAAAAAEwAA`,
 	}
 	return utils.Validate(r, tps, fps)
 }

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -3060,7 +3060,7 @@ keywords = [
 [[rules]]
 id = "square-access-token"
 description = "Detected a Square Access Token, risking unauthorized payment processing and financial transaction exposure."
-regex = '''\b((?:EAAA|sq0atp-)[\w-]{22,60})(?:[\x60'"\s;]|\\[nr]|$)'''
+regex = '''\b((?:EAAA[\w-]{60}|sq0atp-[\w-]{22,60}))(?:[\x60'"\s;]|\\[nr]|$)'''
 entropy = 2
 keywords = [
     "sq0atp-",


### PR DESCRIPTION
### Description:

Fixes https://github.com/gitleaks/gitleaks/issues/2093

The `square-access-token` rule allowed the `EAAA` prefix to match variable-length tokens. Because the generated rule can stop at the first allowed suffix boundary, it could report a shorter slice from the middle of longer MIME/base64 attachment data.

This keeps the existing `sq0atp-` length range, but requires `EAAA` tokens to use the 64-character length shown by the rule's existing positive sample. I also added the reported MIME/base64 line to the rule validation false positives and regenerated `config/gitleaks.toml`.

Tests:

```text
docker run --rm --user "$(id -u):$(id -g)" -e GOCACHE=/tmp/gocache -e GOPATH=/tmp/gopath -v "$PWD":/src -w /src golang:1.25 go generate ./...
docker run --rm --user "$(id -u):$(id -g)" -e GOCACHE=/tmp/gocache -e GOPATH=/tmp/gopath -v "$PWD":/src -w /src golang:1.25 go test ./cmd/generate/config/...
docker run --rm --user "$(id -u):$(id -g)" -e GOCACHE=/tmp/gocache -e GOPATH=/tmp/gopath -v "$PWD":/src -w /src golang:1.25 go test ./config ./detect
```

Manual checks:

```text
Before: the issue `.eml` sample reported one `square-access-token` finding.
After: the same sample reports `no leaks found`.
After: the existing `sq0atp-...` and `EAAA...` Square positive samples still report as `square-access-token`.
```

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?