### PR TITLE
fix: global commit allowlist bypassed due to misscoped continue

### DIFF
--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -908,6 +908,35 @@ func TestFromGit(t *testing.T) {
 			},
 		},
 		{
+			// Regression test: global [[allowlists]] commit entries must skip the entire
+			// diff file, not just advance the inner allowlist loop.
+			source:  filepath.Join(repoBasePath, "small"),
+			cfgName: "valid/allowlist_global_commit",
+			expectedFindings: []report.Finding{
+				{
+					RuleID:      "aws-access-key",
+					Description: "AWS Access Key",
+					StartLine:   9,
+					EndLine:     9,
+					StartColumn: 17,
+					EndColumn:   36,
+					Secret:      "AKIALALEMEL33243OLIA",
+					Match:       "AKIALALEMEL33243OLIA",
+					Line:        "\n\taws_token := \"AKIALALEMEL33243OLIA\"",
+					File:        "foo/foo.go",
+					Date:        "2021-11-02T23:48:06Z",
+					Commit:      "491504d5a31946ce75e22554cc34203d8e5ff3ca",
+					Author:      "Zach Rice",
+					Email:       "zricer@protonmail.com",
+					Message:     "adding foo package with secret",
+					Tags:        []string{"key", "AWS"},
+					Entropy:     3.0841837,
+					Fingerprint: "491504d5a31946ce75e22554cc34203d8e5ff3ca:foo/foo.go:aws-access-key:9",
+					Link:        "https://github.com/gitleaks/test/blob/491504d5a31946ce75e22554cc34203d8e5ff3ca/foo/foo.go#L9",
+				},
+			},
+		},
+		{
 			source:  filepath.Join(repoBasePath, "small"),
 			logOpts: "--all foo...",
 			cfgName: "simple",

--- a/sources/git.go
+++ b/sources/git.go
@@ -338,11 +338,16 @@ func (s *Git) Fragments(ctx context.Context, yield FragmentsFunc) error {
 			var commitInfo *CommitInfo
 			if gitdiffFile.PatchHeader != nil {
 				commitSHA = gitdiffFile.PatchHeader.SHA
+				commitAllowed := false
 				for _, a := range s.Config.Allowlists {
 					if ok, c := a.CommitAllowed(gitdiffFile.PatchHeader.SHA); ok {
 						logging.Trace().Str("allowed-commit", c).Msg("skipping commit: global allowlist")
-						continue
+						commitAllowed = true
+						break
 					}
+				}
+				if commitAllowed {
+					continue
 				}
 
 				commitInfo = &CommitInfo{

--- a/sources/git.go
+++ b/sources/git.go
@@ -295,6 +295,19 @@ type CommitInfo struct {
 	SHA         string
 }
 
+// isCommitAllowed reports whether the commit SHA is covered by any global
+// allowlist. It returns the matched allowlist's commit value so callers can
+// trace which entry applied. It stops at the first match, since one match is
+// enough to skip the commit.
+func isCommitAllowed(allowlists []*config.Allowlist, sha string) (bool, string) {
+	for _, a := range allowlists {
+		if ok, c := a.CommitAllowed(sha); ok {
+			return true, c
+		}
+	}
+	return false, ""
+}
+
 // Fragments yields fragments from a git repo
 func (s *Git) Fragments(ctx context.Context, yield FragmentsFunc) error {
 	defer func() {
@@ -338,15 +351,8 @@ func (s *Git) Fragments(ctx context.Context, yield FragmentsFunc) error {
 			var commitInfo *CommitInfo
 			if gitdiffFile.PatchHeader != nil {
 				commitSHA = gitdiffFile.PatchHeader.SHA
-				commitAllowed := false
-				for _, a := range s.Config.Allowlists {
-					if ok, c := a.CommitAllowed(gitdiffFile.PatchHeader.SHA); ok {
-						logging.Trace().Str("allowed-commit", c).Msg("skipping commit: global allowlist")
-						commitAllowed = true
-						break
-					}
-				}
-				if commitAllowed {
+				if ok, c := isCommitAllowed(s.Config.Allowlists, commitSHA); ok {
+					logging.Trace().Str("allowed-commit", c).Msg("skipping commit: global allowlist")
 					continue
 				}
 

--- a/sources/git_test.go
+++ b/sources/git_test.go
@@ -1,5 +1,77 @@
 package sources
 
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+func TestIsCommitAllowed(t *testing.T) {
+	tests := map[string]struct {
+		allowlists  []*config.Allowlist
+		sha         string
+		wantAllowed bool
+		wantCommit  string
+	}{
+		"no allowlists": {
+			allowlists:  nil,
+			sha:         "commitA",
+			wantAllowed: false,
+		},
+		"single allowlist matches": {
+			allowlists:  []*config.Allowlist{{Commits: []string{"commitA"}}},
+			sha:         "commitA",
+			wantAllowed: true,
+			wantCommit:  "commitA",
+		},
+		"single allowlist does not match": {
+			allowlists:  []*config.Allowlist{{Commits: []string{"commitB"}}},
+			sha:         "commitA",
+			wantAllowed: false,
+		},
+		"empty sha is never allowed": {
+			allowlists:  []*config.Allowlist{{Commits: []string{"commitA"}}},
+			sha:         "",
+			wantAllowed: false,
+		},
+		// The original bug: the allowed commit lived in a later allowlist and the
+		// misscoped continue let it fall through to be scanned anyway. Match on a
+		// non-first entry guards against that regression.
+		"match in a later allowlist": {
+			allowlists: []*config.Allowlist{
+				{Commits: []string{"commitB"}},
+				{Commits: []string{"commitA"}},
+			},
+			sha:         "commitA",
+			wantAllowed: true,
+			wantCommit:  "commitA",
+		},
+		// Overlapping allowlists: both cover the commit. We stop at the first
+		// match and never scan, regardless of how many entries match.
+		"overlapping allowlists both match": {
+			allowlists: []*config.Allowlist{
+				{Commits: []string{"commitA"}},
+				{Commits: []string{"commitA"}},
+			},
+			sha:         "commitA",
+			wantAllowed: true,
+			wantCommit:  "commitA",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotAllowed, gotCommit := isCommitAllowed(tt.allowlists, tt.sha)
+			assert.Equal(t, tt.wantAllowed, gotAllowed)
+			if tt.wantAllowed {
+				assert.Equal(t, tt.wantCommit, gotCommit)
+			}
+		})
+	}
+}
+
 // TODO: commenting out this test for now because it's flaky. Alternatives to consider to get this working:
 // -- use `git stash` instead of `restore()`
 

--- a/testdata/config/valid/allowlist_global_commit.toml
+++ b/testdata/config/valid/allowlist_global_commit.toml
@@ -1,0 +1,10 @@
+title = "config with global commit allowlist"
+
+[[rules]]
+    description = "AWS Access Key"
+    id = "aws-access-key"
+    regex = '''(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}'''
+    tags = ["key", "AWS"]
+
+[[allowlists]]
+    commits = ["1b6da43b82b22e4eaa10bcf8ee591e91abbfc587"]


### PR DESCRIPTION
## Summary

Fixes #2165

Global `[[allowlists]]` entries with `commits = [...]` were silently ignored during `gitleaks git` scans. The allowlisted commit was logged as skipped but fully scanned anyway.

**Root cause:** The `continue` inside `for _, a := range s.Config.Allowlists` in `sources/git.go` only advanced to the next allowlist entry — it never escaped the outer diff-file loop. Every commit, including explicitly allowlisted ones, fell through to `commitInfo` construction and goroutine launch.

```go
// BEFORE — continue only skips to next allowlist entry
for _, a := range s.Config.Allowlists {
    if ok, c := a.CommitAllowed(sha); ok {
        logging.Trace().…Msg("skipping commit: global allowlist")
        continue  // ← wrong scope
    }
}
// always reached, even for allowlisted commits
commitInfo = &CommitInfo{…}
```

```go
// AFTER — boolean flag + continue escapes to the outer for loop
commitAllowed := false
for _, a := range s.Config.Allowlists {
    if ok, c := a.CommitAllowed(sha); ok {
        logging.Trace().…Msg("skipping commit: global allowlist")
        commitAllowed = true
        break
    }
}
if commitAllowed {
    continue  // ← correctly skips to next diff file
}
```

## Changes

- `sources/git.go`: replace misscoped `continue` with boolean flag pattern
- `detect/detect_test.go`: add regression test case in `TestFromGit` that allowlists one commit by SHA and asserts only the non-allowlisted commit's finding is returned
- `testdata/config/valid/allowlist_global_commit.toml`: test config with a global commit allowlist targeting the first "small" repo commit

## Test plan

- [ ] `go test ./detect/... -run TestFromGit` — new test case passes (allowlisted commit finding absent, other finding present)
- [ ] `go test ./...` — full suite green
- [ ] Manual: configure a `[[allowlists]] commits = ["<sha>"]` and confirm `gitleaks git` reports no finding for that commit