### PR TITLE
Decode base64 values containing valid UTF-8 characters

### DIFF
--- a/detect/codec/ascii.go
+++ b/detect/codec/ascii.go
@@ -1,5 +1,10 @@
 package codec
 
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
 var printableASCII [256]bool
 
 func init() {
@@ -10,12 +15,31 @@ func init() {
 	}
 }
 
-// isPrintableASCII returns true if all bytes are printable ASCII
-func isPrintableASCII(b []byte) bool {
-	for _, c := range b {
-		if !printableASCII[c] {
+// isPrintable returns true if b is valid UTF-8 made up entirely of printable
+// characters. ASCII bytes are checked against the printableASCII table (so the
+// existing tab/newline/carriage-return allowances are preserved), while
+// multi-byte runes are accepted when they are valid UTF-8 and printable. This
+// keeps base64 values that decode to text containing Unicode characters
+// (e.g. accented letters, CJK) from being silently skipped.
+func isPrintable(b []byte) bool {
+	for i := 0; i < len(b); {
+		c := b[i]
+		if c < utf8.RuneSelf {
+			if !printableASCII[c] {
+				return false
+			}
+			i++
+			continue
+		}
+
+		r, size := utf8.DecodeRune(b[i:])
+		if r == utf8.RuneError && size == 1 {
 			return false
 		}
+		if !unicode.IsPrint(r) {
+			return false
+		}
+		i += size
 	}
 
 	return true

--- a/detect/codec/base64.go
+++ b/detect/codec/base64.go
@@ -25,13 +25,13 @@ func decodeBase64(encodedValue string) string {
 
 	// Try standard base64 decoding
 	decodedValue, err := base64.StdEncoding.DecodeString(encodedValue)
-	if err == nil && isPrintableASCII(decodedValue) {
+	if err == nil && isPrintable(decodedValue) {
 		return string(decodedValue)
 	}
 
 	// Try base64url decoding
 	decodedValue, err = base64.RawURLEncoding.DecodeString(encodedValue)
-	if err == nil && isPrintableASCII(decodedValue) {
+	if err == nil && isPrintable(decodedValue) {
 		return string(decodedValue)
 	}
 

--- a/detect/codec/decoder_test.go
+++ b/detect/codec/decoder_test.go
@@ -25,6 +25,20 @@ func TestDecode(t *testing.T) {
 			expected: `token: longer-encoded-secret-test`,
 		},
 		{
+			// decodes to "café-encoded-secret-token-value": previously the
+			// accented letter made the segment fail the printable-ASCII check
+			// and it was silently skipped (#2000).
+			name:     "decodes to text with an accented character",
+			chunk:    `token: Y2Fmw6ktZW5jb2RlZC1zZWNyZXQtdG9rZW4tdmFsdWU=`,
+			expected: `token: café-encoded-secret-token-value`,
+		},
+		{
+			// decodes to "encoded-secret-日本語-token-value" (#2000).
+			name:     "decodes to text with CJK characters",
+			chunk:    `token: ZW5jb2RlZC1zZWNyZXQt5pel5pys6KqeLXRva2VuLXZhbHVl`,
+			expected: `token: encoded-secret-日本語-token-value`,
+		},
+		{
 			name:     "no chunk",
 			chunk:    ``,
 			expected: ``,


### PR DESCRIPTION
The base64 decoder dropped any decoded value that was not pure printable ASCII (`isPrintableASCII` in `detect/codec/ascii.go`). So when a base64 segment decoded to text containing a valid UTF-8 character (an accented letter like `é`, a CJK character, etc.), the whole segment was silently skipped and any secret next to it was never scanned. This is #2000.

The fix swaps that check for a UTF-8-aware one:
- ASCII bytes still go through the existing `printableASCII` table, so the current tab / newline / carriage-return allowances are unchanged.
- Multi-byte sequences are accepted when they are valid UTF-8 and the rune is printable (`unicode.IsPrint`), and rejected when the bytes are not valid UTF-8. So genuine binary still gets filtered out; only legitimately printable Unicode text now survives.

`isPrintableASCII` was the only consumer of that name (both calls in `decodeBase64`), so I renamed it to `isPrintable` to match the new behavior.

Added two `TestDecode` cases that decode to accented (`café-...`) and CJK (`...日本語...`) text; both failed before the change and pass now. `go test ./detect/codec/...` is green.

Fixes #2000