### PR TITLE
feat(rules): add Anthropic OAuth refresh token rule (sk-ant-ort01-)

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -40,6 +40,7 @@ func main() {
 		rules.AmazonBedrockAPIKeyShortLived(),
 		rules.AnthropicAdminApiKey(),
 		rules.AnthropicApiKey(),
+		rules.AnthropicOauthRefreshToken(),
 		rules.ArtifactoryApiKey(),
 		rules.ArtifactoryReferenceToken(),
 		rules.AsanaClientID(),

--- a/cmd/generate/config/rules/anthropic.go
+++ b/cmd/generate/config/rules/anthropic.go
@@ -67,3 +67,32 @@ func AnthropicAdminApiKey() *config.Rule {
 
 	return utils.Validate(r, tps, fps)
 }
+
+func AnthropicOauthRefreshToken() *config.Rule {
+	// define rule
+	r := config.Rule{
+		RuleID:      "anthropic-oauth-refresh-token",
+		Description: "Identified an Anthropic OAuth refresh token (e.g. Claude Code), which can be exchanged for new access tokens and provides long-lived access to Anthropic APIs on behalf of a user.",
+		Regex:       utils.GenerateUniqueTokenRegex(`sk-ant-ort01-[a-zA-Z0-9_\-]{95}`, false),
+		Keywords: []string{
+			"sk-ant-ort01",
+		},
+	}
+
+	// validate
+	tps := []string{
+		// Valid OAuth refresh token example
+		"sk-ant-ort01-ort01samplexyzABC0123456789-_ort01samplexyzABC0123456789-_ort01samplexyzABC0123456789-_ort01sam",
+		// Generate additional random test tokens
+		utils.GenerateSampleSecret("anthropic", "sk-ant-ort01-"+secrets.NewSecret(utils.AlphaNumericExtendedShort("95"))),
+	}
+
+	fps := []string{
+		// Too short token (missing characters)
+		"sk-ant-ort01-tooShort0123456789-_abcXYZ",
+		// Wrong prefix (access token, not refresh token)
+		"sk-ant-oat01-oat01samplexyzABC0123456789-_oat01samplexyzABC0123456789-_oat01samplexyzABC0123456789-_oat01sam",
+	}
+
+	return utils.Validate(r, tps, fps)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -153,6 +153,12 @@ regex = '''\b(sk-ant-api03-[a-zA-Z0-9_\-]{93}AA)(?:[\x60'"\s;]|\\[nr]|$)'''
 keywords = ["sk-ant-api03"]
 
 [[rules]]
+id = "anthropic-oauth-refresh-token"
+description = "Identified an Anthropic OAuth refresh token (e.g. Claude Code), which can be exchanged for new access tokens and provides long-lived access to Anthropic APIs on behalf of a user."
+regex = '''\b(sk-ant-ort01-[a-zA-Z0-9_\-]{95})(?:[\x60'"\s;]|\\[nr]|$)'''
+keywords = ["sk-ant-ort01"]
+
+[[rules]]
 id = "artifactory-api-key"
 description = "Detected an Artifactory api key, posing a risk unauthorized access to the central repository."
 regex = '''\bAKCp[A-Za-z0-9]{69}\b'''


### PR DESCRIPTION
### Summary

Adds a default rule `anthropic-oauth-refresh-token` detecting the OAuth **refresh** tokens (`sk-ant-ort01-`) minted by Claude Code and other Anthropic OAuth flows. This complements the existing `sk-ant-api03-` / `sk-ant-admin01-` API-key rules and the OAuth **access**-token work tracked in #2104 / #2105.

### Why this is distinct from #2105

Issue #2104 and the open PR #2105 cover the OAuth **access** token (`sk-ant-oat01-`). Neither covers the **refresh** token (`sk-ant-ort01-`), which is stored alongside the access token (e.g. in the macOS Keychain `claudeAiOauth` entry: `{accessToken: sk-ant-oat01-…, refreshToken: sk-ant-ort01-…}`). A leaked refresh token is arguably higher-impact than the access token because it can mint new access tokens until revoked. This PR adds only that missing refresh-token rule, so it stacks cleanly on top of #2105 without duplicating it.

### Change

- New `AnthropicOauthRefreshToken()` rule in `cmd/generate/config/rules/anthropic.go`:
  - `RuleID: anthropic-oauth-refresh-token`
  - Regex: `sk-ant-ort01-[a-zA-Z0-9_\-]{95}` (same char class and body length as the confirmed `sk-ant-oat01-` access token, which is documented at 95 chars / 108 total). The refresh token shares the `sk-ant-` OAuth issuer family; if maintainers have a confirmed refresh-token length that differs, happy to adjust.
  - Keyword prefilter `sk-ant-ort01`, with too-short and wrong-prefix false-positive samples.
- Registered in `cmd/generate/config/main.go` and `config/gitleaks.toml` regenerated via `go generate ./...`.

### Testing

- `go generate ./...` runs `utils.Validate(tps, fps)` — passes (TPs match, FPs rejected).
- `go build ./...` clean; `go generate` is idempotent (CI `git diff --exit-code` passes).
- Live: built the binary and scanned a file containing `sk-ant-ort01-<95>` → detected as `anthropic-oauth-refresh-token`.
