### PR TITLE
feat(rules): add Resend API key detection rule

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -194,6 +194,7 @@ func main() {
 		rules.PyPiUploadToken(),
 		rules.RapidAPIAccessToken(),
 		rules.ReadMe(),
+		rules.Resend(),
 		rules.RubyGemsAPIToken(),
 		rules.ScalingoAPIToken(),
 		rules.SendbirdAccessID(),

--- a/cmd/generate/config/rules/resend.go
+++ b/cmd/generate/config/rules/resend.go
@@ -1,0 +1,47 @@
+package rules
+
+import (
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/config/utils"
+	"github.com/zricethezav/gitleaks/v8/cmd/generate/secrets"
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+func Resend() *config.Rule {
+	// define rule
+	r := config.Rule{
+		RuleID:      "resend-api-key",
+		Description: "Identified a Resend API key, which could allow unauthorized email sending and access to the Resend account.",
+		// Resend keys: literal `re_`, 8 base58 chars, `_`, 24 base58 chars.
+		// Base58 alphabet excludes `0`, `O`, `I`, and `l`.
+		Regex:   utils.GenerateUniqueTokenRegex(`re_[1-9A-HJ-NP-Za-km-z]{8}_[1-9A-HJ-NP-Za-km-z]{24}`, false),
+		Entropy: 3,
+		Keywords: []string{
+			"re_",
+		},
+	}
+
+	// validate
+	tps := utils.GenerateSampleSecrets(
+		"resend",
+		"re_"+secrets.NewSecret(`[1-9A-HJ-NP-Za-km-z]{8}`)+"_"+secrets.NewSecret(`[1-9A-HJ-NP-Za-km-z]{24}`),
+	)
+	tps = append(tps,
+		`resendApiKey := "re_1234abcd_aBcDeFgHiJkLmNoPqRsTuVwX"`,
+	)
+
+	fps := []string{
+		// `0` is not in the base58 alphabet.
+		`resendApiKey := "re_0234abcd_aBcDeFgHiJkLmNoPqRsTuVwX"`,
+		// `O` is not in the base58 alphabet.
+		`resendApiKey := "re_1234abcd_OBcDeFgHiJkLmNoPqRsTuVwX"`,
+		// `I` is not in the base58 alphabet.
+		`resendApiKey := "re_I234abcd_aBcDeFgHiJkLmNoPqRsTuVwX"`,
+		// `l` is not in the base58 alphabet.
+		`resendApiKey := "re_1234abcl_aBcDeFgHiJkLmNoPqRsTuVwX"`,
+		// First segment is only 7 chars.
+		`resendApiKey := "re_1234abc_aBcDeFgHiJkLmNoPqRsTuVwX"`,
+		// Missing the `_` separator between segments.
+		`resendApiKey := "re_1234abcdaBcDeFgHiJkLmNoPqRsTuVwX"`,
+	}
+	return utils.Validate(r, tps, fps)
+}

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2826,6 +2826,13 @@ entropy = 2
 keywords = ["rdme_"]
 
 [[rules]]
+id = "resend-api-key"
+description = "Identified a Resend API key, which could allow unauthorized email sending and access to the Resend account."
+regex = '''\b(re_[1-9A-HJ-NP-Za-km-z]{8}_[1-9A-HJ-NP-Za-km-z]{24})(?:[\x60'"\s;]|\\[nr]|$)'''
+entropy = 3
+keywords = ["re_"]
+
+[[rules]]
 id = "rubygems-api-token"
 description = "Identified a Rubygem API token, potentially compromising Ruby library distribution and package management."
 regex = '''\b(rubygems_[a-f0-9]{48})(?:[\x60'"\s;]|\\[nr]|$)'''


### PR DESCRIPTION
### Description:
I'm on the team at Resend (https://resend.com), submitting the detection rule for our own API key format.

Format: `re_[1-9A-HJ-NP-Za-km-z]{8}_[1-9A-HJ-NP-Za-km-z]{24}` (base58 alphabet, excluding the ambiguous characters 0, O, I, and l).

### Checklist:

* [ ] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
