### PR TITLE
fix: stderr from git log no longer silently drops remaining commits

### DIFF
--- a/sources/git.go
+++ b/sources/git.go
@@ -417,7 +417,9 @@ func (s *Git) Fragments(ctx context.Context, yield FragmentsFunc) error {
 				break
 			}
 
-			return yield(Fragment{}, err)
+			if err := yield(Fragment{}, err); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

`Git.Fragments()`'s select loop in `sources/git.go` returned immediately as soon as any error arrived on `errCh` — i.e. any unrecognized line on `git log`'s stderr (see `listenForStdErr`), such as git-crypt's `Warning: file not encrypted` textconv output — instead of continuing to drain `diffFilesCh`:

```go
case err, open := <-errCh:
    if !open {
        errCh = nil
        break
    }
    return yield(Fragment{}, err)   // aborts immediately
```

`listenForStdErr` only sends its error to `errCh` after the entire stderr stream has closed (i.e. near the end of the git process). By that point `diffFilesCh` may still have files queued/unread. Because `select` picks between ready channels arbitrarily, whichever files hadn't been consumed from `diffFilesCh` yet were silently discarded the moment the errCh branch fired — even though the caller's `yield` callback (`Detector.DetectSource`) just logs the error and returns `nil` to signal "continue."

### Reproduction

I built a repo with a custom `textconv` filter (mirroring git-crypt's `Warning: file not encrypted` behavior) that writes to stderr for a tracked file. Confirmed via plain `git log -p` that the raw diff for the affected commit correctly contains a matching secret (`ghp_...` token). Running `gitleaks git` against this repo on current master:

- **Before**: consistently reports `no leaks found`, silently dropping the commit that introduced the secret.
- **After**: consistently reports `leaks found: 1` across repeated runs.

Removing the stderr-writing textconv (all else equal) also correctly finds the leak, confirming stderr activity — not the textconv/attribute setup itself — was the trigger.

This is the same class of bug reported in #2129 (git-crypt repos silently scanning 0 commits due to stderr noise) and is related to #1450/#1455.

Fixes #2129

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] Manual repro: custom textconv filter writing to stderr, confirmed leak is now found consistently across 5 repeated runs (previously missed consistently)